### PR TITLE
Adding integration test on physical compilation with GHZ state prep

### DIFF
--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -169,13 +169,13 @@ def test_physical_compilation(size: int):
 
         meas = gemini_logical.terminal_measure(reg)
 
-        def set_observables(qubit_index: int):
+        def set_observable(qubit_index: int):
             return squin.set_observable(
                 [meas[qubit_index][0], meas[qubit_index][1], meas[qubit_index][5]],
                 qubit_index,
             )
 
-        return ilist.map(set_observables, ilist.range(len(reg)))
+        return ilist.map(set_observable, ilist.range(len(reg)))
 
     result = GeminiLogicalSimulator().run(main, 1000, with_noise=False)
     # checks to make sure logical GHZ state is created.


### PR DESCRIPTION
In this PR I add an integration test that compiles the input kernel to the physical level move program then decompiles it back to squin using the virtual QPU. The logical kernel has observables used to measure the state of the logical qubit. 

In this case its a GHZ state so the logical observables must be all True or False.