### PR TITLE
feat: expose user-facing Gemini APIs from bloqade.gemini

### DIFF
--- a/demo/cudaq_demo.py
+++ b/demo/cudaq_demo.py
@@ -1,6 +1,6 @@
 import cudaq  # type: ignore[reportMissingImports]
 
-from bloqade.lanes import GeminiLogicalSimulator, steane7_m2dets, steane7_m2obs
+from bloqade.gemini import GeminiLogicalSimulator, steane7_m2dets, steane7_m2obs
 
 m2dets, m2obs = steane7_m2dets(5), steane7_m2obs(5)
 

--- a/demo/ghz_moves_demo.py
+++ b/demo/ghz_moves_demo.py
@@ -1,7 +1,7 @@
 from kirin.dialects import ilist
 
 from bloqade import qubit, squin
-from bloqade.lanes.logical_mvp import compile_squin_to_move_and_visualize
+from bloqade.gemini import compile_squin_to_move_and_visualize
 
 
 @squin.kernel(typeinfer=True, fold=True)

--- a/demo/msd.py
+++ b/demo/msd.py
@@ -3,11 +3,8 @@ import math
 from kirin.dialects import ilist
 
 from bloqade import qubit, squin
-from bloqade.gemini import logical as gemini_logical
+from bloqade.gemini import compile_to_stim_program, logical as gemini_logical
 from bloqade.gemini.logical.stdlib import default_post_processing
-from bloqade.lanes.logical_mvp import (
-    compile_to_stim_program,
-)
 
 
 @gemini_logical.kernel(aggressive_unroll=True)

--- a/demo/pipeline_demo.py
+++ b/demo/pipeline_demo.py
@@ -1,10 +1,7 @@
 from kirin.dialects import ilist
 
 from bloqade import squin
-from bloqade.gemini import logical as gemini_logical
-from bloqade.lanes.logical_mvp import (
-    compile_to_stim_program,
-)
+from bloqade.gemini import compile_to_stim_program, logical as gemini_logical
 
 
 @gemini_logical.kernel(aggressive_unroll=True)

--- a/demo/simulator_device_demo.ipynb
+++ b/demo/simulator_device_demo.ipynb
@@ -40,10 +40,9 @@
     "\n",
     "# Functions and methods\n",
     "from bloqade.decoders import BpLsdDecoder\n",
-    "from bloqade.lanes import GeminiLogicalSimulator\n",
+    "from bloqade.gemini import GeminiLogicalSimulator, logical\n",
     "\n",
     "# Dialect groups\n",
-    "from bloqade.gemini import logical\n",
     "from bloqade import qubit, squin"
    ]
   },

--- a/demo/simulator_device_demo.py
+++ b/demo/simulator_device_demo.py
@@ -6,9 +6,8 @@ from bloqade.decoders import BpLsdDecoder
 from kirin.dialects import ilist
 
 from bloqade import qubit, squin
-from bloqade.gemini import logical
+from bloqade.gemini import GeminiLogicalSimulator, logical
 from bloqade.gemini.logical.stdlib import default_post_processing
-from bloqade.lanes import GeminiLogicalSimulator
 
 
 # helper functions to analyze statistical distribution of logical measurements

--- a/python/bloqade/gemini/__init__.py
+++ b/python/bloqade/gemini/__init__.py
@@ -1,1 +1,86 @@
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
 from . import logical as logical
+
+if TYPE_CHECKING:
+    from . import compile as compile, simulator as simulator
+    from .compile import (
+        append_measurements_and_annotations as append_measurements_and_annotations,
+        compile_squin_to_move as compile_squin_to_move,
+        compile_squin_to_move_and_visualize as compile_squin_to_move_and_visualize,
+        compile_to_physical_squin_noise_model as compile_to_physical_squin_noise_model,
+        compile_to_stim_program as compile_to_stim_program,
+        run_squin_kernel_validation as run_squin_kernel_validation,
+        transversal_rewrites as transversal_rewrites,
+    )
+    from .simulator import (
+        DetectorResult as DetectorResult,
+        GeminiLogicalSimulator as GeminiLogicalSimulator,
+        GeminiLogicalSimulatorTask as GeminiLogicalSimulatorTask,
+        NoiseModelABC as NoiseModelABC,
+        Result as Result,
+        generate_simple_noise_model as generate_simple_noise_model,
+        steane7_m2dets as steane7_m2dets,
+        steane7_m2obs as steane7_m2obs,
+    )
+
+__all__ = [
+    "logical",
+    "compile",
+    "simulator",
+    "DetectorResult",
+    "GeminiLogicalSimulator",
+    "GeminiLogicalSimulatorTask",
+    "Result",
+    "NoiseModelABC",
+    "generate_simple_noise_model",
+    "steane7_m2dets",
+    "steane7_m2obs",
+    "run_squin_kernel_validation",
+    "compile_squin_to_move",
+    "compile_squin_to_move_and_visualize",
+    "compile_to_physical_squin_noise_model",
+    "compile_to_stim_program",
+    "transversal_rewrites",
+    "append_measurements_and_annotations",
+]
+
+_SIMULATOR_EXPORTS = {
+    "DetectorResult",
+    "GeminiLogicalSimulator",
+    "GeminiLogicalSimulatorTask",
+    "Result",
+    "NoiseModelABC",
+    "generate_simple_noise_model",
+    "steane7_m2dets",
+    "steane7_m2obs",
+}
+
+_COMPILE_EXPORTS = {
+    "run_squin_kernel_validation",
+    "compile_squin_to_move",
+    "compile_squin_to_move_and_visualize",
+    "compile_to_physical_squin_noise_model",
+    "compile_to_stim_program",
+    "transversal_rewrites",
+    "append_measurements_and_annotations",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name == "compile":
+        return import_module(".compile", __name__)
+    if name == "simulator":
+        return import_module(".simulator", __name__)
+    if name in _SIMULATOR_EXPORTS:
+        module = import_module(".simulator", __name__)
+        return getattr(module, name)
+    if name in _COMPILE_EXPORTS:
+        module = import_module(".compile", __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/python/bloqade/gemini/compile.py
+++ b/python/bloqade/gemini/compile.py
@@ -1,0 +1,19 @@
+from bloqade.lanes.logical_mvp import (
+    append_measurements_and_annotations as append_measurements_and_annotations,
+    compile_squin_to_move as compile_squin_to_move,
+    compile_squin_to_move_and_visualize as compile_squin_to_move_and_visualize,
+    compile_to_physical_squin_noise_model as compile_to_physical_squin_noise_model,
+    compile_to_stim_program as compile_to_stim_program,
+    run_squin_kernel_validation as run_squin_kernel_validation,
+    transversal_rewrites as transversal_rewrites,
+)
+
+__all__ = [
+    "run_squin_kernel_validation",
+    "compile_squin_to_move",
+    "compile_squin_to_move_and_visualize",
+    "compile_to_physical_squin_noise_model",
+    "compile_to_stim_program",
+    "transversal_rewrites",
+    "append_measurements_and_annotations",
+]

--- a/python/bloqade/gemini/simulator.py
+++ b/python/bloqade/gemini/simulator.py
@@ -1,0 +1,25 @@
+from bloqade.lanes.device import (
+    DetectorResult as DetectorResult,
+    GeminiLogicalSimulator as GeminiLogicalSimulator,
+    GeminiLogicalSimulatorTask as GeminiLogicalSimulatorTask,
+    Result as Result,
+)
+from bloqade.lanes.noise_model import (
+    generate_simple_noise_model as generate_simple_noise_model,
+)
+from bloqade.lanes.rewrite.move2squin.noise import NoiseModelABC as NoiseModelABC
+from bloqade.lanes.steane_defaults import (
+    steane7_m2dets as steane7_m2dets,
+    steane7_m2obs as steane7_m2obs,
+)
+
+__all__ = [
+    "DetectorResult",
+    "GeminiLogicalSimulator",
+    "GeminiLogicalSimulatorTask",
+    "Result",
+    "generate_simple_noise_model",
+    "NoiseModelABC",
+    "steane7_m2dets",
+    "steane7_m2obs",
+]

--- a/python/tests/gemini/test_public_api.py
+++ b/python/tests/gemini/test_public_api.py
@@ -1,0 +1,31 @@
+import bloqade.gemini as gemini
+import bloqade.lanes as lanes
+
+
+def test_root_exports_user_facing_simulator_and_compile_helpers():
+    assert gemini.logical is not None
+    assert gemini.GeminiLogicalSimulator is not None
+    assert gemini.GeminiLogicalSimulatorTask is not None
+    assert gemini.Result is not None
+    assert gemini.DetectorResult is not None
+    assert gemini.compile_squin_to_move is not None
+    assert gemini.compile_squin_to_move_and_visualize is not None
+    assert gemini.compile_to_physical_squin_noise_model is not None
+    assert gemini.compile_to_stim_program is not None
+    assert gemini.transversal_rewrites is not None
+    assert gemini.append_measurements_and_annotations is not None
+    assert gemini.run_squin_kernel_validation is not None
+    assert gemini.generate_simple_noise_model is not None
+    assert gemini.NoiseModelABC is not None
+    assert gemini.steane7_m2dets is not None
+    assert gemini.steane7_m2obs is not None
+
+
+def test_lanes_compatibility_aliases_still_work():
+    assert gemini.GeminiLogicalSimulator is lanes.GeminiLogicalSimulator
+    assert gemini.GeminiLogicalSimulatorTask is lanes.GeminiLogicalSimulatorTask
+    assert gemini.Result is lanes.Result
+    assert gemini.DetectorResult is lanes.DetectorResult
+    assert gemini.generate_simple_noise_model is lanes.generate_simple_noise_model
+    assert gemini.steane7_m2dets is lanes.steane7_m2dets
+    assert gemini.steane7_m2obs is lanes.steane7_m2obs

--- a/python/tests/test_compile_api_split.py
+++ b/python/tests/test_compile_api_split.py
@@ -3,6 +3,7 @@ from typing import cast
 
 from kirin import ir
 
+from bloqade.gemini import compile as gemini_compile
 from bloqade.lanes import compile as compile_api, logical_mvp
 from bloqade.lanes.analysis.layout import LayoutHeuristicABC
 from bloqade.lanes.analysis.placement import PlacementStrategyABC
@@ -34,7 +35,7 @@ def test_logical_mvp_compile_to_move_uses_logical_defaults(monkeypatch):
     monkeypatch.setattr(logical_mvp, "squin_to_move", fake_squin_to_move)
 
     marker = cast(ir.Method, object())
-    out = logical_mvp.compile_squin_to_move(marker)
+    out = gemini_compile.compile_squin_to_move(marker)
 
     assert out == "move_ir"
     assert captured["mt"] is marker

--- a/python/tests/test_cudaq_integration.py
+++ b/python/tests/test_cudaq_integration.py
@@ -6,14 +6,13 @@ from kirin.dialects import func
 
 from bloqade import qubit, squin
 from bloqade.gemini import logical as gemini_logical
+from bloqade.gemini.compile import (
+    append_measurements_and_annotations,
+)
 from bloqade.gemini.logical.dialects.operations.stmts import (
     TerminalLogicalMeasurement,
 )
-from bloqade.lanes.logical_mvp import (
-    _find_qubit_ssas,
-    _find_return_stmt,
-    append_measurements_and_annotations,
-)
+from bloqade.lanes.logical_mvp import _find_qubit_ssas, _find_return_stmt
 
 DETS = [[1, 0], [0, 1]]  # 2 measurements, 2 detectors
 OBS = [[1], [1]]  # 2 measurements, 1 observable

--- a/python/tests/test_device.py
+++ b/python/tests/test_device.py
@@ -7,13 +7,14 @@ from kirin.dialects import ilist
 
 from bloqade import qubit, squin, types
 from bloqade.gemini import logical as gemini_logical
-from bloqade.lanes.device import (
+from bloqade.gemini.simulator import (
     DetectorResult,
     GeminiLogicalSimulator,
     Result,
+    generate_simple_noise_model,
+    steane7_m2dets,
+    steane7_m2obs,
 )
-from bloqade.lanes.noise_model import generate_simple_noise_model
-from bloqade.lanes.steane_defaults import steane7_m2dets, steane7_m2obs
 
 
 @gemini_logical.kernel(verify=False)

--- a/python/tests/test_integration.py
+++ b/python/tests/test_integration.py
@@ -11,16 +11,16 @@ from kirin.dialects import ilist
 
 from bloqade import qubit, squin, types
 from bloqade.gemini import logical as gemini_logical
+from bloqade.gemini.compile import (
+    compile_squin_to_move,
+    transversal_rewrites,
+)
+from bloqade.gemini.simulator import generate_simple_noise_model
 from bloqade.lanes.arch.gemini import logical
 from bloqade.lanes.arch.gemini.impls import generate_arch_hypercube
 from bloqade.lanes.arch.gemini.logical import get_arch_spec
 from bloqade.lanes.heuristics import logical_layout
 from bloqade.lanes.heuristics.logical_placement import LogicalPlacementStrategyNoHome
-from bloqade.lanes.logical_mvp import (
-    compile_squin_to_move,
-    transversal_rewrites,
-)
-from bloqade.lanes.noise_model import generate_simple_noise_model
 from bloqade.lanes.transform import MoveToSquin
 from bloqade.lanes.upstream import (
     always_merge_heuristic,


### PR DESCRIPTION
## Summary
- expose user-facing logical compile and simulator APIs from `bloqade.gemini` via thin wrappers
- keep `bloqade.lanes` compatibility aliases working while shifting demos and user-facing tests to Gemini imports
- add Gemini public API coverage and fix Pyright-facing imports for the new surface

## Test Plan
- [x] `uv run pytest python/tests/gemini/test_public_api.py`
- [x] `uv run pytest python/tests/test_device.py python/tests/test_integration.py python/tests/test_cudaq_integration.py python/tests/test_compile_api_split.py python/tests/gemini`
- [x] `uv run pytest python/tests`
- [x] `uv run pyright python/bloqade/gemini/__init__.py python/tests/test_device.py python/tests/test_cudaq_integration.py python/tests/test_integration.py`

Closes #312
