### PR TITLE
fix: correct CZ connectivity in steane7_initialize

### DIFF
--- a/src/bloqade/lanes/arch/gemini/logical/upstream.py
+++ b/src/bloqade/lanes/arch/gemini/logical/upstream.py
@@ -44,10 +44,11 @@ def steane7_initialize(
     debug.info("Begin Steane7 Initialize")
     squin.u3(theta, phi, lam, qubits[6])
     squin.broadcast.sqrt_y_adj(qubits[:6])
-    evens = qubits[::2]
-    odds = qubits[1::2]
+    evens = qubits[::2]  # [0, 2, 4, 6]
+    odds = qubits[1::2]  # [1, 3, 5]
 
-    squin.broadcast.cz(odds, evens[:-1])
+    # Fixed: CZ pairs should be (1,2), (3,4), (5,6) not (1,0), (3,2), (5,4)
+    squin.broadcast.cz(odds, evens[1:])
     squin.sqrt_y(qubits[6])
     squin.broadcast.cz(evens[:-1], ilist.IList([qubits[3], qubits[5], qubits[6]]))
     squin.broadcast.sqrt_y(qubits[2:])


### PR DESCRIPTION
The first CZ layer had wrong qubit pairing:
- Before: CZ(1,0), CZ(3,2), CZ(5,4) via cz(odds, evens[:-1])
- After:  CZ(1,2), CZ(3,4), CZ(5,6) via cz(odds, evens[1:])

This fix ensures the Steane [[7,1,3]] encoding produces states in the correct code space with deterministic stabilizer outcomes.