### PR TITLE
fix(ci): remove pinned uv 0.5.1 from cross-platform workflow

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          version: "0.5.1"
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 


### PR DESCRIPTION
## Summary
- Removes the `version: "0.5.1"` pin on uv in the cross-platform CI workflow
- uv 0.5.1 doesn't support the `--group` flag that maturin invokes via `uv pip install --group`, causing "Build Python extension" to fail on macOS-14 and windows-latest
- The CI and lint workflows already use the latest uv without a version pin — this aligns cross-platform with them

Closes #311

## Test plan
- [ ] Cross-platform CI passes on macOS-14 and windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)