### PR TITLE
fix(python): backport PyO3 module path fix for griffe cyclic alias (v0.7)

### DIFF
--- a/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
@@ -14,7 +14,7 @@ use crate::validation::{validate_field, validate_vec};
     eq_int,
     hash,
     frozen,
-    module = "bloqade.lanes.bytecode"
+    module = "bloqade.lanes.bytecode._native"
 )]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum PyDirection {
@@ -59,7 +59,7 @@ impl PyDirection {
     eq_int,
     hash,
     frozen,
-    module = "bloqade.lanes.bytecode"
+    module = "bloqade.lanes.bytecode._native"
 )]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub enum PyMoveType {
@@ -98,7 +98,7 @@ impl PyMoveType {
 
 // ── LocationAddr ──
 
-#[pyclass(name = "LocationAddress", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(name = "LocationAddress", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PyLocationAddr {
     pub(crate) inner: rs_addr::LocationAddr,
@@ -154,7 +154,7 @@ impl PyLocationAddr {
 
 // ── LaneAddr ──
 
-#[pyclass(name = "LaneAddress", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(name = "LaneAddress", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PyLaneAddr {
     pub(crate) inner: rs_addr::LaneAddr,
@@ -247,7 +247,7 @@ impl PyLaneAddr {
 
 // ── ZoneAddr ──
 
-#[pyclass(name = "ZoneAddress", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(name = "ZoneAddress", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyZoneAddr {
     pub(crate) inner: rs_addr::ZoneAddr,
@@ -294,7 +294,7 @@ impl PyZoneAddr {
 
 // ── Grid ──
 
-#[pyclass(name = "Grid", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "Grid", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyGrid {
     pub(crate) inner: rs::Grid,
@@ -406,7 +406,7 @@ impl PyGrid {
 
 // ── Word ──
 
-#[pyclass(name = "Word", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "Word", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyWord {
     pub(crate) inner: rs::Word,
@@ -465,7 +465,7 @@ impl PyWord {
 
 // ── Geometry ──
 
-#[pyclass(name = "Geometry", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "Geometry", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyGeometry {
     pub(crate) inner: rs::Geometry,
@@ -509,7 +509,7 @@ impl PyGeometry {
 
 // ── Bus ──
 
-#[pyclass(name = "Bus", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "Bus", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyBus {
     pub(crate) inner: rs::Bus,
@@ -568,7 +568,7 @@ impl PyBus {
 
 // ── Buses ──
 
-#[pyclass(name = "Buses", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "Buses", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyBuses {
     pub(crate) inner: rs::Buses,
@@ -615,7 +615,7 @@ impl PyBuses {
 
 // ── Zone ──
 
-#[pyclass(name = "Zone", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "Zone", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyZone {
     pub(crate) inner: rs::Zone,
@@ -643,7 +643,7 @@ impl PyZone {
 
 // ── TransportPath ──
 
-#[pyclass(name = "TransportPath", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "TransportPath", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyTransportPath {
     pub(crate) inner: rs::TransportPath,
@@ -704,7 +704,7 @@ impl PyTransportPath {
 
 // ── ArchSpec ──
 
-#[pyclass(name = "ArchSpec", frozen, module = "bloqade.lanes.bytecode.arch")]
+#[pyclass(name = "ArchSpec", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyArchSpec {
     pub(crate) inner: rs::ArchSpec,

--- a/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
@@ -98,7 +98,11 @@ impl PyMoveType {
 
 // ── LocationAddr ──
 
-#[pyclass(name = "LocationAddress", frozen, module = "bloqade.lanes.bytecode._native")]
+#[pyclass(
+    name = "LocationAddress",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PyLocationAddr {
     pub(crate) inner: rs_addr::LocationAddr,
@@ -154,7 +158,11 @@ impl PyLocationAddr {
 
 // ── LaneAddr ──
 
-#[pyclass(name = "LaneAddress", frozen, module = "bloqade.lanes.bytecode._native")]
+#[pyclass(
+    name = "LaneAddress",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PyLaneAddr {
     pub(crate) inner: rs_addr::LaneAddr,
@@ -247,7 +255,11 @@ impl PyLaneAddr {
 
 // ── ZoneAddr ──
 
-#[pyclass(name = "ZoneAddress", frozen, module = "bloqade.lanes.bytecode._native")]
+#[pyclass(
+    name = "ZoneAddress",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
 #[derive(Clone)]
 pub struct PyZoneAddr {
     pub(crate) inner: rs_addr::ZoneAddr,
@@ -643,7 +655,11 @@ impl PyZone {
 
 // ── TransportPath ──
 
-#[pyclass(name = "TransportPath", frozen, module = "bloqade.lanes.bytecode._native")]
+#[pyclass(
+    name = "TransportPath",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
 #[derive(Clone)]
 pub struct PyTransportPath {
     pub(crate) inner: rs::TransportPath,

--- a/crates/bloqade-lanes-bytecode-python/src/atom_state_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/atom_state_python.rs
@@ -16,7 +16,7 @@ use crate::validation::{validate_i64_key_map, validate_i64_kv_map, validate_i64_
 /// Immutable value type: mutation methods return new instances. Backed by a
 /// Rust implementation for performance. Used by the IR analysis pipeline to
 /// simulate atom movement, detect collisions, and identify CZ gate pairings.
-#[pyclass(name = "AtomStateData", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(name = "AtomStateData", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyAtomStateData {
     pub(crate) inner: AtomStateData,

--- a/crates/bloqade-lanes-bytecode-python/src/atom_state_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/atom_state_python.rs
@@ -16,7 +16,11 @@ use crate::validation::{validate_i64_key_map, validate_i64_kv_map, validate_i64_
 /// Immutable value type: mutation methods return new instances. Backed by a
 /// Rust implementation for performance. Used by the IR analysis pipeline to
 /// simulate atom movement, detect collisions, and identify CZ gate pairings.
-#[pyclass(name = "AtomStateData", frozen, module = "bloqade.lanes.bytecode._native")]
+#[pyclass(
+    name = "AtomStateData",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
 #[derive(Clone)]
 pub struct PyAtomStateData {
     pub(crate) inner: AtomStateData,

--- a/crates/bloqade-lanes-bytecode-python/src/instruction_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/instruction_python.rs
@@ -6,7 +6,7 @@ use bloqade_lanes_bytecode_core::bytecode::instruction as rs;
 use crate::arch_python::{PyDirection, PyMoveType};
 use crate::validation::validate_field;
 
-#[pyclass(name = "Instruction", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(name = "Instruction", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyInstruction {
     pub(crate) inner: rs::Instruction,

--- a/crates/bloqade-lanes-bytecode-python/src/instruction_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/instruction_python.rs
@@ -6,7 +6,11 @@ use bloqade_lanes_bytecode_core::bytecode::instruction as rs;
 use crate::arch_python::{PyDirection, PyMoveType};
 use crate::validation::validate_field;
 
-#[pyclass(name = "Instruction", frozen, module = "bloqade.lanes.bytecode._native")]
+#[pyclass(
+    name = "Instruction",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
 #[derive(Clone)]
 pub struct PyInstruction {
     pub(crate) inner: rs::Instruction,

--- a/crates/bloqade-lanes-bytecode-python/src/program_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/program_python.rs
@@ -9,7 +9,7 @@ use bloqade_lanes_bytecode_core::version::Version;
 use crate::arch_python::PyArchSpec;
 use crate::instruction_python::PyInstruction;
 
-#[pyclass(name = "Program", frozen, module = "bloqade.lanes.bytecode")]
+#[pyclass(name = "Program", frozen, module = "bloqade.lanes.bytecode._native")]
 #[derive(Clone)]
 pub struct PyProgram {
     pub(crate) inner: rs_prog::Program,


### PR DESCRIPTION
## Summary

Manual backport of PR #441 to `release-0-7`. The automated cherry-pick failed because `search_python.rs` doesn't exist on this branch (it was added by PR #436 on `main`).

This PR applies the same fix to the 4 files that exist on `release-0-7`:
- `arch_python.rs` — all `module` attributes changed from `bloqade.lanes.bytecode` / `bloqade.lanes.bytecode.arch` to `bloqade.lanes.bytecode._native`
- `instruction_python.rs` — same
- `program_python.rs` — same
- `atom_state_python.rs` — same

Fixes griffe/mkdocstrings `CyclicAliasError` when building docs.

## Test plan

- [x] `cargo check -p bloqade-lanes-bytecode-python` compiles
- [ ] Verify mkdocs build no longer hits `CyclicAliasError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)