### PR TITLE
fix(python): set PyO3 module paths to _native to fix griffe cyclic alias

### DIFF
--- a/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
@@ -14,7 +14,7 @@ use crate::validation::{validate_field, validate_vec};
     eq_int,
     hash,
     frozen,
-    module = "bloqade.lanes.bytecode"
+    module = "bloqade.lanes.bytecode._native"
 )]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum PyDirection {
@@ -59,7 +59,7 @@ impl PyDirection {
     eq_int,
     hash,
     frozen,
-    module = "bloqade.lanes.bytecode"
+    module = "bloqade.lanes.bytecode._native"
 )]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum PyMoveType {
@@ -98,7 +98,11 @@ impl PyMoveType {
 
 // ── LocationAddr ──
 
-#[pyclass(name = "LocationAddress", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(
+    name = "LocationAddress",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PyLocationAddr {
     pub(crate) inner: rs_addr::LocationAddr,
@@ -154,7 +158,11 @@ impl PyLocationAddr {
 
 // ── LaneAddr ──
 
-#[pyclass(name = "LaneAddress", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(
+    name = "LaneAddress",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PyLaneAddr {
     pub(crate) inner: rs_addr::LaneAddr,
@@ -247,7 +255,11 @@ impl PyLaneAddr {
 
 // ── ZoneAddr ──
 
-#[pyclass(name = "ZoneAddress", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(
+    name = "ZoneAddress",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
 #[derive(Clone)]
 pub struct PyZoneAddr {
     pub(crate) inner: rs_addr::ZoneAddr,
@@ -294,7 +306,7 @@ impl PyZoneAddr {
 
 // ── Grid ──
 
-#[pyclass(name = "Grid", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "Grid", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyGrid {
     pub(crate) inner: rs::Grid,
@@ -406,7 +418,7 @@ impl PyGrid {
 
 // ── Word ──
 
-#[pyclass(name = "Word", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "Word", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyWord {
     pub(crate) inner: rs::Word,
@@ -451,7 +463,7 @@ impl PyWord {
 
 // ── Geometry ──
 
-#[pyclass(name = "Geometry", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "Geometry", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyGeometry {
     pub(crate) inner: rs::Geometry,
@@ -495,7 +507,7 @@ impl PyGeometry {
 
 // ── Bus ──
 
-#[pyclass(name = "Bus", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "Bus", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyBus {
     pub(crate) inner: rs::Bus,
@@ -561,7 +573,7 @@ impl PyBus {
 
 // ── Buses ──
 
-#[pyclass(name = "Buses", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "Buses", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyBuses {
     pub(crate) inner: rs::Buses,
@@ -608,7 +620,7 @@ impl PyBuses {
 
 // ── Zone ──
 
-#[pyclass(name = "Zone", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "Zone", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyZone {
     pub(crate) inner: rs::Zone,
@@ -636,7 +648,11 @@ impl PyZone {
 
 // ── TransportPath ──
 
-#[pyclass(name = "TransportPath", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(
+    name = "TransportPath",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
 #[derive(Clone)]
 pub struct PyTransportPath {
     pub(crate) inner: rs::TransportPath,
@@ -697,7 +713,7 @@ impl PyTransportPath {
 
 // ── ArchSpec ──
 
-#[pyclass(name = "ArchSpec", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "ArchSpec", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyArchSpec {
     pub(crate) inner: rs::ArchSpec,

--- a/crates/bloqade-lanes-bytecode-python/src/atom_state_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/atom_state_python.rs
@@ -16,7 +16,11 @@ use crate::validation::{validate_i64_key_map, validate_i64_kv_map, validate_i64_
 /// Immutable value type: mutation methods return new instances. Backed by a
 /// Rust implementation for performance. Used by the IR analysis pipeline to
 /// simulate atom movement, detect collisions, and identify CZ gate pairings.
-#[pyclass(name = "AtomStateData", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(
+    name = "AtomStateData",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
 #[derive(Clone)]
 pub struct PyAtomStateData {
     pub(crate) inner: AtomStateData,

--- a/crates/bloqade-lanes-bytecode-python/src/instruction_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/instruction_python.rs
@@ -6,7 +6,11 @@ use bloqade_lanes_bytecode_core::bytecode::instruction as rs;
 use crate::arch_python::{PyDirection, PyMoveType};
 use crate::validation::validate_field;
 
-#[pyclass(name = "Instruction", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(
+    name = "Instruction",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
 #[derive(Clone)]
 pub struct PyInstruction {
     pub(crate) inner: rs::Instruction,

--- a/crates/bloqade-lanes-bytecode-python/src/program_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/program_python.rs
@@ -9,7 +9,7 @@ use bloqade_lanes_bytecode_core::version::Version;
 use crate::arch_python::PyArchSpec;
 use crate::instruction_python::PyInstruction;
 
-#[pyclass(name = "Program", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(name = "Program", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyProgram {
     pub(crate) inner: rs_prog::Program,

--- a/crates/bloqade-lanes-bytecode-python/src/search_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/search_python.rs
@@ -16,7 +16,11 @@ use crate::arch_python::PyArchSpec;
 ///
 /// Contains the sequence of move steps, the final qubit configuration,
 /// and search statistics.
-#[pyclass(name = "SolveResult", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(
+    name = "SolveResult",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
 pub struct PySolveResult {
     inner: SolveResult,
 }
@@ -105,7 +109,7 @@ impl PySolveResult {
 /// Then `solve()` can be called multiple times with different placements.
 ///
 /// Works for both physical and logical architectures.
-#[pyclass(name = "MoveSolver", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(name = "MoveSolver", frozen, module = "bloqade.lanes.bytecode._native")]
 pub struct PyMoveSolver {
     inner: MoveSolver,
 }


### PR DESCRIPTION
## Summary

- Fix griffe/mkdocstrings `CyclicAliasError` when building docs by setting all PyO3 `#[pyclass]` module attributes to `bloqade.lanes.bytecode._native` instead of `bloqade.lanes.bytecode`

The cycle was: `bloqade.lanes.bytecode.MoveType` → `_native.MoveType` → `bloqade.lanes.bytecode.MoveType`. With the canonical module set to `_native`, griffe resolves the re-exports as one-way aliases.

## Test plan

- [x] `cargo check -p bloqade-lanes-bytecode-python` compiles
- [x] Pre-commit hooks pass (clippy, fmt, pyright)
- [ ] Verify mkdocs build no longer hits `CyclicAliasError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)