### PR TITLE
Fix typos in README and badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Welcome to Bloqade Lanes -- A component package of QuEra's Neutral Atom SDK
 
-[![CI](https://github.com/QuEraComputing/bloqade-lanes/actions/workflows/ci.yml/badge.svg)](https://github.com/QuEraComputing/bloqade-circuit/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/QuEraComputing/bloqade-lanes/graph/badge.svg?token=BpHsAYuzdo)](https://codecov.io/gh/QuEraComputing/bloqade-circuit)
-[![Supported Python versions](https://img.shields.io/pypi/pyversions/bloqade-lanes.svg?color=%2334D058)](https://pypi.org/project/bloqade-circuit)
+[![CI](https://github.com/QuEraComputing/bloqade-lanes/actions/workflows/ci.yml/badge.svg)](https://github.com/QuEraComputing/bloqade-lanes/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/QuEraComputing/bloqade-lanes/graph/badge.svg?token=BpHsAYuzdo)](https://codecov.io/gh/QuEraComputing/bloqade-lanes)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/bloqade-lanes.svg?color=%2334D058)](https://pypi.org/project/bloqade-lanes)
 [![Documentation](https://img.shields.io/badge/Documentation-6437FF)](https://bloqade.quera.com/)
 
 Bloqade is a Python SDK for neutral atom quantum computing. It provides a set of embedded domain-specific languages (eDSLs) for programming neutral atom quantum computers. Bloqade is designed to be a high-level, user-friendly SDK that abstracts away the complexities of neutral atom quantum computing, allowing users to focus on developing quantum algorithms and compilation strategies for neutral atom quantum computers.


### PR DESCRIPTION
Very very minor, but I thought these would help eliminate some obvious sharp bits for any readers...

 - Fixed "loqade" → "Bloqade" (the B was missing!)
 - Fixed badge URLs pointing to bloqade-circuit when they should point to bloqade-lanes

That's it. Nothing fancy, just couldn't unsee them while passing by 😅