### PR TITLE
test(python): add physical Squin kernel validation suite

### DIFF
--- a/python/tests/_validation_squin_kernels.py
+++ b/python/tests/_validation_squin_kernels.py
@@ -1,0 +1,401 @@
+"""Inline SQuIn kernel catalog for movement/layering/CZ regression coverage.
+
+This module is intentionally kernels-only: it does not contain pytest tests.
+Future parametrized tests can consume this catalog as follows:
+
+    from tests._squin_kernels import select_kernels
+
+    for spec in select_kernels(tags={"movement", "cz"}):
+        kernel = spec.build_kernel()
+        # compile and assert invariants in a test module
+
+Rubric:
+- Qubit hard limit: <= 10 for every kernel.
+- Mixed composition:
+  - curated motifs to stress known compiler behaviors
+  - manually translated qasmbench-inspired kernels
+- Required tags:
+  movement, layering, cz, control, entangling_density, locality_pattern
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import pi
+from typing import Callable, Literal
+
+from kirin.dialects import ilist
+
+from bloqade import squin
+
+Tag = Literal[
+    "movement",
+    "layering",
+    "cz",
+    "control",
+    "entangling_density",
+    "locality_pattern",
+]
+
+ALLOWED_TAGS: frozenset[str] = frozenset(
+    {
+        "movement",
+        "layering",
+        "cz",
+        "control",
+        "entangling_density",
+        "locality_pattern",
+    }
+)
+
+
+@dataclass(frozen=True)
+class KernelSpec:
+    name: str
+    origin: Literal["curated", "qasmbench_manual"]
+    source_id: str
+    qubits: int
+    tags: tuple[Tag, ...]
+    build_kernel: Callable[[], object]
+
+
+def _curated_chain_cz_sweep() -> object:
+    """Chain-like CZ pairings in two passes with global rotations around them.
+
+    Intended stress: ensure CZ batches compile cleanly as adjacency patterns shift
+    from (0-1, 2-3, 4-5) to (1-2, 3-4), without corrupting layer structure.
+    """
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(6)
+        squin.broadcast.u3(0.2 * pi, 0.0, 0.1 * pi, reg)
+        squin.broadcast.cz(
+            ilist.IList([reg[0], reg[2], reg[4]]),
+            ilist.IList([reg[1], reg[3], reg[5]]),
+        )
+        squin.broadcast.cz(
+            ilist.IList([reg[1], reg[3]]),
+            ilist.IList([reg[2], reg[4]]),
+        )
+        squin.broadcast.u3(0.15 * pi, 0.25 * pi, 0.0, reg)
+
+    return kernel
+
+
+def _curated_star_fanout() -> object:
+    """Star/fanout control pattern with sequential CZ interactions from a shared hub.
+
+    Intended stress: repeated reuse of one control qubit across many interactions,
+    exercising non-parallel entangler sequencing.
+    """
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(5)
+        squin.h(reg[0])
+        for i in range(1, len(reg)):
+            squin.cx(reg[0], reg[i])
+        squin.cz(reg[0], reg[1])
+        squin.cz(reg[0], reg[3])
+
+    return kernel
+
+
+def _curated_movement_reorder_pattern() -> object:
+    """Broadcast CZ blocks with intermediate targeted CNOT reordering pressure.
+
+    Intended stress: movement-sensitive scheduling where local interaction edits
+    occur between larger CZ batches, probing reorder/regression behavior.
+    """
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(7)
+        squin.broadcast.u3(0.5 * pi, 0.0, 0.0, reg)
+        squin.broadcast.cz(
+            ilist.IList([reg[0], reg[1], reg[2]]),
+            ilist.IList([reg[3], reg[4], reg[5]]),
+        )
+        squin.cx(reg[6], reg[2])
+        squin.cx(reg[6], reg[4])
+        squin.broadcast.cz(
+            ilist.IList([reg[0], reg[2], reg[4]]),
+            ilist.IList([reg[1], reg[3], reg[5]]),
+        )
+
+    return kernel
+
+
+def _curated_control_entangler_mix() -> object:
+    """Mixed sparse controls and overlapping entangler neighborhoods.
+
+    Intended stress: interplay between CNOT-style control paths and CZ-style
+    entangler layers with partial qubit overlap across consecutive operations.
+    """
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(8)
+        for idx in (0, 2, 5):
+            squin.h(reg[idx])
+        squin.cx(reg[0], reg[3])
+        squin.cx(reg[2], reg[4])
+        squin.cx(reg[5], reg[7])
+        squin.broadcast.cz(ilist.IList([reg[3], reg[6]]), ilist.IList([reg[4], reg[7]]))
+        squin.cz(reg[4], reg[6])
+        squin.broadcast.u3(0.2 * pi, 0.5 * pi, 0.0, reg)
+
+    return kernel
+
+
+def _qasmbench_toffoli_n3_manual() -> object:
+    """Manual translation inspired by QASMBench's toffoli_n3 circuit"""
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(3)
+        squin.h(reg[2])
+        squin.cx(reg[1], reg[2])
+        squin.broadcast.u3(0.0, 0.75 * pi, 0.25 * pi, ilist.IList([reg[2]]))
+        squin.cx(reg[0], reg[2])
+        squin.cx(reg[1], reg[2])
+        squin.cx(reg[0], reg[2])
+        squin.cx(reg[0], reg[1])
+        squin.h(reg[2])
+
+    return kernel
+
+
+def _qasmbench_fredkin_n3_manual() -> object:
+    """Manual translation inspired by QASMBench's fredkin_n3 circuit"""
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(3)
+        squin.cx(reg[2], reg[1])
+        squin.cx(reg[0], reg[1])
+        squin.h(reg[2])
+        squin.cx(reg[0], reg[2])
+        squin.cx(reg[2], reg[1])
+        squin.cx(reg[0], reg[2])
+        squin.cx(reg[2], reg[1])
+        squin.h(reg[2])
+
+    return kernel
+
+
+def _qasmbench_qft_n4_manual() -> object:
+    """Manual translation inspired by QASMBench's qft_n4 circuit"""
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(4)
+        squin.h(reg[0])
+        squin.cz(reg[1], reg[0])
+        squin.cz(reg[2], reg[0])
+        squin.cz(reg[3], reg[0])
+        squin.h(reg[1])
+        squin.cz(reg[2], reg[1])
+        squin.cz(reg[3], reg[1])
+        squin.h(reg[2])
+        squin.cz(reg[3], reg[2])
+        squin.h(reg[3])
+
+    return kernel
+
+
+def _qasmbench_qaoa_n3_manual() -> object:
+    """Manual translation inspired by QASMBench's qaoa_n3 circuit"""
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(3)
+        squin.broadcast.u3(0.5 * pi, 0.0, pi, reg)
+        squin.cx(reg[0], reg[2])
+        squin.cx(reg[0], reg[1])
+        squin.cx(reg[1], reg[2])
+        squin.broadcast.u3(0.18 * pi, 0.0, 0.0, ilist.IList([reg[2]]))
+        squin.cx(reg[1], reg[2])
+        squin.cx(reg[0], reg[1])
+        squin.broadcast.u3(0.11 * pi, 0.0, 0.0, reg)
+
+    return kernel
+
+
+def _qasmbench_basis_change_n3_manual() -> object:
+    """Manual translation inspired by QASMBench's basis_change_n3 circuit"""
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(3)
+        squin.broadcast.u3(0.5 * pi, 0.0, 0.06 * pi, ilist.IList([reg[2]]))
+        squin.broadcast.u3(0.5 * pi, 1.5 * pi, 0.29 * pi, ilist.IList([reg[1]]))
+        squin.broadcast.u3(0.5 * pi, 1.5 * pi, 1.5 * pi, ilist.IList([reg[0]]))
+        squin.cz(reg[1], reg[2])
+        squin.cz(reg[0], reg[1])
+        squin.broadcast.u3(0.12 * pi, 0.5 * pi, 1.5 * pi, ilist.IList([reg[1], reg[2]]))
+        squin.broadcast.cz(ilist.IList([reg[0]]), ilist.IList([reg[1]]))
+        squin.broadcast.u3(0.33 * pi, 0.0, 0.0, ilist.IList([reg[0], reg[1]]))
+
+    return kernel
+
+
+def _qasmbench_adder_n4_manual() -> object:
+    """Manual translation inspired by QASMBench's adder_n4 circuit"""
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(4)
+        squin.h(reg[3])
+        squin.cx(reg[2], reg[3])
+        squin.cx(reg[0], reg[1])
+        squin.cx(reg[2], reg[3])
+        squin.cx(reg[3], reg[0])
+        squin.cx(reg[1], reg[2])
+        squin.cx(reg[0], reg[1])
+        squin.cx(reg[2], reg[3])
+        squin.cx(reg[0], reg[1])
+        squin.cx(reg[2], reg[3])
+        squin.cx(reg[3], reg[0])
+        squin.h(reg[3])
+
+    return kernel
+
+
+def _qasmbench_qpe_n9_manual() -> object:
+    """Manual translation inspired by QASMBench's qpe_n9 circuit"""
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(9)
+        squin.broadcast.u3(
+            0.5 * pi,
+            0.0,
+            pi,
+            ilist.IList([reg[0], reg[1], reg[2], reg[3], reg[4], reg[5]]),
+        )
+        for i in (6, 7, 8):
+            squin.x(reg[i])
+        squin.cx(reg[5], reg[7])
+        squin.cz(reg[7], reg[8])
+        squin.cx(reg[5], reg[7])
+        squin.cz(reg[5], reg[0])
+        squin.cz(reg[4], reg[0])
+        squin.cz(reg[3], reg[1])
+        squin.cz(reg[2], reg[1])
+        squin.cz(reg[1], reg[0])
+        for i in range(6):
+            squin.h(reg[i])
+
+    return kernel
+
+
+SQUIN_KERNEL_SUITE: tuple[KernelSpec, ...] = (
+    KernelSpec(
+        name="curated_chain_cz_sweep",
+        origin="curated",
+        source_id="curated.chain_cz_sweep",
+        qubits=6,
+        tags=("movement", "layering", "cz", "entangling_density", "locality_pattern"),
+        build_kernel=_curated_chain_cz_sweep,
+    ),
+    KernelSpec(
+        name="curated_star_fanout",
+        origin="curated",
+        source_id="curated.star_fanout",
+        qubits=5,
+        tags=("movement", "control", "layering", "locality_pattern"),
+        build_kernel=_curated_star_fanout,
+    ),
+    KernelSpec(
+        name="curated_movement_reorder_pattern",
+        origin="curated",
+        source_id="curated.movement_reorder_pattern",
+        qubits=7,
+        tags=("movement", "layering", "cz", "control", "locality_pattern"),
+        build_kernel=_curated_movement_reorder_pattern,
+    ),
+    KernelSpec(
+        name="curated_control_entangler_mix",
+        origin="curated",
+        source_id="curated.control_entangler_mix",
+        qubits=8,
+        tags=("movement", "layering", "cz", "control", "entangling_density"),
+        build_kernel=_curated_control_entangler_mix,
+    ),
+    KernelSpec(
+        name="qasmbench_toffoli_n3_manual",
+        origin="qasmbench_manual",
+        source_id="toffoli_n3",
+        qubits=3,
+        tags=("control", "layering", "movement", "locality_pattern"),
+        build_kernel=_qasmbench_toffoli_n3_manual,
+    ),
+    KernelSpec(
+        name="qasmbench_fredkin_n3_manual",
+        origin="qasmbench_manual",
+        source_id="fredkin_n3",
+        qubits=3,
+        tags=("control", "layering", "movement", "locality_pattern"),
+        build_kernel=_qasmbench_fredkin_n3_manual,
+    ),
+    KernelSpec(
+        name="qasmbench_qft_n4_manual",
+        origin="qasmbench_manual",
+        source_id="qft_n4",
+        qubits=4,
+        tags=("layering", "cz", "entangling_density", "locality_pattern"),
+        build_kernel=_qasmbench_qft_n4_manual,
+    ),
+    KernelSpec(
+        name="qasmbench_qaoa_n3_manual",
+        origin="qasmbench_manual",
+        source_id="qaoa_n3",
+        qubits=3,
+        tags=("layering", "cz", "entangling_density", "movement"),
+        build_kernel=_qasmbench_qaoa_n3_manual,
+    ),
+    KernelSpec(
+        name="qasmbench_basis_change_n3_manual",
+        origin="qasmbench_manual",
+        source_id="basis_change_n3",
+        qubits=3,
+        tags=("cz", "layering", "movement", "locality_pattern"),
+        build_kernel=_qasmbench_basis_change_n3_manual,
+    ),
+    KernelSpec(
+        name="qasmbench_adder_n4_manual",
+        origin="qasmbench_manual",
+        source_id="adder_n4",
+        qubits=4,
+        tags=("control", "movement", "layering", "locality_pattern"),
+        build_kernel=_qasmbench_adder_n4_manual,
+    ),
+    KernelSpec(
+        name="qasmbench_qpe_n9_manual",
+        origin="qasmbench_manual",
+        source_id="qpe_n9",
+        qubits=9,
+        tags=("control", "cz", "layering", "movement", "entangling_density"),
+        build_kernel=_qasmbench_qpe_n9_manual,
+    ),
+)
+
+
+def select_kernels(
+    tags: set[str] | None = None,
+    max_qubits: int = 10,
+    origins: set[str] | None = None,
+) -> tuple[KernelSpec, ...]:
+    """Filter kernels by tag/origin while honoring the qubit cap."""
+    selected: list[KernelSpec] = []
+    for spec in SQUIN_KERNEL_SUITE:
+        if spec.qubits > max_qubits:
+            continue
+        if tags is not None and not tags.issubset(set(spec.tags)):
+            continue
+        if origins is not None and spec.origin not in origins:
+            continue
+        selected.append(spec)
+    return tuple(selected)

--- a/python/tests/test_validation_squin_kernels.py
+++ b/python/tests/test_validation_squin_kernels.py
@@ -1,0 +1,132 @@
+import pytest
+from tests._validation_squin_kernels import (
+    KernelSpec,
+    select_kernels,
+)
+
+from bloqade.lanes.analysis import atom
+from bloqade.lanes.arch.gemini.physical import get_arch_spec as get_physical_arch_spec
+from bloqade.lanes.compile import squin_to_move
+from bloqade.lanes.dialects import move
+from bloqade.lanes.heuristics.physical_layout import (
+    PhysicalLayoutHeuristicGraphPartitionCenterOut,
+)
+from bloqade.lanes.heuristics.physical_placement import PhysicalPlacementStrategy
+from bloqade.lanes.validation.address import Validation
+
+
+def _collect_move_nodes(move_kernel) -> list[move.StatefulStatement]:
+    return [
+        stmt
+        for stmt in move_kernel.callable_region.walk()
+        if isinstance(stmt, move.StatefulStatement)
+    ]
+
+
+def _compile_physical_move(kernel):
+    return squin_to_move(
+        kernel,
+        PhysicalLayoutHeuristicGraphPartitionCenterOut(),
+        PhysicalPlacementStrategy(),
+        logical_initialize=False,
+        no_raise=False,
+    )
+
+
+def _assert_cz_pairs_are_blockaded_neighbors(move_kernel) -> None:
+    arch_spec = get_physical_arch_spec()
+    atom_interp = atom.AtomInterpreter(move_kernel.dialects, arch_spec=arch_spec)
+    frame, _ = atom_interp.run(move_kernel)
+
+    for stmt in move_kernel.callable_region.walk():
+        if not isinstance(stmt, move.CZ):
+            continue
+
+        state = frame.get(stmt.current_state)
+        assert isinstance(
+            state, atom.AtomState
+        ), "Expected concrete atom state at move.CZ"
+
+        controls, targets, _ = state.data.get_qubit_pairing(
+            stmt.zone_address, arch_spec
+        )
+        assert len(controls) == len(
+            targets
+        ), "Mismatched control/target pairing at move.CZ"
+
+        for control_id, target_id in zip(controls, targets, strict=True):
+            control_loc = state.data.qubit_to_locations[control_id]
+            target_loc = state.data.qubit_to_locations[target_id]
+
+            assert (
+                arch_spec.get_blockaded_location(control_loc) == target_loc
+                or arch_spec.get_blockaded_location(target_loc) == control_loc
+            ), (
+                "CZ pair is not blockaded neighbors: "
+                f"control={control_id}@{control_loc}, target={target_id}@{target_loc}"
+            )
+
+
+@pytest.mark.parametrize("spec", select_kernels(), ids=lambda spec: spec.name)
+def test_kernel_catalog_compiles_to_valid_physical_move(spec: KernelSpec):
+    """Ensure every catalog kernel compiles and passes physical address validation."""
+    kernel = spec.build_kernel()
+    move_kernel = _compile_physical_move(kernel)
+
+    _, validation_errors = Validation(arch_spec=get_physical_arch_spec()).run(
+        move_kernel
+    )
+    assert (
+        not validation_errors
+    ), f"{spec.name} produced invalid physical addresses: {validation_errors}"
+
+    # Physical compilation should not include logical initialization artifacts.
+    assert all(
+        not isinstance(stmt, move.LogicalInitialize)
+        for stmt in move_kernel.callable_region.walk()
+    )
+
+    _assert_cz_pairs_are_blockaded_neighbors(move_kernel)
+
+
+@pytest.mark.parametrize("spec", select_kernels(), ids=lambda spec: spec.name)
+def test_tagged_kernel_features_appear_in_compiled_move_ir(spec: KernelSpec):
+    """Check that tag-labeled behaviors are present in compiled move operations."""
+    kernel = spec.build_kernel()
+    move_kernel = _compile_physical_move(kernel)
+    nodes = _collect_move_nodes(move_kernel)
+
+    if "cz" in spec.tags:
+        assert any(
+            isinstance(stmt, move.CZ) for stmt in nodes
+        ), f"{spec.name} is tagged 'cz' but compiled without move.CZ"
+
+    if "movement" in spec.tags:
+        assert any(
+            isinstance(stmt, move.Move) and len(stmt.lanes) > 0 for stmt in nodes
+        ), f"{spec.name} is tagged 'movement' but compiled without lane movement"
+
+    if "layering" in spec.tags:
+        assert (
+            len(nodes) >= 2
+        ), f"{spec.name} is tagged 'layering' but produced too few stateful move ops"
+
+
+def test_movement_cz_interaction_has_nontrivial_physical_artifacts():
+    """Guard a known movement+CZ kernel against trivialized physical compilation."""
+    spec = next(
+        s
+        for s in select_kernels(tags={"movement", "cz"})
+        if s.name == "curated_chain_cz_sweep"
+    )
+    kernel = spec.build_kernel()
+    move_kernel = _compile_physical_move(kernel)
+    nodes = _collect_move_nodes(move_kernel)
+
+    move_count = sum(
+        isinstance(stmt, move.Move) and len(stmt.lanes) > 0 for stmt in nodes
+    )
+    cz_count = sum(isinstance(stmt, move.CZ) for stmt in nodes)
+
+    assert move_count >= 1
+    assert cz_count >= 2


### PR DESCRIPTION
## Summary
- add `python/tests/_validation_squin_kernels.py` with a curated + qasmbench-inspired SQuIn kernel catalog for physical-compilation regression coverage
- add `python/tests/test_validation_squin_kernels.py` with parametrized physical compilation tests that validate move address correctness, tag-driven structural invariants, and non-trivial movement+CZ behavior
- validate that each compiled `move.CZ` executes on blockade-neighbor qubit pairs and link this work to issue closure

## Test plan
- [x] `uv run pytest python/tests/test_validation_squin_kernels.py`

Closes #391

Made with [Cursor](https://cursor.com)