### PR TITLE
fix(docs): resolve griffe cyclic alias for bytecode ArchSpec

### DIFF
--- a/python/bloqade/lanes/bytecode/arch.py
+++ b/python/bloqade/lanes/bytecode/arch.py
@@ -1,15 +1,6 @@
 from bloqade.geometry.dialects import grid as geometry_grid
 
-from bloqade.lanes.bytecode._native import (
-    ArchSpec as ArchSpec,
-    Bus as Bus,
-    Buses as Buses,
-    Geometry as Geometry,
-    Grid as Grid,
-    TransportPath as TransportPath,
-    Word as Word,
-    Zone as Zone,
-)
+from bloqade.lanes.bytecode._native import Grid
 
 
 def grid_to_rust(g: geometry_grid.Grid) -> Grid:

--- a/python/tests/bytecode/test_arch_spec.py
+++ b/python/tests/bytecode/test_arch_spec.py
@@ -3,18 +3,16 @@ import json
 import pytest
 
 from bloqade.lanes.bytecode import (
+    ArchSpec,
     ArchSpecError,
+    Bus,
+    Buses,
     Direction,
+    Geometry,
+    Grid,
     LaneAddress,
     LocationAddress,
     MoveType,
-)
-from bloqade.lanes.bytecode.arch import (
-    ArchSpec,
-    Bus,
-    Buses,
-    Geometry,
-    Grid,
     TransportPath,
     Word,
     Zone,


### PR DESCRIPTION
## Summary
- Fixes `CyclicAliasError` in griffe/mkdocs when building documentation in the upstream bloqade repo
- Root cause: `arch.py` re-exported all `_native` types (ArchSpec, Bus, Buses, etc.) using `X as X`, creating duplicate public aliases alongside `__init__.py`'s canonical exports
- Fix: remove the re-exports from `arch.py` entirely — it only needs `Grid` for its `grid_to_rust`/`grid_from_rust` functions
- Update test imports to use `bloqade.lanes.bytecode` (the canonical path) instead of `bloqade.lanes.bytecode.arch`

Closes #336

## Test plan
- [x] 151 bytecode tests pass
- [x] All pre-commit hooks pass
- [ ] Upstream bloqade docs build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)