### PR TITLE
build: unify Rust crate versions via workspace.package.version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "crates/bloqade-lanes-bytecode-cli",
 ]
 resolver = "2"
+
+[workspace.package]
+version = "0.6.0-dev"

--- a/crates/bloqade-lanes-bytecode-cli/Cargo.toml
+++ b/crates/bloqade-lanes-bytecode-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bloqade-lanes-bytecode-cli"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/crates/bloqade-lanes-bytecode-core/Cargo.toml
+++ b/crates/bloqade-lanes-bytecode-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bloqade-lanes-bytecode-core"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]

--- a/crates/bloqade-lanes-bytecode-python/Cargo.toml
+++ b/crates/bloqade-lanes-bytecode-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bloqade-lanes-bytecode-python"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
## Summary

- Add `[workspace.package] version = "0.6.0-dev"` to root `Cargo.toml`
- All three crates (`core`, `cli`, `python`) now use `version.workspace = true` instead of hardcoded `"0.1.0"`
- Version only needs to be updated in two places for releases: `Cargo.toml` (workspace) and `pyproject.toml`

**Why:** Rust crate versions were stuck at `0.1.0` and completely disconnected from the Python package version. This makes it easy to keep them in sync and sets up for future release automation.

## Breaking changes

### Python API
- No changes

### Rust API
- No changes (version metadata only)

### C API
- No changes

## Test plan

- [x] `cargo check` passes
- [x] 196 Rust tests pass
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)