### PR TITLE
feat(arch): zone-addressed ArchSpec APIs for flair bridge

### DIFF
--- a/python/bloqade/lanes/layout/__init__.py
+++ b/python/bloqade/lanes/layout/__init__.py
@@ -1,4 +1,4 @@
-from .arch import ArchSpec as ArchSpec
+from .arch import ArchSpec as ArchSpec, BusDescriptor as BusDescriptor
 from .encoding import (
     Direction as Direction,
     LaneAddress as LaneAddress,

--- a/python/bloqade/lanes/layout/arch.py
+++ b/python/bloqade/lanes/layout/arch.py
@@ -386,12 +386,12 @@ class ArchSpec:
             x and y positions.
 
         Raises:
-            IndexError: If zone_id is out of range.
+            ValueError: If zone_id is out of range.
         """
         from bloqade.geometry.dialects.grid import Grid as GeoGrid
 
         if zone_id < 0 or zone_id >= len(self._inner.zones):
-            raise IndexError(
+            raise ValueError(
                 f"zone_id {zone_id} out of range [0, {len(self._inner.zones)})"
             )
         zone = self._inner.zones[zone_id]
@@ -402,18 +402,15 @@ class ArchSpec:
     def get_all_sites(self) -> list[tuple[float, float]]:
         """Get all site positions across all zones in canonical order.
 
-        Returns positions in zone-major, word-major, site-major order.
+        Returns positions in zone-major order, with each zone flattened
+        in column-major grid order (``x`` outer, ``y`` inner).
         Each position is an ``(x, y)`` tuple.
         """
         sites: list[tuple[float, float]] = []
-        for zone_id in range(len(self._inner.zones)):
-            for word_id in range(len(self.words)):
-                word = self.words[word_id]
-                for site_id in range(len(word.site_indices)):
-                    loc = LocationAddress(word_id, site_id, zone_id)
-                    pos = self._inner.location_position(loc._inner)
-                    if pos is not None:
-                        sites.append(pos)
+        for zone in self._inner.zones:
+            for x in zone.grid.x_positions:
+                for y in zone.grid.y_positions:
+                    sites.append((x, y))
         return sites
 
     def get_available_buses(self, zone_id: int) -> list[BusDescriptor]:
@@ -427,10 +424,10 @@ class ArchSpec:
             combination that has at least one lane in this zone.
 
         Raises:
-            IndexError: If zone_id is out of range.
+            ValueError: If zone_id is out of range.
         """
         if zone_id < 0 or zone_id >= len(self._inner.zones):
-            raise IndexError(
+            raise ValueError(
                 f"zone_id {zone_id} out of range [0, {len(self._inner.zones)})"
             )
         zone = self._inner.zones[zone_id]
@@ -486,13 +483,13 @@ class ArchSpec:
             positions of all source/destination sites for this bus.
 
         Raises:
-            IndexError: If zone_id or bus_id is out of range.
-            ValueError: If move_type is not SITE or WORD.
+            ValueError: If zone_id or bus_id is out of range, or
+                move_type is not SITE or WORD.
         """
         from bloqade.geometry.dialects.grid import Grid as GeoGrid
 
         if zone_id < 0 or zone_id >= len(self._inner.zones):
-            raise IndexError(
+            raise ValueError(
                 f"zone_id {zone_id} out of range [0, {len(self._inner.zones)})"
             )
         zone = self._inner.zones[zone_id]
@@ -502,7 +499,7 @@ class ArchSpec:
 
         if move_type == MoveType.SITE:
             if bus_id < 0 or bus_id >= len(zone.site_buses):
-                raise IndexError(
+                raise ValueError(
                     f"site bus_id {bus_id} out of range [0, {len(zone.site_buses)})"
                 )
             bus = zone.site_buses[bus_id]
@@ -521,7 +518,7 @@ class ArchSpec:
                             dst_positions.append(dst_pos)
         elif move_type == MoveType.WORD:
             if bus_id < 0 or bus_id >= len(zone.word_buses):
-                raise IndexError(
+                raise ValueError(
                     f"word bus_id {bus_id} out of range [0, {len(zone.word_buses)})"
                 )
             bus = zone.word_buses[bus_id]

--- a/python/bloqade/lanes/layout/arch.py
+++ b/python/bloqade/lanes/layout/arch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from dataclasses import dataclass
 from functools import cached_property
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Sequence
@@ -19,6 +20,7 @@ from bloqade.lanes.layout.encoding import (
     Direction,
     LaneAddress,
     LocationAddress,
+    MoveType,
     SiteLaneAddress,
     WordLaneAddress,
     ZoneAddress,
@@ -29,7 +31,19 @@ from .word import Word
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from bloqade.geometry.dialects.grid import Grid as GeoGrid
+
     from bloqade.lanes.bytecode.exceptions import LaneGroupError, LocationGroupError
+
+
+@dataclass(frozen=True)
+class BusDescriptor:
+    """Descriptor for a bus within a zone."""
+
+    bus_id: int
+    move_type: MoveType
+    direction: Direction
+    num_lanes: int
 
 
 class ArchSpec:
@@ -358,6 +372,184 @@ class ArchSpec:
         if pos is None:
             raise ValueError(f"Invalid location address: {location!r}")
         return pos
+
+    # ── Zone-addressed APIs (#419/#420) ──
+
+    def get_zone_grid(self, zone_id: int) -> GeoGrid:
+        """Get the coordinate grid for a zone as a ``bloqade.geometry.Grid``.
+
+        Args:
+            zone_id: Zone index.
+
+        Returns:
+            A ``bloqade.geometry.dialects.grid.Grid`` with the zone's
+            x and y positions.
+
+        Raises:
+            IndexError: If zone_id is out of range.
+        """
+        from bloqade.geometry.dialects.grid import Grid as GeoGrid
+
+        if zone_id < 0 or zone_id >= len(self._inner.zones):
+            raise IndexError(
+                f"zone_id {zone_id} out of range [0, {len(self._inner.zones)})"
+            )
+        zone = self._inner.zones[zone_id]
+        return GeoGrid.from_positions(
+            tuple(zone.grid.x_positions), tuple(zone.grid.y_positions)
+        )
+
+    def get_all_sites(self) -> list[tuple[float, float]]:
+        """Get all site positions across all zones in canonical order.
+
+        Returns positions in zone-major, word-major, site-major order.
+        Each position is an ``(x, y)`` tuple.
+        """
+        sites: list[tuple[float, float]] = []
+        for zone_id in range(len(self._inner.zones)):
+            for word_id in range(len(self.words)):
+                word = self.words[word_id]
+                for site_id in range(len(word.site_indices)):
+                    loc = LocationAddress(word_id, site_id, zone_id)
+                    pos = self._inner.location_position(loc._inner)
+                    if pos is not None:
+                        sites.append(pos)
+        return sites
+
+    def get_available_buses(self, zone_id: int) -> list[BusDescriptor]:
+        """Enumerate all valid bus descriptors for a zone.
+
+        Args:
+            zone_id: Zone index.
+
+        Returns:
+            List of ``BusDescriptor`` for each (bus_id, move_type, direction)
+            combination that has at least one lane in this zone.
+
+        Raises:
+            IndexError: If zone_id is out of range.
+        """
+        if zone_id < 0 or zone_id >= len(self._inner.zones):
+            raise IndexError(
+                f"zone_id {zone_id} out of range [0, {len(self._inner.zones)})"
+            )
+        zone = self._inner.zones[zone_id]
+        result: list[BusDescriptor] = []
+
+        for bus_id, bus in enumerate(zone.site_buses):
+            n = len(bus.src) * len(zone.words_with_site_buses)
+            for direction in (Direction.FORWARD, Direction.BACKWARD):
+                result.append(
+                    BusDescriptor(
+                        bus_id=bus_id,
+                        move_type=MoveType.SITE,
+                        direction=direction,
+                        num_lanes=n,
+                    )
+                )
+
+        for bus_id, bus in enumerate(zone.word_buses):
+            n = len(bus.src) * len(zone.sites_with_word_buses)
+            for direction in (Direction.FORWARD, Direction.BACKWARD):
+                result.append(
+                    BusDescriptor(
+                        bus_id=bus_id,
+                        move_type=MoveType.WORD,
+                        direction=direction,
+                        num_lanes=n,
+                    )
+                )
+
+        return result
+
+    def get_grid_endpoints(
+        self,
+        zone_id: int,
+        bus_id: int,
+        move_type: MoveType,
+        direction: Direction,
+    ) -> tuple[GeoGrid, GeoGrid]:
+        """Get start and end grids for a bus move at full occupancy.
+
+        Returns two ``bloqade.geometry.Grid`` objects representing the
+        source and destination positions for all lanes in the specified
+        bus group.
+
+        Args:
+            zone_id: Zone index.
+            bus_id: Bus index within the zone.
+            move_type: SITE or WORD.
+            direction: FORWARD or BACKWARD.
+
+        Returns:
+            ``(src_grid, dst_grid)`` where each grid contains the physical
+            positions of all source/destination sites for this bus.
+
+        Raises:
+            IndexError: If zone_id or bus_id is out of range.
+            ValueError: If move_type is not SITE or WORD.
+        """
+        from bloqade.geometry.dialects.grid import Grid as GeoGrid
+
+        if zone_id < 0 or zone_id >= len(self._inner.zones):
+            raise IndexError(
+                f"zone_id {zone_id} out of range [0, {len(self._inner.zones)})"
+            )
+        zone = self._inner.zones[zone_id]
+
+        src_positions: list[tuple[float, float]] = []
+        dst_positions: list[tuple[float, float]] = []
+
+        if move_type == MoveType.SITE:
+            if bus_id < 0 or bus_id >= len(zone.site_buses):
+                raise IndexError(
+                    f"site bus_id {bus_id} out of range [0, {len(zone.site_buses)})"
+                )
+            bus = zone.site_buses[bus_id]
+            for word_id in zone.words_with_site_buses:
+                for src_site, dst_site in zip(bus.src, bus.dst):
+                    lane = LaneAddress(
+                        move_type, word_id, src_site, bus_id, direction, zone_id
+                    )
+                    endpoints = self._inner.lane_endpoints(lane._inner)
+                    if endpoints is not None:
+                        src_loc, dst_loc = endpoints
+                        src_pos = self._inner.location_position(src_loc)
+                        dst_pos = self._inner.location_position(dst_loc)
+                        if src_pos is not None and dst_pos is not None:
+                            src_positions.append(src_pos)
+                            dst_positions.append(dst_pos)
+        elif move_type == MoveType.WORD:
+            if bus_id < 0 or bus_id >= len(zone.word_buses):
+                raise IndexError(
+                    f"word bus_id {bus_id} out of range [0, {len(zone.word_buses)})"
+                )
+            bus = zone.word_buses[bus_id]
+            for src_word, dst_word in zip(bus.src, bus.dst):
+                for site_id in zone.sites_with_word_buses:
+                    lane = LaneAddress(
+                        move_type, src_word, site_id, bus_id, direction, zone_id
+                    )
+                    endpoints = self._inner.lane_endpoints(lane._inner)
+                    if endpoints is not None:
+                        src_loc, dst_loc = endpoints
+                        src_pos = self._inner.location_position(src_loc)
+                        dst_pos = self._inner.location_position(dst_loc)
+                        if src_pos is not None and dst_pos is not None:
+                            src_positions.append(src_pos)
+                            dst_positions.append(dst_pos)
+        else:
+            raise ValueError(f"Unsupported move_type: {move_type}")
+
+        src_xs = sorted(set(p[0] for p in src_positions))
+        src_ys = sorted(set(p[1] for p in src_positions))
+        dst_xs = sorted(set(p[0] for p in dst_positions))
+        dst_ys = sorted(set(p[1] for p in dst_positions))
+
+        return (
+            GeoGrid.from_positions(tuple(src_xs), tuple(src_ys)),
+            GeoGrid.from_positions(tuple(dst_xs), tuple(dst_ys)),
+        )
 
     def _get_word_bus_paths(
         self, show_word_bus: Sequence[int]

--- a/python/tests/layout/test_zone_apis.py
+++ b/python/tests/layout/test_zone_apis.py
@@ -67,12 +67,12 @@ class TestGetZoneGrid:
 
     def test_invalid_zone_id_raises(self):
         arch = _single_zone_arch()
-        with pytest.raises(IndexError):
+        with pytest.raises(ValueError):
             arch.get_zone_grid(99)
 
     def test_negative_zone_id_raises(self):
         arch = _single_zone_arch()
-        with pytest.raises(IndexError):
+        with pytest.raises(ValueError):
             arch.get_zone_grid(-1)
 
     def test_two_zone_different_grids(self):
@@ -107,8 +107,8 @@ class TestGetAllSites:
     def test_two_zone_includes_both(self):
         arch = _two_zone_arch()
         sites = arch.get_all_sites()
-        # Each zone resolves all 8 words × 4 sites = 32, 2 zones = 64
-        assert len(sites) == 64
+        # Each zone has 8 x-positions × 2 y-positions = 16, 2 zones = 32
+        assert len(sites) == 32
 
 
 # ── get_available_buses ──
@@ -142,7 +142,7 @@ class TestGetAvailableBuses:
 
     def test_invalid_zone_raises(self):
         arch = _single_zone_arch()
-        with pytest.raises(IndexError):
+        with pytest.raises(ValueError):
             arch.get_available_buses(99)
 
     def test_zone_without_buses(self):
@@ -181,12 +181,12 @@ class TestGetGridEndpoints:
 
     def test_invalid_zone_raises(self):
         arch = _single_zone_arch()
-        with pytest.raises(IndexError):
+        with pytest.raises(ValueError):
             arch.get_grid_endpoints(99, 0, MoveType.SITE, Direction.FORWARD)
 
     def test_invalid_bus_id_raises(self):
         arch = _single_zone_arch()
-        with pytest.raises(IndexError):
+        with pytest.raises(ValueError):
             arch.get_grid_endpoints(0, 99, MoveType.SITE, Direction.FORWARD)
 
     def test_backward_swaps_endpoints(self):

--- a/python/tests/layout/test_zone_apis.py
+++ b/python/tests/layout/test_zone_apis.py
@@ -1,0 +1,202 @@
+"""Tests for zone-addressed ArchSpec APIs (#419/#420)."""
+
+import pytest
+from bloqade.geometry.dialects.grid import Grid as GeoGrid
+
+from bloqade.lanes.arch import (
+    ArchBlueprint,
+    DeviceLayout,
+    HypercubeSiteTopology,
+    HypercubeWordTopology,
+    MatchingTopology,
+    ZoneSpec,
+    build_arch,
+)
+from bloqade.lanes.layout import BusDescriptor, Direction, MoveType
+
+
+def _single_zone_arch():
+    bp = ArchBlueprint(
+        zones={
+            "gate": ZoneSpec(
+                num_rows=2,
+                num_cols=2,
+                entangling=True,
+                word_topology=HypercubeWordTopology(),
+                site_topology=HypercubeSiteTopology(),
+            ),
+        },
+        layout=DeviceLayout(sites_per_word=4),
+    )
+    return build_arch(bp).arch
+
+
+def _two_zone_arch():
+    bp = ArchBlueprint(
+        zones={
+            "proc": ZoneSpec(
+                num_rows=2,
+                num_cols=2,
+                entangling=True,
+                word_topology=HypercubeWordTopology(),
+                site_topology=HypercubeSiteTopology(),
+            ),
+            "mem": ZoneSpec(num_rows=2, num_cols=2),
+        },
+        layout=DeviceLayout(sites_per_word=4),
+    )
+    return build_arch(bp, connections={("proc", "mem"): MatchingTopology()}).arch
+
+
+# ── get_zone_grid ──
+
+
+class TestGetZoneGrid:
+    def test_returns_geo_grid(self):
+        arch = _single_zone_arch()
+        grid = arch.get_zone_grid(0)
+        assert isinstance(grid, GeoGrid)
+
+    def test_grid_has_correct_shape(self):
+        arch = _single_zone_arch()
+        grid = arch.get_zone_grid(0)
+        # 2 cols × 4 sites/word interleaved → multiple x positions
+        # 2 rows → multiple y positions
+        assert grid.shape[0] > 0
+        assert grid.shape[1] > 0
+
+    def test_invalid_zone_id_raises(self):
+        arch = _single_zone_arch()
+        with pytest.raises(IndexError):
+            arch.get_zone_grid(99)
+
+    def test_negative_zone_id_raises(self):
+        arch = _single_zone_arch()
+        with pytest.raises(IndexError):
+            arch.get_zone_grid(-1)
+
+    def test_two_zone_different_grids(self):
+        arch = _two_zone_arch()
+        grid0 = arch.get_zone_grid(0)
+        grid1 = arch.get_zone_grid(1)
+        # Both zones have the same grid dimensions (same ZoneSpec shape)
+        assert grid0.shape == grid1.shape
+
+
+# ── get_all_sites ──
+
+
+class TestGetAllSites:
+    def test_returns_list_of_tuples(self):
+        arch = _single_zone_arch()
+        sites = arch.get_all_sites()
+        assert isinstance(sites, list)
+        assert all(isinstance(s, tuple) and len(s) == 2 for s in sites)
+
+    def test_single_zone_site_count(self):
+        arch = _single_zone_arch()
+        sites = arch.get_all_sites()
+        # 4 words × 4 sites = 16 positions (single zone)
+        assert len(sites) == 16
+
+    def test_positions_are_unique(self):
+        arch = _single_zone_arch()
+        sites = arch.get_all_sites()
+        assert len(sites) == len(set(sites))
+
+    def test_two_zone_includes_both(self):
+        arch = _two_zone_arch()
+        sites = arch.get_all_sites()
+        # Each zone resolves all 8 words × 4 sites = 32, 2 zones = 64
+        assert len(sites) == 64
+
+
+# ── get_available_buses ──
+
+
+class TestGetAvailableBuses:
+    def test_returns_bus_descriptors(self):
+        arch = _single_zone_arch()
+        buses = arch.get_available_buses(0)
+        assert isinstance(buses, list)
+        assert all(isinstance(b, BusDescriptor) for b in buses)
+
+    def test_site_and_word_buses_present(self):
+        arch = _single_zone_arch()
+        buses = arch.get_available_buses(0)
+        move_types = {b.move_type for b in buses}
+        assert MoveType.SITE in move_types
+        assert MoveType.WORD in move_types
+
+    def test_forward_and_backward(self):
+        arch = _single_zone_arch()
+        buses = arch.get_available_buses(0)
+        directions = {b.direction for b in buses}
+        assert Direction.FORWARD in directions
+        assert Direction.BACKWARD in directions
+
+    def test_num_lanes_positive(self):
+        arch = _single_zone_arch()
+        buses = arch.get_available_buses(0)
+        assert all(b.num_lanes > 0 for b in buses)
+
+    def test_invalid_zone_raises(self):
+        arch = _single_zone_arch()
+        with pytest.raises(IndexError):
+            arch.get_available_buses(99)
+
+    def test_zone_without_buses(self):
+        arch = _two_zone_arch()
+        # mem zone has no site or word topology
+        buses = arch.get_available_buses(1)
+        assert len(buses) == 0
+
+
+# ── get_grid_endpoints ──
+
+
+class TestGetGridEndpoints:
+    def test_returns_two_grids(self):
+        arch = _single_zone_arch()
+        src_grid, dst_grid = arch.get_grid_endpoints(
+            0, 0, MoveType.SITE, Direction.FORWARD
+        )
+        assert isinstance(src_grid, GeoGrid)
+        assert isinstance(dst_grid, GeoGrid)
+
+    def test_src_dst_different(self):
+        arch = _single_zone_arch()
+        src_grid, dst_grid = arch.get_grid_endpoints(
+            0, 0, MoveType.SITE, Direction.FORWARD
+        )
+        assert src_grid != dst_grid
+
+    def test_word_bus_endpoints(self):
+        arch = _single_zone_arch()
+        src_grid, dst_grid = arch.get_grid_endpoints(
+            0, 0, MoveType.WORD, Direction.FORWARD
+        )
+        assert isinstance(src_grid, GeoGrid)
+        assert isinstance(dst_grid, GeoGrid)
+
+    def test_invalid_zone_raises(self):
+        arch = _single_zone_arch()
+        with pytest.raises(IndexError):
+            arch.get_grid_endpoints(99, 0, MoveType.SITE, Direction.FORWARD)
+
+    def test_invalid_bus_id_raises(self):
+        arch = _single_zone_arch()
+        with pytest.raises(IndexError):
+            arch.get_grid_endpoints(0, 99, MoveType.SITE, Direction.FORWARD)
+
+    def test_backward_swaps_endpoints(self):
+        arch = _single_zone_arch()
+        fwd_src, fwd_dst = arch.get_grid_endpoints(
+            0, 0, MoveType.SITE, Direction.FORWARD
+        )
+        bwd_src, bwd_dst = arch.get_grid_endpoints(
+            0, 0, MoveType.SITE, Direction.BACKWARD
+        )
+        # Backward swaps src and dst
+        assert fwd_src == bwd_dst
+        assert fwd_dst == bwd_src


### PR DESCRIPTION
## Summary

- Add `get_zone_grid(zone_id)` — returns zone's coordinate grid as `bloqade.geometry.Grid`
- Add `get_all_sites()` — canonical flat site list across all zones
- Add `get_available_buses(zone_id)` — enumerate valid `(bus_id, move_type, direction)` for a zone
- Add `get_grid_endpoints(zone_id, bus_id, move_type, direction)` — start/end grids for a bus move
- Add `BusDescriptor` dataclass to `bloqade.lanes.layout`

These APIs enable flair to generate AOD grid moves directly from the ArchSpec.

Closes #420
Partially addresses #419, #421

## Test plan

- [x] 21 new tests in `python/tests/layout/test_zone_apis.py`
- [x] All hooks pass (pyright, ruff, black, isort)

🤖 Generated with [Claude Code](https://claude.com/claude-code)