### PR TITLE
fix(python): remove deprecated cudaq annotation matrix test

### DIFF
--- a/python/tests/test_device.py
+++ b/python/tests/test_device.py
@@ -245,22 +245,6 @@ def test_append_annotations_to_kernel_with_terminal_measure(
         assert all(isinstance(b, bool) for obs in result.observables for b in obs)
 
 
-def test_cudaq_kernel_requires_annotation_matrices():
-    cudaq = pytest.importorskip("cudaq")
-
-    @cudaq.kernel
-    def bell_pair():
-        q = cudaq.qvector(2)
-        h(q[0])  # noqa: F821  # pyright: ignore[reportUndefinedVariable]
-        cx(q[0], q[1])  # noqa: F821  # pyright: ignore[reportUndefinedVariable]
-
-    with pytest.raises(
-        ValueError,
-        match="At least one of m2dets or m2obs must be provided for CUDA-Q kernels",
-    ):
-        GeminiLogicalSimulator().task(bell_pair)
-
-
 @pytest.mark.parametrize(
     "use_dets, use_obs",
     [(True, True), (True, False), (False, True)],


### PR DESCRIPTION
## Summary
- Remove the `test_cudaq_kernel_requires_annotation_matrices` test which expected a `ValueError` that is no longer raised
- The `GeminiLogicalSimulator.task()` method now defaults to Steane [[7,1,3]] annotation matrices when neither `m2dets` nor `m2obs` is provided for CUDA-Q kernels, so the test is invalid

## Test plan
- [x] Verify CI passes (the removed test was failing in environments with cudaq installed)
- [x] Confirm remaining cudaq tests (`test_cudaq_kernel_integration`) still pass

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)