### PR TITLE
fix(ci): handle empty cherry-picks and conflicts in backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout main
         uses: actions/checkout@v6
@@ -132,7 +133,7 @@ jobs:
                 }
 
                 // Commit, push, and create PR
-                execSync(`git commit --no-edit -m "Backport PR #${prNum} (${commit}) to ${branch}"`);
+                execSync(`git commit -m "Backport PR #${prNum} (${commit}) to ${branch}"`);
                 execSync(`git push origin ${backportBranch}`);
                 const pr = await github.rest.pulls.create({
                   owner: context.repo.owner,


### PR DESCRIPTION
## Summary

- Handle empty cherry-picks (already-applied commits) gracefully — skip with a clear log message instead of failing
- Detect real conflicts and report which files conflicted
- Add diagnostic logging throughout (commit SHA, PR number, labels, matched versions, cherry-pick outcome)
- Comment on the original PR with backport results (success links, skipped reasons, failure details + manual resolution instructions)

Closes #376

## Test plan

- [ ] Merge a PR with `backport v<version>` label where the commit is already on the release branch → should skip and comment "already applied"
- [ ] Merge a PR with `backport v<version>` label that cherry-picks cleanly → should create backport PR and comment with link
- [ ] Merge a PR with `backport v<version>` label that has conflicts → should fail, comment with conflicting files and manual instructions
- [ ] Merge a PR without backport labels → should exit early with clear log

🤖 Generated with [Claude Code](https://claude.com/claude-code)