### PR TITLE
Added all related functionality to physical compilation

### DIFF
--- a/demo/pipeline_details.py
+++ b/demo/pipeline_details.py
@@ -62,20 +62,20 @@ example_kernel.print()
 # part of the input to the layout analysis is the layout heuristic which takes data collected from
 # the analysis interpreter to generate the initial layout. In this example we use a heuristic
 # that priorities placing qubits that interact frequently within the same word. This heuristic
-# is implemented in the `fixed` module inside bloqade-lanes.
+# is implemented in the `logical_layout` module inside bloqade-lanes.
 
 # %%
 from bloqade.analysis import address  # noqa: E402
 
 from bloqade.lanes.analysis import layout  # noqa: E402
-from bloqade.lanes.heuristics import fixed  # noqa: E402
+from bloqade.lanes.heuristics import logical_layout  # noqa: E402
 
 address_frame, _ = address.AddressAnalysis(example_kernel.dialects).run(example_kernel)
 
 
 layout_analysis = layout.LayoutAnalysis(
     example_kernel.dialects,
-    fixed.LogicalLayoutHeuristic(),
+    logical_layout.LogicalLayoutHeuristic(),
     address_frame.entries,
     tuple(range(2)),
 )
@@ -135,7 +135,7 @@ example_kernel.print(analysis=placement_frame.entries)
 from bloqade.lanes.upstream import PlaceToMove  # noqa: E402
 
 example_kernel = PlaceToMove(
-    fixed.LogicalLayoutHeuristic(),
+    logical_layout.LogicalLayoutHeuristic(),
     LogicalPlacementStrategy(),
     True,
 ).emit(example_kernel)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "deprecated>=1.3.1",
     "kirin-toolchain~=0.22.6",
     "numpy>=2.2.6",
+    "pymetis>=2025.2.1",
     "rustworkx>=0.17.1",
 ]
 requires-python = ">= 3.10"

--- a/src/bloqade/lanes/arch/gemini/physical/__init__.py
+++ b/src/bloqade/lanes/arch/gemini/physical/__init__.py
@@ -1,0 +1,1 @@
+from .spec import get_arch_spec as get_arch_spec

--- a/src/bloqade/lanes/arch/gemini/physical/spec.py
+++ b/src/bloqade/lanes/arch/gemini/physical/spec.py
@@ -1,0 +1,5 @@
+from ..impls import generate_arch_hypercube
+
+
+def get_arch_spec():
+    return generate_arch_hypercube(hypercube_dims=4, word_size_y=5)

--- a/src/bloqade/lanes/heuristics/logical_layout.py
+++ b/src/bloqade/lanes/heuristics/logical_layout.py
@@ -1,0 +1,6 @@
+from bloqade.lanes.heuristics.fixed import (
+    LogicalLayoutHeuristic,
+    LogicalLayoutHeuristicRecencyWeighted,
+)
+
+__all__ = ["LogicalLayoutHeuristic", "LogicalLayoutHeuristicRecencyWeighted"]

--- a/src/bloqade/lanes/heuristics/physical_layout.py
+++ b/src/bloqade/lanes/heuristics/physical_layout.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+import pymetis
+
+from bloqade.lanes import layout
+from bloqade.lanes.analysis.layout import LayoutHeuristicABC
+from bloqade.lanes.arch.gemini.physical import get_arch_spec as get_physical_arch_spec
+
+
+def _to_cz_layers(
+    stages: list[tuple[tuple[int, int], ...]],
+) -> tuple[tuple[tuple[int, ...], tuple[int, ...]], ...]:
+    layers = []
+    for stage in stages:
+        controls = tuple(pair[0] for pair in stage)
+        targets = tuple(pair[1] for pair in stage)
+        layers.append((controls, targets))
+    return tuple(layers)
+
+
+@dataclass
+class PhysicalLayoutHeuristicFixed(LayoutHeuristicABC):
+    arch_spec: layout.ArchSpec = field(default_factory=get_physical_arch_spec)
+
+    @property
+    def left_site_count(self) -> int:
+        return len(self.arch_spec.words[0].site_indices) // 2
+
+    def compute_layout(
+        self,
+        all_qubits: tuple[int, ...],
+        stages: list[tuple[tuple[int, int], ...]],
+    ) -> tuple[layout.LocationAddress, ...]:
+        _ = stages
+        qubits = tuple(sorted(all_qubits))
+        sites: list[layout.LocationAddress] = []
+        for word_id in range(len(self.arch_spec.words)):
+            for site_id in range(self.left_site_count):
+                sites.append(layout.LocationAddress(word_id, site_id))
+        return tuple(sites[: len(qubits)])
+
+
+@dataclass
+class PhysicalLayoutHeuristicGraphPartitionCenterOut(LayoutHeuristicABC):
+    arch_spec: layout.ArchSpec = field(default_factory=get_physical_arch_spec)
+    preferred_fill: int | None = None
+    max_words: int | None = None
+    metis_ubvec: float = 1.001
+    metis_recursive: bool = False
+
+    @property
+    def left_site_count(self) -> int:
+        return len(self.arch_spec.words[0].site_indices) // 2
+
+    def _effective_fill(self) -> int:
+        _ = self.preferred_fill
+        # Pack words by physical capacity first: full words, then one partial word.
+        return self.left_site_count
+
+    def _word_count(self, qubit_count: int) -> int:
+        max_words = (
+            len(self.arch_spec.words) if self.max_words is None else self.max_words
+        )
+        f_eff = self._effective_fill()
+        return min(max_words, math.ceil(qubit_count / f_eff))
+
+    def _target_block_sizes(self, qubit_count: int, k_words: int) -> tuple[int, ...]:
+        sizes: list[int] = []
+        remaining = qubit_count
+        for _ in range(k_words):
+            size = min(self.left_site_count, remaining)
+            sizes.append(size)
+            remaining -= size
+        return tuple(sizes)
+
+    def _build_weighted_graph(
+        self,
+        qubits: tuple[int, ...],
+        cz_layers: tuple[tuple[tuple[int, ...], tuple[int, ...]], ...],
+    ) -> tuple[dict[int, int], dict[tuple[int, int], int]]:
+        qids = tuple(sorted(set(qubits)))
+        q_to_node = {qid: idx for idx, qid in enumerate(qids)}
+
+        edge_weights: dict[tuple[int, int], int] = defaultdict(int)
+        for controls, targets in cz_layers:
+            for c, t in zip(controls, targets):
+                if c == t:
+                    continue
+                if c not in q_to_node or t not in q_to_node:
+                    continue
+                u = q_to_node[c]
+                v = q_to_node[t]
+                if u > v:
+                    u, v = v, u
+                edge_weights[(u, v)] += 1
+
+        return q_to_node, edge_weights
+
+    def _partition_words(
+        self,
+        qubits: tuple[int, ...],
+        cz_layers: tuple[tuple[tuple[int, ...], tuple[int, ...]], ...],
+        k_words: int,
+        target_sizes: tuple[int, ...],
+    ) -> dict[int, int]:
+        q_to_node, edge_weights = self._build_weighted_graph(qubits, cz_layers)
+        qids = tuple(sorted(set(qubits)))
+        n = len(qids)
+        if k_words == 1:
+            return {qid: 0 for qid in qids}
+
+        tpwgts = [size / float(n) for size in target_sizes]
+        adjacency: list[list[int]] = [[] for _ in range(n)]
+        adjacency_w: list[list[int]] = [[] for _ in range(n)]
+        for (u, v), w in sorted(edge_weights.items()):
+            adjacency[u].append(v)
+            adjacency[v].append(u)
+            adjacency_w[u].append(w)
+            adjacency_w[v].append(w)
+        xadj = [0]
+        adjncy: list[int] = []
+        eweights: list[int] = []
+        for node in range(n):
+            adjncy.extend(adjacency[node])
+            eweights.extend(adjacency_w[node])
+            xadj.append(len(adjncy))
+
+        ufactor = max(1, int(round((self.metis_ubvec - 1.0) * 1000.0)))
+        options = pymetis.Options(ufactor=ufactor)
+        csr_adjacency = pymetis.CSRAdjacency(xadj, adjncy)
+        graph_partition = pymetis.part_graph(
+            nparts=k_words,
+            adjacency=csr_adjacency,
+            eweights=eweights,
+            tpwgts=tpwgts,
+            recursive=self.metis_recursive,
+            options=options,
+        )
+        if hasattr(graph_partition, "vertex_part"):
+            parts = graph_partition.vertex_part
+        else:
+            _, parts = graph_partition
+        if len(parts) != n:
+            raise RuntimeError("METIS returned unexpected partition size.")
+        q_to_word = {qid: int(parts[q_to_node[qid]]) for qid in qids}
+        return q_to_word
+
+    def _left_to_right_relabel_words(
+        self,
+        q_to_word: dict[int, int],
+    ) -> dict[int, int]:
+        members: dict[int, list[int]] = defaultdict(list)
+        for qid, wid in q_to_word.items():
+            members[wid].append(qid)
+        old_words = sorted(members.keys(), key=lambda wid: min(members[wid]))
+        desired_word_ids = list(range(len(old_words)))
+        old_words_sorted = sorted(
+            old_words,
+            key=lambda wid: (-len(members[wid]), min(members[wid])),
+        )
+        remap = {
+            old_wid: new_wid
+            for old_wid, new_wid in zip(old_words_sorted, desired_word_ids)
+        }
+        return {qid: remap[wid] for qid, wid in q_to_word.items()}
+
+    def _left_sites_center_out(self, word_id: int) -> list[layout.LocationAddress]:
+        left_sites = [
+            layout.LocationAddress(word_id, site_id)
+            for site_id in range(self.left_site_count)
+        ]
+        center_site = (self.left_site_count - 1) / 2.0
+        return sorted(
+            left_sites,
+            key=lambda addr: (abs(addr.site_id - center_site), addr.site_id),
+        )
+
+    def _within_word_placement(
+        self,
+        members: list[int],
+        q_to_node: dict[int, int],
+        weighted_edges: dict[tuple[int, int], int],
+        sites: list[layout.LocationAddress],
+    ) -> dict[int, layout.LocationAddress]:
+        def edge_weight(q0: int, q1: int) -> int:
+            u = q_to_node[q0]
+            v = q_to_node[q1]
+            if u > v:
+                u, v = v, u
+            return weighted_edges.get((u, v), 0)
+
+        def local_weighted_degree(q: int) -> int:
+            return sum(edge_weight(q, other) for other in members if other != q)
+
+        def local_unweighted_degree(q: int) -> int:
+            return sum(
+                1 for other in members if other != q and edge_weight(q, other) > 0
+            )
+
+        if len(members) == 0:
+            return {}
+
+        placed: dict[int, layout.LocationAddress] = {}
+        remaining = set(members)
+        center_qubit = max(
+            sorted(remaining),
+            key=lambda q: (
+                local_weighted_degree(q),
+                local_unweighted_degree(q),
+                -q,
+            ),
+        )
+        placed[center_qubit] = sites[0]
+        remaining.remove(center_qubit)
+
+        for site in sites[1 : len(members)]:
+            best_q = None
+            best_key = None
+            for q in sorted(remaining):
+                score = 0.0
+                for p, p_site in placed.items():
+                    distance = abs(site.site_id - p_site.site_id)
+                    score += edge_weight(q, p) / float(1 + distance)
+                key = (
+                    score,
+                    local_weighted_degree(q),
+                    local_unweighted_degree(q),
+                    -q,
+                )
+                if best_key is None or key > best_key:
+                    best_key = key
+                    best_q = q
+            assert best_q is not None
+            placed[best_q] = site
+            remaining.remove(best_q)
+
+        return placed
+
+    def _compute_layout_from_cz_layers(
+        self,
+        qubits: tuple[int, ...],
+        cz_layers: tuple[tuple[tuple[int, ...], tuple[int, ...]], ...],
+    ) -> tuple[layout.LocationAddress, ...]:
+        k_words = self._word_count(len(qubits))
+        target_sizes = self._target_block_sizes(len(qubits), k_words)
+        q_to_node, weighted_edges = self._build_weighted_graph(qubits, cz_layers)
+
+        q_to_word_raw = self._partition_words(qubits, cz_layers, k_words, target_sizes)
+        q_to_word = self._left_to_right_relabel_words(q_to_word_raw)
+
+        members_by_word: dict[int, list[int]] = defaultdict(list)
+        for qid in sorted(qubits):
+            members_by_word[q_to_word[qid]].append(qid)
+
+        # Enforce left-to-right target capacities after METIS assignment.
+        capacities = {word_id: target_sizes[word_id] for word_id in range(k_words)}
+        for word_id in range(k_words):
+            members_by_word.setdefault(word_id, [])
+
+        for src_word in range(k_words):
+            while len(members_by_word[src_word]) > capacities[src_word]:
+                # Move deterministically: spill highest-id qubits first.
+                spill_qid = max(members_by_word[src_word])
+                members_by_word[src_word].remove(spill_qid)
+                for dst_word in range(src_word + 1, k_words):
+                    if len(members_by_word[dst_word]) < capacities[dst_word]:
+                        members_by_word[dst_word].append(spill_qid)
+                        break
+                else:
+                    members_by_word[src_word].append(spill_qid)
+                    break
+
+        q_to_location: dict[int, layout.LocationAddress] = {}
+        for word_id in range(k_words):
+            members = members_by_word[word_id]
+            sites = self._left_sites_center_out(word_id)
+            assigned = self._within_word_placement(
+                members,
+                q_to_node=q_to_node,
+                weighted_edges=weighted_edges,
+                sites=sites,
+            )
+            q_to_location.update(assigned)
+
+        return tuple(q_to_location[qid] for qid in qubits)
+
+    def compute_layout(
+        self,
+        all_qubits: tuple[int, ...],
+        stages: list[tuple[tuple[int, int], ...]],
+    ) -> tuple[layout.LocationAddress, ...]:
+        qubits = tuple(sorted(all_qubits))
+        cz_layers = _to_cz_layers(stages)
+        return self._compute_layout_from_cz_layers(qubits, cz_layers)

--- a/src/bloqade/lanes/heuristics/physical_movement.py
+++ b/src/bloqade/lanes/heuristics/physical_movement.py
@@ -1,0 +1,367 @@
+from dataclasses import dataclass, field, replace
+
+from bloqade.lanes import layout
+from bloqade.lanes.analysis.placement import (
+    AtomState,
+    ConcreteState,
+    ExecuteCZ,
+    SingleZonePlacementStrategyABC,
+)
+from bloqade.lanes.arch.gemini.physical import get_arch_spec as get_physical_arch_spec
+from bloqade.lanes.layout.path import PathFinder
+
+
+@dataclass
+class PhysicalGreedyPlacementStrategy(SingleZonePlacementStrategyABC):
+    """Greedy physical placement strategy for single-zone architectures.
+
+    The strategy chooses CZ placements by moving at most one qubit per pair to a
+    blockaded partner location, with optional lookahead pressure toward upcoming
+    CZ partners. Move routing is synthesized with shortest paths from PathFinder
+    and packed into compatible move layers.
+    """
+
+    arch_spec: layout.ArchSpec = field(default_factory=get_physical_arch_spec)
+    return_to_left_after_cz: bool = True
+    lane_move_overhead_cost: float = 0.0
+    large_cost: float = 1e9
+    _path_finder: PathFinder = field(init=False, repr=False)
+    _pending_return_from: tuple[layout.LocationAddress, ...] | None = field(
+        init=False, default=None, repr=False
+    )
+    _pending_return_to: tuple[layout.LocationAddress, ...] | None = field(
+        init=False, default=None, repr=False
+    )
+    _pending_return_layers: tuple[tuple[layout.LaneAddress, ...], ...] | None = field(
+        init=False, default=None, repr=False
+    )
+
+    def __post_init__(self):
+        self._path_finder = PathFinder(self.arch_spec)
+
+    @property
+    def _home_site_count(self) -> int:
+        # Gemini words are shaped as two columns x word_size_y rows.
+        return len(self.arch_spec.words[0].site_indices) // 2
+
+    def validate_initial_layout(
+        self,
+        initial_layout: tuple[layout.LocationAddress, ...],
+    ) -> None:
+        _ = initial_layout
+
+    def _path_cost(self, path: tuple[layout.LaneAddress, ...] | None) -> float:
+        if path is None:
+            return self.large_cost
+        return sum(
+            self.arch_spec.get_lane_duration_cost(lane) + self.lane_move_overhead_cost
+            for lane in path
+        )
+
+    def _find_route(
+        self,
+        src: layout.LocationAddress,
+        dst: layout.LocationAddress,
+        occupied: frozenset[layout.LocationAddress] = frozenset(),
+    ) -> (
+        tuple[tuple[layout.LaneAddress, ...], tuple[layout.LocationAddress, ...]] | None
+    ):
+        if src == dst:
+            return (), (src,)
+        return self._path_finder.find_path(
+            src,
+            dst,
+            occupied=occupied,
+            edge_weight=lambda lane: self.arch_spec.get_lane_duration_cost(lane)
+            + self.lane_move_overhead_cost,
+        )
+
+    def _occupied_except(
+        self,
+        qubit_layout: tuple[layout.LocationAddress, ...] | list[layout.LocationAddress],
+        occupied_static: (
+            set[layout.LocationAddress] | frozenset[layout.LocationAddress]
+        ),
+        excluded_qids: frozenset[int] = frozenset(),
+    ) -> frozenset[layout.LocationAddress]:
+        return frozenset(occupied_static) | {
+            loc for qid, loc in enumerate(qubit_layout) if qid not in excluded_qids
+        }
+
+    def _move_candidate_score(
+        self,
+        moved_qid: int,
+        src: layout.LocationAddress,
+        dst: layout.LocationAddress,
+        occupied: frozenset[layout.LocationAddress],
+        move_count: tuple[int, ...],
+    ) -> float:
+        route = self._find_route(src, dst, occupied=occupied)
+        path_cost = self._path_cost(None if route is None else route[0])
+        if path_cost >= self.large_cost:
+            return self.large_cost
+        # Prefer qubits with fewer accumulated moves on equal geometric cost.
+        move_penalty = 1e-6 * float(move_count[moved_qid])
+        return path_cost + move_penalty
+
+    def desired_cz_layout(
+        self,
+        state: ConcreteState,
+        controls: tuple[int, ...],
+        targets: tuple[int, ...],
+    ) -> ConcreteState:
+        updated_layout = list(state.layout)
+        updated_move_count = list(state.move_count)
+        occupied_static = set(state.occupied)
+
+        pair_order = sorted(
+            range(len(controls)),
+            key=lambda idx: (
+                -(state.move_count[controls[idx]] + state.move_count[targets[idx]]),
+                controls[idx],
+                targets[idx],
+            ),
+        )
+
+        for idx in pair_order:
+            control = controls[idx]
+            target = targets[idx]
+            c_loc = updated_layout[control]
+            t_loc = updated_layout[target]
+
+            c_blockaded = self.arch_spec.get_blockaded_location(c_loc)
+            t_blockaded = self.arch_spec.get_blockaded_location(t_loc)
+
+            if c_blockaded == t_loc or t_blockaded == c_loc:
+                continue
+
+            occupied_now = self._occupied_except(
+                updated_layout,
+                occupied_static,
+                excluded_qids=frozenset((control, target)),
+            )
+
+            candidates: list[tuple[float, int, layout.LocationAddress]] = []
+            if (
+                c_blockaded is not None
+                and c_blockaded not in occupied_now
+                and c_blockaded != t_loc
+            ):
+                candidates.append(
+                    (
+                        self._move_candidate_score(
+                            target,
+                            t_loc,
+                            c_blockaded,
+                            occupied_now,
+                            tuple(updated_move_count),
+                        ),
+                        target,
+                        c_blockaded,
+                    )
+                )
+
+            if (
+                t_blockaded is not None
+                and t_blockaded not in occupied_now
+                and t_blockaded != c_loc
+            ):
+                candidates.append(
+                    (
+                        self._move_candidate_score(
+                            control,
+                            c_loc,
+                            t_blockaded,
+                            occupied_now,
+                            tuple(updated_move_count),
+                        ),
+                        control,
+                        t_blockaded,
+                    )
+                )
+
+            if len(candidates) == 0:
+                raise RuntimeError(
+                    "No feasible movement candidate for CZ pair "
+                    f"(control={control}, target={target})."
+                )
+
+            best_score, moved_qid, dst = min(
+                candidates,
+                key=lambda item: (item[0], item[1], item[2].word_id, item[2].site_id),
+            )
+            if best_score >= self.large_cost:
+                raise RuntimeError(
+                    "No finite-cost movement candidate for CZ pair "
+                    f"(control={control}, target={target})."
+                )
+            if updated_layout[moved_qid] != dst:
+                updated_layout[moved_qid] = dst
+                updated_move_count[moved_qid] += 1
+
+        return replace(
+            state,
+            layout=tuple(updated_layout),
+            move_count=tuple(updated_move_count),
+        )
+
+    def _inverse_layers(
+        self,
+        move_layers: tuple[tuple[layout.LaneAddress, ...], ...],
+    ) -> tuple[tuple[layout.LaneAddress, ...], ...]:
+        return tuple(
+            tuple(lane.reverse() for lane in reversed(layer))
+            for layer in reversed(move_layers)
+        )
+
+    def _apply_pending_return(
+        self,
+        state: ConcreteState,
+    ) -> tuple[ConcreteState, tuple[tuple[layout.LaneAddress, ...], ...]]:
+        if (
+            not self.return_to_left_after_cz
+            or self._pending_return_from is None
+            or self._pending_return_to is None
+            or self._pending_return_layers is None
+        ):
+            return state, ()
+
+        if state.layout != self._pending_return_from:
+            self._pending_return_from = None
+            self._pending_return_to = None
+            self._pending_return_layers = None
+            return state, ()
+
+        returned_state = replace(
+            state,
+            layout=self._pending_return_to,
+            move_count=tuple(
+                mc + int(src != dst)
+                for mc, src, dst in zip(
+                    state.move_count,
+                    state.layout,
+                    self._pending_return_to,
+                    strict=True,
+                )
+            ),
+        )
+        return_layers = self._pending_return_layers
+        self._pending_return_from = None
+        self._pending_return_to = None
+        self._pending_return_layers = None
+        return returned_state, return_layers
+
+    def compute_moves(
+        self, state_before: ConcreteState, state_after: ConcreteState
+    ) -> tuple[tuple[layout.LaneAddress, ...], ...]:
+        changed = [
+            (qid, src, dst)
+            for qid, (src, dst) in enumerate(
+                zip(state_before.layout, state_after.layout)
+            )
+            if src != dst
+        ]
+        if len(changed) == 0:
+            return ()
+
+        targets = {qid: dst for qid, _, dst in changed}
+        current_layout = list(state_before.layout)
+        layers: list[tuple[layout.LaneAddress, ...]] = []
+        while any(current_layout[qid] != dst for qid, dst in targets.items()):
+            layer: list[layout.LaneAddress] = []
+            reserved_src: set[layout.LocationAddress] = set()
+            reserved_dst: set[layout.LocationAddress] = set()
+            moved_this_layer: dict[int, layout.LocationAddress] = {}
+            occupied_at_layer_start = set(state_before.occupied) | set(current_layout)
+
+            for qid in sorted(targets):
+                src = current_layout[qid]
+                dst_final = targets[qid]
+                if src == dst_final:
+                    continue
+                occupied_for_path = occupied_at_layer_start - {src}
+                route = self._find_route(
+                    src,
+                    dst_final,
+                    occupied=frozenset(occupied_for_path),
+                )
+                if route is None:
+                    continue
+                path, locations = route
+                if len(path) == 0:
+                    continue
+                lane = path[0]
+                step_src = locations[0]
+                step_dst = locations[1]
+                if step_src != current_layout[qid]:
+                    raise RuntimeError(
+                        "Path synthesis produced an invalid first hop "
+                        f"for qubit {qid}: expected source {current_layout[qid]}, "
+                        f"got {step_src}."
+                    )
+                if not all(
+                    self.arch_spec.compatible_lanes(lane, other) for other in layer
+                ):
+                    continue
+                if step_src in reserved_src or step_src in reserved_dst:
+                    continue
+                if step_dst in occupied_at_layer_start:
+                    continue
+                if step_dst in reserved_src or step_dst in reserved_dst:
+                    continue
+                layer.append(lane)
+                reserved_src.add(step_src)
+                reserved_dst.add(step_dst)
+                moved_this_layer[qid] = step_dst
+
+            if len(layer) == 0:
+                blocked_qids = tuple(
+                    qid
+                    for qid, dst in sorted(targets.items())
+                    if current_layout[qid] != dst
+                )
+                raise RuntimeError(
+                    "Physical move synthesis deadlocked: no collision-safe, "
+                    "lane-compatible hop could be scheduled for remaining qubits "
+                    f"{blocked_qids}."
+                )
+            for qid, dst in moved_this_layer.items():
+                current_layout[qid] = dst
+            layers.append(tuple(layer))
+
+        return tuple(layers)
+
+    def cz_placements(
+        self,
+        state: AtomState,
+        controls: tuple[int, ...],
+        targets: tuple[int, ...],
+        lookahead_cz_layers: tuple[tuple[tuple[int, ...], tuple[int, ...]], ...] = (),
+    ) -> AtomState:
+        _ = lookahead_cz_layers
+        if len(controls) != len(targets) or state == AtomState.bottom():
+            return AtomState.bottom()
+
+        if not isinstance(state, ConcreteState):
+            return AtomState.top()
+
+        restored_state, return_layers = self._apply_pending_return(state)
+        desired = self.desired_cz_layout(
+            restored_state,
+            controls,
+            targets,
+        )
+        forward_layers = self.compute_moves(restored_state, desired)
+        if self.return_to_left_after_cz:
+            self._pending_return_from = desired.layout
+            self._pending_return_to = restored_state.layout
+            self._pending_return_layers = self._inverse_layers(forward_layers)
+        move_layers = return_layers + forward_layers
+
+        return ExecuteCZ(
+            occupied=desired.occupied,
+            layout=desired.layout,
+            move_count=desired.move_count,
+            active_cz_zones=frozenset([layout.ZoneAddress(0)]),
+            move_layers=move_layers,
+        )

--- a/src/bloqade/lanes/heuristics/physical_placement.py
+++ b/src/bloqade/lanes/heuristics/physical_placement.py
@@ -1,0 +1,3 @@
+from bloqade.lanes.heuristics.physical_movement import PhysicalGreedyPlacementStrategy
+
+__all__ = ["PhysicalGreedyPlacementStrategy"]

--- a/src/bloqade/lanes/logical_mvp.py
+++ b/src/bloqade/lanes/logical_mvp.py
@@ -1,4 +1,5 @@
 import io
+from typing import Literal
 
 from bloqade.analysis.validation.simple_nocloning import FlatKernelNoCloningValidation
 from bloqade.gemini.analysis.logical_validation import GeminiLogicalValidation
@@ -12,10 +13,20 @@ from kirin.validation import ValidationSuite
 
 from bloqade.lanes import visualize
 from bloqade.lanes.analysis.layout import LayoutHeuristicABC
+from bloqade.lanes.analysis.placement import PlacementStrategyABC
 from bloqade.lanes.arch.gemini import logical
-from bloqade.lanes.arch.gemini.impls import generate_arch_hypercube
-from bloqade.lanes.heuristics import fixed
-from bloqade.lanes.heuristics.logical_placement import LogicalPlacementStrategyNoHome
+from bloqade.lanes.arch.gemini.physical import get_arch_spec as get_physical_arch_spec
+from bloqade.lanes.dialects import move
+from bloqade.lanes.heuristics import logical_layout
+from bloqade.lanes.heuristics.logical_placement import (
+    LogicalPlacementStrategy,
+    LogicalPlacementStrategyNoHome,
+)
+from bloqade.lanes.heuristics.physical_layout import (
+    PhysicalLayoutHeuristicFixed,
+    PhysicalLayoutHeuristicGraphPartitionCenterOut,
+)
+from bloqade.lanes.heuristics.physical_placement import PhysicalGreedyPlacementStrategy
 from bloqade.lanes.noise_model import generate_simple_noise_model
 from bloqade.lanes.rewrite import transversal
 from bloqade.lanes.rewrite.move2squin.noise import NoiseModelABC
@@ -76,7 +87,10 @@ def compile_squin_to_move(
     mt: ir.Method,
     transversal_rewrite: bool = False,
     no_raise: bool = True,
+    placement_mode: Literal["logical", "physical"] = "logical",
     layout_heuristic: LayoutHeuristicABC | None = None,
+    placement_strategy: PlacementStrategyABC | None = None,
+    insert_palindrome_moves: bool = True,
 ):
     """
     Compile a squin kernel to move dialect.
@@ -89,14 +103,76 @@ def compile_squin_to_move(
     Returns:
         ir.Method: The compiled move dialect method.
     """
-    if layout_heuristic is None:
-        layout_heuristic = fixed.LogicalLayoutHeuristic()
 
+    def _layout_mode(
+        layout_h: LayoutHeuristicABC,
+    ) -> Literal["logical", "physical"] | None:
+        if isinstance(
+            layout_h,
+            (
+                PhysicalLayoutHeuristicFixed,
+                PhysicalLayoutHeuristicGraphPartitionCenterOut,
+            ),
+        ):
+            return "physical"
+        if isinstance(layout_h, logical_layout.LogicalLayoutHeuristic):
+            return "logical"
+        return None
+
+    def _strategy_mode(
+        strategy: PlacementStrategyABC,
+    ) -> Literal["logical", "physical"] | None:
+        if isinstance(strategy, PhysicalGreedyPlacementStrategy):
+            return "physical"
+        if isinstance(
+            strategy, (LogicalPlacementStrategy, LogicalPlacementStrategyNoHome)
+        ):
+            return "logical"
+        return None
+
+    if placement_mode not in ("logical", "physical"):
+        raise ValueError(
+            f"Unsupported placement_mode={placement_mode!r}; expected 'logical' or 'physical'."
+        )
+    physical_arch_spec = None
+    if placement_mode == "physical" and (
+        layout_heuristic is None or placement_strategy is None
+    ):
+        physical_arch_spec = get_physical_arch_spec()
+    if layout_heuristic is None:
+        if placement_mode == "logical":
+            layout_heuristic = logical_layout.LogicalLayoutHeuristic()
+        else:
+            assert physical_arch_spec is not None
+            layout_heuristic = PhysicalLayoutHeuristicGraphPartitionCenterOut(
+                arch_spec=physical_arch_spec
+            )
+    if placement_strategy is None:
+        if placement_mode == "logical":
+            placement_strategy = LogicalPlacementStrategyNoHome()
+        else:
+            assert physical_arch_spec is not None
+            placement_strategy = PhysicalGreedyPlacementStrategy(
+                arch_spec=physical_arch_spec
+            )
+
+    layout_mode = _layout_mode(layout_heuristic)
+    strategy_mode = _strategy_mode(placement_strategy)
+    if layout_mode is not None and layout_mode != placement_mode:
+        raise ValueError(
+            "layout_heuristic is incompatible with placement_mode="
+            f"{placement_mode!r}; inferred mode is {layout_mode!r}."
+        )
+    if strategy_mode is not None and strategy_mode != placement_mode:
+        raise ValueError(
+            "placement_strategy is incompatible with placement_mode="
+            f"{placement_mode!r}; inferred mode is {strategy_mode!r}."
+        )
     mt = squin_to_move(
         mt,
         layout_heuristic=layout_heuristic,
-        placement_strategy=LogicalPlacementStrategyNoHome(),
-        insert_palindrome_moves=True,
+        placement_strategy=placement_strategy,
+        insert_palindrome_moves=insert_palindrome_moves,
         no_raise=no_raise,
     )
     if transversal_rewrite:
@@ -111,7 +187,10 @@ def compile_squin_to_move_and_visualize(
     transversal_rewrite: bool = False,
     animated: bool = False,
     no_raise: bool = True,
+    placement_mode: Literal["logical", "physical"] = "logical",
     layout_heuristic: LayoutHeuristicABC | None = None,
+    placement_strategy: PlacementStrategyABC | None = None,
+    insert_palindrome_moves: bool = True,
 ):
     """
     Compile a squin kernel to moves and visualize the program.
@@ -128,10 +207,25 @@ def compile_squin_to_move_and_visualize(
         mt,
         transversal_rewrite,
         no_raise=no_raise,
+        placement_mode=placement_mode,
         layout_heuristic=layout_heuristic,
+        placement_strategy=placement_strategy,
+        insert_palindrome_moves=insert_palindrome_moves,
     )
-    if transversal_rewrite:
-        arch_spec = generate_arch_hypercube(4)
+    use_physical_visualization = (
+        transversal_rewrite
+        or placement_mode == "physical"
+        or isinstance(
+            layout_heuristic,
+            (
+                PhysicalLayoutHeuristicFixed,
+                PhysicalLayoutHeuristicGraphPartitionCenterOut,
+            ),
+        )
+        or isinstance(placement_strategy, PhysicalGreedyPlacementStrategy)
+    )
+    if use_physical_visualization:
+        arch_spec = get_physical_arch_spec()
         marker = "o"
     else:
         arch_spec = logical.get_arch_spec()
@@ -149,7 +243,11 @@ def compile_to_physical_squin_noise_model(
     mt: ir.Method,
     noise_model: NoiseModelABC | None = None,
     no_raise: bool = True,
+    arch_spec=None,
+    placement_mode: Literal["logical", "physical"] = "physical",
     layout_heuristic: LayoutHeuristicABC | None = None,
+    placement_strategy: PlacementStrategyABC | None = None,
+    insert_palindrome_moves: bool = True,
 ) -> ir.Method:
     """
     Compiles a logical squin kernel to a physical squin kernel with noise channels inserted.
@@ -164,15 +262,30 @@ def compile_to_physical_squin_noise_model(
     """
     if noise_model is None:
         noise_model = generate_simple_noise_model()
+    if arch_spec is None:
+        arch_spec = get_physical_arch_spec()
+    use_physical_defaults = (
+        placement_mode == "physical" and move.dialect not in mt.dialects
+    )
+    if use_physical_defaults:
+        if layout_heuristic is None:
+            layout_heuristic = PhysicalLayoutHeuristicGraphPartitionCenterOut(
+                arch_spec=arch_spec
+            )
+        if placement_strategy is None:
+            placement_strategy = PhysicalGreedyPlacementStrategy(arch_spec=arch_spec)
 
     move_mt = compile_squin_to_move(
         mt,
         transversal_rewrite=True,
         no_raise=no_raise,
+        placement_mode=placement_mode,
         layout_heuristic=layout_heuristic,
+        placement_strategy=placement_strategy,
+        insert_palindrome_moves=insert_palindrome_moves,
     )
     transformer = MoveToSquin(
-        arch_spec=generate_arch_hypercube(4),
+        arch_spec=arch_spec,
         logical_initialization=logical.steane7_initialize,
         noise_model=noise_model,
         aggressive_unroll=False,
@@ -185,7 +298,11 @@ def compile_to_physical_stim_program(
     mt: ir.Method,
     noise_model: NoiseModelABC | None = None,
     no_raise: bool = True,
+    arch_spec=None,
+    placement_mode: Literal["logical", "physical"] = "physical",
     layout_heuristic: LayoutHeuristicABC | None = None,
+    placement_strategy: PlacementStrategyABC | None = None,
+    insert_palindrome_moves: bool = True,
 ) -> str:
     """
     Compiles a logical squin kernel to a physical stim kernel with noise channels inserted.
@@ -202,7 +319,11 @@ def compile_to_physical_stim_program(
         mt,
         noise_model,
         no_raise=no_raise,
+        arch_spec=arch_spec,
+        placement_mode=placement_mode,
         layout_heuristic=layout_heuristic,
+        placement_strategy=placement_strategy,
+        insert_palindrome_moves=insert_palindrome_moves,
     )
     RemoveReturn().rewrite(noise_kernel.code)
     noise_kernel = squin_to_stim(noise_kernel)

--- a/src/bloqade/lanes/metrics.py
+++ b/src/bloqade/lanes/metrics.py
@@ -8,7 +8,7 @@ from bloqade.lanes.analysis.placement.strategy import PlacementStrategyABC
 from bloqade.lanes.arch.gemini import logical
 from bloqade.lanes.arch.gemini.impls import generate_arch_hypercube
 from bloqade.lanes.dialects import move
-from bloqade.lanes.heuristics import fixed
+from bloqade.lanes.heuristics import logical_layout
 from bloqade.lanes.logical_mvp import transversal_rewrites
 from bloqade.lanes.noise_model import generate_simple_noise_model
 from bloqade.lanes.rewrite.move2squin.noise import NoiseModelABC
@@ -183,7 +183,7 @@ def _compile_kernel_to_noisy_physical_squin(
 
     move_mt = squin_to_move(
         mt,
-        layout_heuristic=fixed.LogicalLayoutHeuristic(),
+        layout_heuristic=logical_layout.LogicalLayoutHeuristic(),
         placement_strategy=placement_strategy,
         insert_palindrome_moves=insert_palindrome_moves,
         merge_heuristic=merge_heuristic,
@@ -321,7 +321,7 @@ def analyze_kernel_moves_with_strategy(
     """
     move_mt = squin_to_move(
         mt,
-        layout_heuristic=fixed.LogicalLayoutHeuristic(),
+        layout_heuristic=logical_layout.LogicalLayoutHeuristic(),
         placement_strategy=placement_strategy,
         insert_palindrome_moves=insert_palindrome_moves,
         merge_heuristic=merge_heuristic,
@@ -357,7 +357,7 @@ def analyze_kernel_move_time_with_strategy(
     """
     move_mt = squin_to_move(
         mt,
-        layout_heuristic=fixed.LogicalLayoutHeuristic(),
+        layout_heuristic=logical_layout.LogicalLayoutHeuristic(),
         placement_strategy=placement_strategy,
         insert_palindrome_moves=insert_palindrome_moves,
         merge_heuristic=merge_heuristic,

--- a/test/heuristics/test_fixed.py
+++ b/test/heuristics/test_fixed.py
@@ -4,7 +4,7 @@ from bloqade.lanes import layout
 from bloqade.lanes.analysis.placement import AtomState, ConcreteState
 from bloqade.lanes.analysis.placement.lattice import ExecuteCZ
 from bloqade.lanes.arch.gemini.logical import get_arch_spec
-from bloqade.lanes.heuristics import fixed
+from bloqade.lanes.heuristics import logical_layout
 from bloqade.lanes.heuristics.logical_placement import (
     LogicalPlacementStrategy,
     LogicalPlacementStrategyNoHome,
@@ -359,7 +359,7 @@ def test_fixed_invalid_initial_layout_2():
 
 
 def test_initial_layout():
-    layout_heuristic = fixed.LogicalLayoutHeuristic()
+    layout_heuristic = logical_layout.LogicalLayoutHeuristic()
     edges = {(i, j): 1 for i in range(10) for j in range(i + 1, 10, 1)}
 
     edges[(0, 1)] = 10
@@ -583,7 +583,7 @@ def test_initial_layout_variable_word_size(word_size_y):
     from bloqade.lanes.arch.gemini.impls import generate_arch_hypercube
 
     arch_spec = generate_arch_hypercube(hypercube_dims=1, word_size_y=word_size_y)
-    layout_heuristic = fixed.LogicalLayoutHeuristic()
+    layout_heuristic = logical_layout.LogicalLayoutHeuristic()
     layout_heuristic.arch_spec = arch_spec
 
     num_qubits = word_size_y

--- a/test/heuristics/test_physical_initial_layout.py
+++ b/test/heuristics/test_physical_initial_layout.py
@@ -1,0 +1,209 @@
+import pytest
+
+from bloqade.lanes.arch.gemini.impls import generate_arch_hypercube
+from bloqade.lanes.heuristics.physical_layout import (
+    PhysicalLayoutHeuristicFixed,
+    PhysicalLayoutHeuristicGraphPartitionCenterOut,
+)
+
+pymetis = pytest.importorskip("pymetis")
+
+
+def _weighted_stages(
+    edge_counts: dict[tuple[int, int], int],
+) -> list[tuple[tuple[int, int], ...]]:
+    stages: list[tuple[tuple[int, int], ...]] = []
+    for (u, v), count in sorted(edge_counts.items()):
+        for _ in range(count):
+            stages.append(((u, v),))
+    return stages
+
+
+def _cut_weight(
+    qubits: tuple[int, ...],
+    q_to_word: dict[int, int],
+    edge_counts: dict[tuple[int, int], int],
+) -> int:
+    _ = qubits
+    total = 0
+    for (u, v), weight in edge_counts.items():
+        if q_to_word[u] != q_to_word[v]:
+            total += weight
+    return total
+
+
+def _layout_affinity_cost(
+    locations: dict[int, int],
+    edge_counts: dict[tuple[int, int], int],
+) -> int:
+    total = 0
+    for (u, v), weight in edge_counts.items():
+        total += weight * abs(locations[u] - locations[v])
+    return total
+
+
+def test_initial_layout_is_left_only_and_balanced():
+    strategy = PhysicalLayoutHeuristicGraphPartitionCenterOut(
+        arch_spec=generate_arch_hypercube(1),
+        preferred_fill=4,
+        max_words=2,
+    )
+    qubits = tuple(range(8))
+    stages = _weighted_stages(
+        {
+            (0, 1): 4,
+            (1, 2): 4,
+            (2, 3): 4,
+            (4, 5): 4,
+            (5, 6): 4,
+            (6, 7): 4,
+        }
+    )
+    layout_out = strategy.compute_layout(qubits, stages)
+    assert len(layout_out) == len(qubits)
+    assert len(set(layout_out)) == len(layout_out)
+    assert all(addr.site_id < strategy.left_site_count for addr in layout_out)
+    per_word = {}
+    for addr in layout_out:
+        per_word[addr.word_id] = per_word.get(addr.word_id, 0) + 1
+    assert sorted(per_word.values()) == [4, 4]
+
+
+def test_initial_layout_is_deterministic():
+    strategy = PhysicalLayoutHeuristicGraphPartitionCenterOut(
+        arch_spec=generate_arch_hypercube(1),
+        preferred_fill=4,
+        max_words=2,
+    )
+    qubits = tuple(range(8))
+    stages = _weighted_stages(
+        {
+            (0, 1): 3,
+            (1, 2): 3,
+            (2, 3): 3,
+            (4, 5): 3,
+            (5, 6): 3,
+            (6, 7): 3,
+            (1, 6): 1,
+        }
+    )
+    first = strategy.compute_layout(qubits, stages)
+    second = strategy.compute_layout(qubits, stages)
+    third = strategy.compute_layout(qubits, stages)
+    assert first == second == third
+
+
+def test_partition_word_fill_is_full_then_partial_left_to_right():
+    strategy = PhysicalLayoutHeuristicGraphPartitionCenterOut(
+        arch_spec=generate_arch_hypercube(1),
+        preferred_fill=3,
+        max_words=2,
+    )
+    qubits = tuple(range(6))
+    edge_counts = {
+        (0, 1): 8,
+        (1, 2): 8,
+        (0, 2): 8,
+        (3, 4): 8,
+        (4, 5): 8,
+        (3, 5): 8,
+        (2, 3): 1,
+    }
+    stages = _weighted_stages(edge_counts)
+    layout_out = strategy.compute_layout(qubits, stages)
+    per_word = {}
+    for addr in layout_out:
+        per_word[addr.word_id] = per_word.get(addr.word_id, 0) + 1
+    assert sorted(per_word.keys()) == [0, 1]
+    assert per_word[0] == 5
+    assert per_word[1] == 1
+
+
+def test_within_word_affinity_cost_beats_naive_ordering():
+    strategy = PhysicalLayoutHeuristicGraphPartitionCenterOut(
+        arch_spec=generate_arch_hypercube(1),
+        preferred_fill=5,
+        max_words=1,
+    )
+    qubits = tuple(range(5))
+    # Star-like affinity where center-out should place qubit 0 near the center.
+    edge_counts = {
+        (0, 1): 10,
+        (0, 2): 10,
+        (0, 3): 10,
+        (0, 4): 10,
+    }
+    stages = _weighted_stages(edge_counts)
+    layout_out = strategy.compute_layout(qubits, stages)
+
+    strategy_sites = {
+        qid: addr.site_id for qid, addr in zip(qubits, layout_out, strict=True)
+    }
+    strategy_cost = _layout_affinity_cost(strategy_sites, edge_counts)
+
+    naive_sites = {qid: idx for idx, qid in enumerate(sorted(qubits))}
+    naive_cost = _layout_affinity_cost(naive_sites, edge_counts)
+    assert strategy_cost <= naive_cost
+
+
+def test_word_assignment_overflow_expands_to_next_word():
+    strategy = PhysicalLayoutHeuristicGraphPartitionCenterOut(
+        arch_spec=generate_arch_hypercube(4),
+        preferred_fill=2,
+        max_words=4,
+    )
+    qubits = tuple(range(8))
+    edge_counts = {
+        (0, 1): 3,
+        (2, 3): 3,
+        (4, 5): 3,
+        (6, 7): 3,
+    }
+    stages = _weighted_stages(edge_counts)
+    layout_out = strategy.compute_layout(qubits, stages)
+
+    used_words = sorted({addr.word_id for addr in layout_out})
+    assert len(used_words) == 2
+    assert used_words == [0, 1]
+
+
+def test_within_word_center_site_used_for_first_placement():
+    strategy = PhysicalLayoutHeuristicGraphPartitionCenterOut(
+        arch_spec=generate_arch_hypercube(1, word_size_y=7),
+        preferred_fill=1,
+        max_words=1,
+    )
+    qubits = (0,)
+    stages = _weighted_stages({})
+    layout_out = strategy.compute_layout(qubits, stages)
+    assert layout_out[0].word_id == 0
+    assert layout_out[0].site_id == 3
+
+
+def test_relabel_words_fill_left_to_right():
+    strategy = PhysicalLayoutHeuristicGraphPartitionCenterOut(
+        arch_spec=generate_arch_hypercube(2),
+        preferred_fill=2,
+        max_words=4,
+    )
+    # Partition ids are arbitrary METIS labels; largest block should map to leftmost word.
+    q_to_word = {
+        0: 10,
+        1: 10,
+        2: 11,
+        3: 12,
+        4: 13,
+    }
+    relabeled = strategy._left_to_right_relabel_words(q_to_word)
+    assert relabeled[0] == 0
+    assert relabeled[1] == 0
+
+
+def test_fixed_baseline_fill_order():
+    strategy = PhysicalLayoutHeuristicFixed(
+        arch_spec=generate_arch_hypercube(1),
+    )
+    qubits = tuple(range(6))
+    out = strategy.compute_layout(qubits, _weighted_stages({}))
+    coords = tuple((addr.word_id, addr.site_id) for addr in out)
+    assert coords == ((0, 0), (0, 1), (0, 2), (0, 3), (0, 4), (1, 0))

--- a/test/heuristics/test_physical_movement.py
+++ b/test/heuristics/test_physical_movement.py
@@ -1,0 +1,270 @@
+import math
+
+from bloqade.gemini import logical as gemini_logical
+from kirin.dialects import ilist
+
+from bloqade import qubit, squin
+from bloqade.lanes.analysis.atom.atom_state_data import AtomStateData
+from bloqade.lanes.analysis.placement import ConcreteState, ExecuteCZ
+from bloqade.lanes.arch.gemini.logical import get_arch_spec
+from bloqade.lanes.dialects import move
+from bloqade.lanes.heuristics.logical_placement import LogicalPlacementStrategyNoHome
+from bloqade.lanes.heuristics.physical_placement import PhysicalGreedyPlacementStrategy
+from bloqade.lanes.layout.encoding import LocationAddress
+from bloqade.lanes.layout.path import PathFinder
+from bloqade.lanes.logical_mvp import (
+    compile_squin_to_move,
+    compile_squin_to_move_and_visualize,
+)
+from bloqade.lanes.metrics import (
+    analyze_kernel_move_time_with_strategy,
+    analyze_kernel_moves_with_strategy,
+)
+
+
+def _count_move_events(mt) -> int:
+    return sum(1 for stmt in mt.callable_region.walk() if isinstance(stmt, move.Move))
+
+
+def test_physical_strategy_validate_initial_layout_multiword():
+    strategy = PhysicalGreedyPlacementStrategy()
+    strategy.validate_initial_layout(
+        (
+            LocationAddress(0, 0),
+            LocationAddress(1, 1),
+            LocationAddress(2, 2),
+            LocationAddress(3, 3),
+        )
+    )
+
+
+def test_physical_strategy_validation_enforces_left_only():
+    strategy = PhysicalGreedyPlacementStrategy()
+    strategy.validate_initial_layout((LocationAddress(0, 5),))
+
+
+def _inverse_layers(move_layers):
+    return tuple(
+        tuple(lane.reverse() for lane in reversed(layer))
+        for layer in reversed(move_layers)
+    )
+
+
+def test_physical_strategy_ignores_future_lookahead_layers():
+    state = ConcreteState(
+        occupied=frozenset(),
+        layout=(
+            LocationAddress(0, 0),
+            LocationAddress(1, 0),
+            LocationAddress(0, 4),
+        ),
+        move_count=(0, 0, 0),
+    )
+    controls = (0,)
+    targets = (1,)
+    lookahead = (((0,), (2,)),)
+
+    strategy = PhysicalGreedyPlacementStrategy(arch_spec=get_arch_spec())
+
+    result_no_lookahead = strategy.cz_placements(
+        state, controls, targets, lookahead_cz_layers=()
+    )
+    result_with_lookahead = strategy.cz_placements(
+        state, controls, targets, lookahead_cz_layers=lookahead
+    )
+
+    assert isinstance(result_no_lookahead, ExecuteCZ)
+    assert isinstance(result_with_lookahead, ExecuteCZ)
+    assert result_no_lookahead.layout == result_with_lookahead.layout
+    assert result_no_lookahead.move_layers == result_with_lookahead.move_layers
+
+
+def test_physical_strategy_uses_inverse_return_layers():
+    strategy = PhysicalGreedyPlacementStrategy(arch_spec=get_arch_spec())
+    initial = ConcreteState(
+        occupied=frozenset(),
+        layout=(
+            LocationAddress(0, 0),
+            LocationAddress(1, 0),
+        ),
+        move_count=(0, 0),
+    )
+    controls = (0,)
+    targets = (1,)
+
+    first = strategy.cz_placements(initial, controls, targets)
+    assert isinstance(first, ExecuteCZ)
+    assert len(first.move_layers) > 0
+    expected_inverse = _inverse_layers(first.move_layers)
+
+    second = strategy.cz_placements(first, controls, targets)
+    assert isinstance(second, ExecuteCZ)
+    assert second.move_layers[: len(expected_inverse)] == expected_inverse
+
+
+def test_compute_moves_only_uses_free_destinations():
+    strategy = PhysicalGreedyPlacementStrategy(arch_spec=get_arch_spec())
+    state_before = ConcreteState(
+        occupied=frozenset(),
+        layout=(
+            LocationAddress(0, 0),  # q0
+            LocationAddress(0, 1),  # q1
+            LocationAddress(0, 3),  # q2 (not moving)
+        ),
+        move_count=(0, 0, 0),
+    )
+    state_after = ConcreteState(
+        occupied=frozenset(),
+        layout=(
+            LocationAddress(0, 1),  # q0 should move after q1 vacates
+            LocationAddress(0, 2),  # q1 moves first
+            LocationAddress(0, 3),
+        ),
+        move_count=(1, 1, 0),
+    )
+
+    move_layers = strategy.compute_moves(state_before, state_after)
+    assert move_layers is not None
+    assert len(move_layers) >= 2
+
+    path_finder = PathFinder(strategy.arch_spec)
+    sim = AtomStateData.new(list(state_before.layout))
+    for layer in move_layers:
+        sim = sim.apply_moves(layer, path_finder)
+        assert sim is not None
+        assert len(sim.qubit_to_locations) == len(state_before.layout)
+
+    assert (
+        tuple(sim.qubit_to_locations[qid] for qid in range(len(state_before.layout)))
+        == state_after.layout
+    )
+
+
+@gemini_logical.kernel(aggressive_unroll=True)
+def _movement_kernel():
+    reg = qubit.qalloc(5)
+    squin.broadcast.u3(0.25 * math.pi, 0.1 * math.pi, 0.0, reg)
+    squin.broadcast.cz(ilist.IList([reg[0], reg[2]]), ilist.IList([reg[1], reg[3]]))
+    squin.broadcast.cz(ilist.IList([reg[0], reg[3]]), ilist.IList([reg[2], reg[4]]))
+
+
+def test_compile_entrypoint_default_behavior_stable():
+    default_move = compile_squin_to_move(_movement_kernel, no_raise=False)
+    explicit_old_move = compile_squin_to_move(
+        _movement_kernel,
+        no_raise=False,
+        placement_strategy=LogicalPlacementStrategyNoHome(),
+        insert_palindrome_moves=True,
+    )
+    assert str(default_move.code) == str(explicit_old_move.code)
+
+
+def test_compile_entrypoint_accepts_physical_strategy():
+    class TrackingPhysicalStrategy(PhysicalGreedyPlacementStrategy):
+        cz_calls: int = 0
+
+        def cz_placements(
+            self,
+            state,
+            controls,
+            targets,
+            lookahead_cz_layers=(),
+        ):
+            self.cz_calls += 1
+            return super().cz_placements(
+                state,
+                controls,
+                targets,
+                lookahead_cz_layers=lookahead_cz_layers,
+            )
+
+    strategy = TrackingPhysicalStrategy(arch_spec=get_arch_spec())
+    physical_move = compile_squin_to_move(
+        _movement_kernel,
+        no_raise=False,
+        transversal_rewrite=False,
+        placement_mode="physical",
+        placement_strategy=strategy,
+    )
+
+    assert _count_move_events(physical_move) >= 0
+    assert strategy.cz_calls > 0
+
+
+def test_compile_entrypoint_physical_mode_uses_physical_defaults(monkeypatch):
+    calls = {"cz_calls": 0}
+    original = PhysicalGreedyPlacementStrategy.cz_placements
+
+    def wrapped(self, state, controls, targets, lookahead_cz_layers=()):
+        calls["cz_calls"] += 1
+        return original(
+            self,
+            state,
+            controls,
+            targets,
+            lookahead_cz_layers=lookahead_cz_layers,
+        )
+
+    monkeypatch.setattr(PhysicalGreedyPlacementStrategy, "cz_placements", wrapped)
+    physical_move = compile_squin_to_move(
+        _movement_kernel,
+        no_raise=False,
+        placement_mode="physical",
+    )
+    assert _count_move_events(physical_move) >= 0
+    assert calls["cz_calls"] > 0
+
+
+def test_visualize_entrypoint_physical_mode_uses_physical_marker(monkeypatch):
+    called = {"debugger": 0, "atom_marker": None}
+
+    def fake_debugger(*_args, **kwargs):
+        called["debugger"] += 1
+        called["atom_marker"] = kwargs.get("atom_marker")
+
+    monkeypatch.setattr("bloqade.lanes.visualize.debugger", fake_debugger)
+    compile_squin_to_move_and_visualize(
+        _movement_kernel,
+        interactive=False,
+        animated=False,
+        no_raise=False,
+        placement_mode="physical",
+    )
+    assert called["debugger"] == 1
+    assert called["atom_marker"] == "o"
+
+
+def test_metrics_harness_quantifies_default_vs_custom_strategy():
+    baseline_strategy = LogicalPlacementStrategyNoHome()
+    custom_strategy = PhysicalGreedyPlacementStrategy(arch_spec=get_arch_spec())
+
+    baseline_moves = analyze_kernel_moves_with_strategy(
+        _movement_kernel,
+        placement_strategy=baseline_strategy,
+        insert_palindrome_moves=True,
+    )
+    custom_moves = analyze_kernel_moves_with_strategy(
+        _movement_kernel,
+        placement_strategy=custom_strategy,
+        insert_palindrome_moves=True,
+    )
+    baseline_time = analyze_kernel_move_time_with_strategy(
+        _movement_kernel,
+        placement_strategy=baseline_strategy,
+        insert_palindrome_moves=True,
+    )
+    custom_time = analyze_kernel_move_time_with_strategy(
+        _movement_kernel,
+        placement_strategy=custom_strategy,
+        insert_palindrome_moves=True,
+    )
+
+    lane_delta = custom_moves.moved_lane_count - baseline_moves.moved_lane_count
+    time_delta_us = custom_time.total_move_time_us - baseline_time.total_move_time_us
+
+    assert isinstance(lane_delta, int)
+    assert isinstance(time_delta_us, float)
+    assert baseline_moves.moved_lane_count >= 0
+    assert custom_moves.moved_lane_count >= 0
+    assert baseline_time.total_move_time_us >= 0.0
+    assert custom_time.total_move_time_us >= 0.0

--- a/test/physical_mode/test_physical_squin_compiler.py
+++ b/test/physical_mode/test_physical_squin_compiler.py
@@ -1,0 +1,151 @@
+import math
+from dataclasses import dataclass
+
+import pytest
+from bloqade.gemini import logical as gemini_logical
+from kirin.dialects import ilist
+
+from bloqade import qubit, squin
+from bloqade.lanes.analysis.layout import LayoutHeuristicABC
+from bloqade.lanes.arch.gemini.impls import generate_arch_hypercube
+from bloqade.lanes.dialects import move
+from bloqade.lanes.heuristics.logical_layout import LogicalLayoutHeuristic
+from bloqade.lanes.heuristics.logical_placement import LogicalPlacementStrategyNoHome
+from bloqade.lanes.heuristics.physical_layout import (
+    PhysicalLayoutHeuristicGraphPartitionCenterOut,
+)
+from bloqade.lanes.heuristics.physical_placement import PhysicalGreedyPlacementStrategy
+from bloqade.lanes.layout.encoding import LocationAddress
+from bloqade.lanes.logical_mvp import compile_squin_to_move
+
+
+def _count_move_events(mt) -> int:
+    return sum(1 for stmt in mt.callable_region.walk() if isinstance(stmt, move.Move))
+
+
+@gemini_logical.kernel(aggressive_unroll=True)
+def _physical_compile_kernel():
+    reg = qubit.qalloc(5)
+    squin.broadcast.u3(0.25 * math.pi, 0.1 * math.pi, 0.0, reg)
+    squin.broadcast.cz(ilist.IList([reg[0], reg[2]]), ilist.IList([reg[1], reg[3]]))
+    squin.broadcast.cz(ilist.IList([reg[0], reg[3]]), ilist.IList([reg[2], reg[4]]))
+
+
+def test_compile_squin_to_move_physical_mode_smoke():
+    physical_move = compile_squin_to_move(
+        _physical_compile_kernel,
+        no_raise=False,
+        placement_mode="physical",
+    )
+    assert _count_move_events(physical_move) >= 0
+
+
+def test_compile_squin_to_move_physical_mode_uses_physical_strategies():
+    @dataclass
+    class TrackingLayoutHeuristic(PhysicalLayoutHeuristicGraphPartitionCenterOut):
+        compute_calls: int = 0
+
+        def compute_layout(self, all_qubits, stages):
+            self.compute_calls += 1
+            return super().compute_layout(all_qubits, stages)
+
+    @dataclass
+    class TrackingMovementStrategy(PhysicalGreedyPlacementStrategy):
+        cz_calls: int = 0
+
+        def cz_placements(
+            self,
+            state,
+            controls,
+            targets,
+            lookahead_cz_layers=(),
+        ):
+            self.cz_calls += 1
+            return super().cz_placements(
+                state,
+                controls,
+                targets,
+                lookahead_cz_layers=lookahead_cz_layers,
+            )
+
+    arch_spec = generate_arch_hypercube(4)
+    layout_heuristic = TrackingLayoutHeuristic(arch_spec=arch_spec)
+    movement_strategy = TrackingMovementStrategy(arch_spec=arch_spec)
+    physical_move = compile_squin_to_move(
+        _physical_compile_kernel,
+        no_raise=False,
+        placement_mode="physical",
+        layout_heuristic=layout_heuristic,
+        placement_strategy=movement_strategy,
+    )
+    assert _count_move_events(physical_move) >= 0
+    assert layout_heuristic.compute_calls > 0
+    assert movement_strategy.cz_calls > 0
+
+
+def test_compile_squin_to_move_physical_mode_respects_explicit_overrides():
+    @dataclass
+    class TrackingLayoutHeuristic(LayoutHeuristicABC):
+        called: bool = False
+
+        def compute_layout(self, all_qubits, stages):
+            self.called = True
+            _ = stages
+            qubits = tuple(sorted(all_qubits))
+            return tuple(LocationAddress(0, idx) for idx, _ in enumerate(qubits))
+
+    @dataclass
+    class TrackingMovementStrategy(PhysicalGreedyPlacementStrategy):
+        cz_calls: int = 0
+
+        def cz_placements(
+            self,
+            state,
+            controls,
+            targets,
+            lookahead_cz_layers=(),
+        ):
+            self.cz_calls += 1
+            return super().cz_placements(
+                state,
+                controls,
+                targets,
+                lookahead_cz_layers=lookahead_cz_layers,
+            )
+
+    arch_spec = generate_arch_hypercube(4)
+    layout_heuristic = TrackingLayoutHeuristic()
+    movement_strategy = TrackingMovementStrategy(arch_spec=arch_spec)
+    physical_move = compile_squin_to_move(
+        _physical_compile_kernel,
+        no_raise=False,
+        placement_mode="physical",
+        layout_heuristic=layout_heuristic,
+        placement_strategy=movement_strategy,
+    )
+    assert _count_move_events(physical_move) >= 0
+    assert layout_heuristic.called
+    assert movement_strategy.cz_calls > 0
+
+
+def test_compile_squin_to_move_rejects_layout_mode_mismatch():
+    with pytest.raises(ValueError, match="layout_heuristic is incompatible"):
+        compile_squin_to_move(
+            _physical_compile_kernel,
+            no_raise=False,
+            placement_mode="physical",
+            layout_heuristic=LogicalLayoutHeuristic(),
+            placement_strategy=PhysicalGreedyPlacementStrategy(
+                arch_spec=generate_arch_hypercube(4)
+            ),
+        )
+
+
+def test_compile_squin_to_move_rejects_strategy_mode_mismatch():
+    with pytest.raises(ValueError, match="placement_strategy is incompatible"):
+        compile_squin_to_move(
+            _physical_compile_kernel,
+            no_raise=False,
+            placement_mode="physical",
+            placement_strategy=LogicalPlacementStrategyNoHome(),
+        )

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -15,7 +15,7 @@ from bloqade.lanes.arch.gemini import logical
 from bloqade.lanes.arch.gemini.impls import generate_arch_hypercube
 from bloqade.lanes.arch.gemini.logical import get_arch_spec
 from bloqade.lanes.device import GeminiLogicalSimulator
-from bloqade.lanes.heuristics import fixed
+from bloqade.lanes.heuristics import logical_layout
 from bloqade.lanes.heuristics.logical_placement import LogicalPlacementStrategyNoHome
 from bloqade.lanes.logical_mvp import (
     compile_squin_to_move,
@@ -68,7 +68,7 @@ def _compile_to_stim_with_merge_heuristic(mt, merge_heuristic):
     noise_model = generate_simple_noise_model()
     move_mt = squin_to_move(
         mt,
-        layout_heuristic=fixed.LogicalLayoutHeuristic(),
+        layout_heuristic=logical_layout.LogicalLayoutHeuristic(),
         placement_strategy=LogicalPlacementStrategyNoHome(),
         insert_palindrome_moves=True,
         merge_heuristic=merge_heuristic,

--- a/uv.lock
+++ b/uv.lock
@@ -217,6 +217,7 @@ dependencies = [
     { name = "deprecated" },
     { name = "kirin-toolchain" },
     { name = "numpy" },
+    { name = "pymetis" },
     { name = "rustworkx" },
 ]
 
@@ -266,6 +267,7 @@ requires-dist = [
     { name = "kirin-toolchain", specifier = "~=0.22.6" },
     { name = "matplotlib", marker = "extra == 'visualization'", specifier = ">=3.9.4" },
     { name = "numpy", specifier = ">=2.2.6" },
+    { name = "pymetis", specifier = ">=2025.2.1" },
     { name = "pyqt5", marker = "sys_platform == 'darwin' and extra == 'visualization'", specifier = ">=5.15.11" },
     { name = "pyqt5", marker = "sys_platform == 'linux' and extra == 'visualization'", specifier = ">=5.15.11" },
     { name = "rustworkx", specifier = ">=0.17.1" },
@@ -3376,6 +3378,41 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+]
+
+[[package]]
+name = "pymetis"
+version = "2025.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/4e/c56ce33ddca372050ae829e5c3a3659e8096234c5c96ea010d27293d661b/pymetis-2025.2.2.tar.gz", hash = "sha256:79c6d56c30c6f3df7cc755617cbadcfc252a175ce4e5a59982edad0f1ab71c99", size = 348479, upload-time = "2025-11-06T17:40:09.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/36/c6f264d36b9becc8fafaabdba97f8604598acc4ccd43fe7eddce1e186025/pymetis-2025.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d0b18c77d68f348a9870d039f8bd1e0c207276cedb18a63fe176cb4f72967837", size = 248966, upload-time = "2025-11-06T17:39:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/1c/523c134af01ba29dd0f4e87db2c269a44d14d2d4b80ce8e673ed0dc7db58/pymetis-2025.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c5756c0d082ac9637337f1c25d1ddd10d4c7226bf27097b251e05d16fe006287", size = 232658, upload-time = "2025-11-06T17:39:31.139Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b2/6b2ee49682f3cc29dffb10e7ad4311a8902553fff968216f8ba060a9ce55/pymetis-2025.2.2-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8195db2a4d217a8a20e6126dd765d636e68164b8cdea66e1f14a798a89403c39", size = 274189, upload-time = "2025-11-06T17:39:32.903Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8e/0880d06017b944a472871b08e9b14bbc36cae96df0db59e06807f6bc3614/pymetis-2025.2.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8c85bd6ca25838652f5ee26887d198c3bd3de78ad3c8269080515fc74a00dc67", size = 1310406, upload-time = "2025-11-06T17:39:34.82Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/dc3b70d884268ad74afe8832e98c5b8926c8710ad83a30b70966595197fc/pymetis-2025.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8f18b10aaeff4a8a86a4d57ff8dfd106a3dfbcd0027da083cefa4f4a8f130a15", size = 250236, upload-time = "2025-11-06T17:39:36.637Z" },
+    { url = "https://files.pythonhosted.org/packages/70/cf/667452524f8ffc39acab34a26e15e221fe6b6708efabc725151fc49d45a1/pymetis-2025.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3b2695e826ec500689f75d701f3b0bbffaea60b8dca3dcccceb7d3f1ac81974", size = 234158, upload-time = "2025-11-06T17:39:37.956Z" },
+    { url = "https://files.pythonhosted.org/packages/46/02/8f8d7c8f730487e974c8d7c473f6a315feb3b09c9ba55dacd77e2b037fc3/pymetis-2025.2.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b283cfc1e45bd5ec237d0db9bce72f05ed54556ef3a7b13f7f642287d22cb48", size = 275404, upload-time = "2025-11-06T17:39:39.956Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/66/d45d93705d721912c2fb5c00b6bf1594a16d4085add3bab97f7d85500921/pymetis-2025.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f8e7723bb3e0dda6ae7f3e54217f22c6ffe2aad78575bafb47ec311b863fc02c", size = 1311880, upload-time = "2025-11-06T17:39:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5f/56fbe4dfdd25bcf3ac870de96bb4a7ce11083701465d25127b9e9933dde3/pymetis-2025.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fccafb50056dc93e22effe14abadb87921d0314741ff0a4d6208df5c42ffdb68", size = 251291, upload-time = "2025-11-06T17:39:43.771Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/5b/17aed510e825e4d7f3a9bb195836fbf9d259e23114175c80e65bb4a749ae/pymetis-2025.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b2758f36952c9fcf864838b6d01b5eab067f5f35ce80721f8d185276e97fe640", size = 236808, upload-time = "2025-11-06T17:39:45.451Z" },
+    { url = "https://files.pythonhosted.org/packages/87/46/bb55dd838496cc9c8a905d8f20f11e6ad1316d23e451678664a853930580/pymetis-2025.2.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e355cd0de2ee17e50f8022970727c7edc98a56136f2db6d623c632b6e7150a96", size = 275908, upload-time = "2025-11-06T17:39:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ce/0f9db4a760e58486d4553ad5ad53d9a6f53f288f341d78851aa241409130/pymetis-2025.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:904d190253492bb48c0dd2e179adb590c4a94e8bbeacbdfe82d0b21a29ccda7f", size = 1312039, upload-time = "2025-11-06T17:39:49.214Z" },
+    { url = "https://files.pythonhosted.org/packages/03/df/9055f899bce6a0cee762367af42fa331279a684400b8f679b25d8af57453/pymetis-2025.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6b0b2a38ced17850553982c8b18d9cd33afba91ac246ce0bdb3d6d8e569bd7e9", size = 251341, upload-time = "2025-11-06T17:39:50.64Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/26/4152817e91fa79d26d7ca7a86f169ffce57112d7ba7fab6e69d0ec07ee9f/pymetis-2025.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:38a4880968203263bfe709105a808ad8f5e0993c962e04639c3a5b36f60bc134", size = 236842, upload-time = "2025-11-06T17:39:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0a/d511dc37e37179b50af47a07a0276be53cbee63fea0119fd0615a64d3662/pymetis-2025.2.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:08f9f603cc5328ee9b747d1cd6ced23a17ff99c1bcd17f20dfced92186e1d127", size = 275896, upload-time = "2025-11-06T17:39:53.339Z" },
+    { url = "https://files.pythonhosted.org/packages/15/75/a411f6fe26b4d90e4645501b1430e6241666baf268ff6dfbfd9fe3dedf02/pymetis-2025.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:896db1f37907335e4e60c39cc2bd5b66e3aebd52e04b092d8d1d2a4bcffba114", size = 1312211, upload-time = "2025-11-06T17:39:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f6/a9c5f2094e05c1891b7d7e3632e8f8488bfdea1956d27add76adfcac797a/pymetis-2025.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c070460ba8b96e2a5d3bfdf1337983d29db9ee3448cbc2c5e8a2fbd8cc65479c", size = 251762, upload-time = "2025-11-06T17:39:56.603Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/46/f4c6a5ebdb0f1a04e3621b560a2ea0493c67985527e7e416c53e4b86e23b/pymetis-2025.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c9a7b93c5a4745bc5abe7316f7542a16a964906394dc32267318315f2804b43c", size = 236946, upload-time = "2025-11-06T17:39:57.992Z" },
+    { url = "https://files.pythonhosted.org/packages/59/5a/f24a69abdf5e1c022a181e82c48992c8518e09fa6f2620e5c08f0b79200a/pymetis-2025.2.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7c93735a8bc200a0f00b3efa6dcc51d9ee1500b48b7852b3a19372e33f04b37", size = 275870, upload-time = "2025-11-06T17:39:59.721Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d6/f0212b3cfec2b2fa7d0ffc9591ef9b5a094223ef23ebe7d2e89706c6160a/pymetis-2025.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:48650250a56611497e0c39c4e52539a5ee1b5349a930d7d7815a0224c85b2706", size = 1311897, upload-time = "2025-11-06T17:40:01.185Z" },
+    { url = "https://files.pythonhosted.org/packages/52/91/764248f2a2c70866e669a06027825b535ebc647587034c1fb2805eb13053/pymetis-2025.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9b0c4ff5e36156dd3d157304634c96642cf909a982ee8f778684a6201952466e", size = 263195, upload-time = "2025-11-06T17:40:02.572Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f4/48ab5ecd30f5bea34db52d6027ed7392d6204550d5c4e704ee1568fad274/pymetis-2025.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fc42996ef8b95078693698074883114f62c0209341f32face33ac6327599d3ad", size = 246663, upload-time = "2025-11-06T17:40:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bc/f842a4770b87cf7f68326c87ebba3aac81f3bbb8e2c5b93fa4af3eb349f1/pymetis-2025.2.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:db8169f36fb042a560e33bb80e15ec91f39f009518ed2fdd4784a457207cd644", size = 278483, upload-time = "2025-11-06T17:40:06.222Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/9f/0347ae3eaea801c1ba28d4f2301f317826d76b1cb4b40c7319d28dde1610/pymetis-2025.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:301c0e6556b37c3321ce190a5638f5ae2110341d6e3e2e5a2141687de06a5e51", size = 1315038, upload-time = "2025-11-06T17:40:08.182Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
See issue #207 for details on solution. This also is an implementation for #208 and for #209:

Edit: The movement is currently causing deadlocks, even for under 35 qubits. I am tweaking the pathfinding code to find the best path that causes no collisions.

Here are the two layout strategies:

**Baseline Layout Strategy:**

1. Enumerate all left-column home sites in deterministic order:
    1. word `0..N-1`
    2. site `0..left_site_count-1`
2. Sort qubit IDs and assign them in that site order.

**METIS + center-out Layout Strategy:**

1. Build a weighted interaction graph over qubits:
    1. one node per qubit
    2. edge `(u,v)` weight = number of CZ co-occurrences across layers
2. Determine how many words to use (`k_words`):
    1. based on qubit count and effective fill (`left_site_count`), capped by max_words (we want to fill full words then possibly one partial (left-to-right)).
3. Partition qubits into `k_words` with METIS:
    1. **objective: minimize cross-partition edge cut (idea is to maximize intra-physical-word interaction to increase likelihood of intra-word lanes usage, which also indirectly increases parallelism),** with paritions constrained by target partition weights (i.e. word sizes, `tpwgts`)
4. Relabel arbitrary METIS partition IDs to deterministic word IDs:
    1. This maps partitions to words, with larger partitions are mapped to lower word IDs first (arbitrary)
        1. Potential Improvement: Map most-cross-word partitions to middle-word, then spill out from there as inter-word order does matter in terms of move distances.
5. Place qubits **within each word** on left sites using center-out greedy:
    1. place first qubit = highest local weighted degree in the center of the word (vertically)
    2. place remaining qubits greedily maximizing affinity to already placed qubits, with distance penalty `weight/(1+distance)`
6. Return layout

-----

**Move Strategy**

Basically, the way the move scheme works right now is as follows:

Given a CZ layer:

1. Determine which qubit in each CZ pair should move based on the best-path move cost for each + each qubit’s move count (fewer moves → should be moved). 
    1. Note usually the path from/to the other I would guess would have the same cost, but it might not ALWAYS be that way, especially with real hardware diagnostics.
2. After choosing which half of the CZ-qubits will move, we do the following:
    1. For each mover that has not reached its destination, compute a shortest route to its destination under the **current move-layer-start occupancy constraints** (meaning the current occupancy of sites)
    2. Propose only the **first lane-hop** of that route for this move-layer.
    3. Accept a hop if:
        1. Its lane is hardware-compatible with every other accepted lane in this move-layer (Maximizing parallelism
        2. It is collision-safe with already accepted hops in this move-layer (no collisions, destination not occupied at move-layer start).
    4. Apply all accepted hops in parallel (i.e. execute the moves of this move-layer)
    5. Repeat a-d for the remaining qubits until all qubits are in final locations
        1. IMPORTANT NOTE: Currently we are not factoring in the possibility of totally-blocked qubits in a layer (i.e. qubits that cannot move at all since all possible hops contain occupied sites). This is entirely possible.
            1. This should not happen with half-filling (35 qubits in gemini physical), but it is increasingly likely as we fill the architecture beyond that.
3. The move backs are should be the reverse of the moves generated in 2 (basically starting with the last move layer, perform it with reversed direction, and move backwards in move-layer order to the start move-layer)
    1. In practice, currently, palindrome moves are what are causing reverse-order move-backs since currently for physical testing we do default_merge_heuristic