### PR TITLE
ci: add macOS-arm64 and Windows test jobs (#253)

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -48,10 +48,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install Python dependencies
-        run: uv sync --dev --all-extras --index-strategy=unsafe-best-match
+        run: just sync
 
       - name: Build Python extension
-        run: uv run --with maturin maturin develop
+        run: just develop-python
 
       - name: Run Python tests
         run: just test-python


### PR DESCRIPTION
## Summary

Closes #253. Adds cross-platform CI jobs for macOS ARM64 and Windows to catch platform-specific build/test issues before publishing wheels.

### New workflow: `.github/workflows/cross-platform.yml`

**Triggers:** Push to `main`, version tags (`v*`), and manual dispatch. Does **not** run on PRs to save CI resources.

**Matrix:**
| Platform | Runner | Rust tests | Python tests | CLI smoke | C FFI |
|----------|--------|-----------|-------------|-----------|-------|
| macOS ARM64 | `macos-14` | Yes | Yes | Yes | Yes |
| Windows x86_64 | `windows-latest` | Yes | Yes | No* | No* |

\* CLI smoke test and C FFI test use bash scripts that are not Windows-compatible. These will be addressed in #270 (Windows wheel support).

**Steps:**
1. Install Rust toolchain + cache
2. Install just + uv
3. `just test-rust`
4. `uv sync` + `uv run maturin develop`
5. `just test-python`
6. (macOS only) `just cli-smoke-test` + `just test-c-ffi`

### Design decisions

- **Separate workflow** (not added to existing `ci.yml`) to keep PR CI fast (Linux only) while validating cross-platform on main/tags
- `fail-fast: false` so both platforms run independently
- Concurrency grouping by workflow + ref with cancel-in-progress

## Test plan

- [ ] Workflow triggers on push to main
- [ ] macOS ARM64: Rust tests, Python tests, CLI smoke, C FFI all pass
- [ ] Windows: Rust tests and Python tests pass
- [ ] Workflow does not trigger on PRs

## Related

- #270 — Windows wheel in release CI (follow-up, depends on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)