### PR TITLE
fix(search): resolve backward AOD rectangle source mapping

### DIFF
--- a/python/bloqade/lanes/search/generators/aod_grouping.py
+++ b/python/bloqade/lanes/search/generators/aod_grouping.py
@@ -155,15 +155,7 @@ class BusContext:
                 loc = self.pos_to_loc.get((x, y))
                 if loc is not None:
                     lane = self.src_to_lane.get(loc)
-                    if lane is None:
-                        lane = LaneAddress(
-                            self.move_type,
-                            loc.word_id,
-                            loc.site_id,
-                            self.bus_id,
-                            self.direction,
-                            loc.zone_id,
-                        )
+                    assert lane is not None
                     lanes.append(lane)
         return frozenset(lanes)
 

--- a/python/bloqade/lanes/search/generators/aod_grouping.py
+++ b/python/bloqade/lanes/search/generators/aod_grouping.py
@@ -52,6 +52,9 @@ class BusContext:
     arch_spec: ArchSpec
     pos_to_loc: dict[tuple[float, float], LocationAddress] = field(repr=False)
     collision_srcs: frozenset[LocationAddress] = field(repr=False)
+    src_to_lane: dict[LocationAddress, LaneAddress] = field(
+        repr=False, default_factory=dict
+    )
 
     @classmethod
     def from_tree(
@@ -75,8 +78,9 @@ class BusContext:
         """
         arch_spec = tree.arch_spec
 
-        # Aggregate sources across zones (or a single zone if specified)
+        # Aggregate executable source locations by evaluating lane endpoints.
         src_locs: list[LocationAddress] = []
+        src_to_lane: dict[LocationAddress, LaneAddress] = {}
         zone_iter: list[tuple[int, _RustZone]] = []
         if zone_id is not None:
             zone_iter = [(zone_id, arch_spec.zones[zone_id])]
@@ -87,19 +91,21 @@ class BusContext:
             if move_type == MoveType.SITE:
                 if bus_id < len(zone.site_buses):
                     bus = zone.site_buses[bus_id]
-                    src_locs.extend(
-                        LocationAddress(w, s, zid)
-                        for w in zone.words_with_site_buses
-                        for s in bus.src
-                    )
+                    for w in zone.words_with_site_buses:
+                        for s in bus.src:
+                            lane = LaneAddress(move_type, w, s, bus_id, direction, zid)
+                            src, _ = arch_spec.get_endpoints(lane)
+                            src_locs.append(src)
+                            src_to_lane[src] = lane
             else:
                 if bus_id < len(zone.word_buses):
                     bus = zone.word_buses[bus_id]
-                    src_locs.extend(
-                        LocationAddress(w, s, zid)
-                        for w in bus.src
-                        for s in zone.sites_with_word_buses
-                    )
+                    for w in bus.src:
+                        for s in zone.sites_with_word_buses:
+                            lane = LaneAddress(move_type, w, s, bus_id, direction, zid)
+                            src, _ = arch_spec.get_endpoints(lane)
+                            src_locs.append(src)
+                            src_to_lane[src] = lane
 
         pos_to_loc: dict[tuple[float, float], LocationAddress] = {}
         for loc in src_locs:
@@ -110,9 +116,9 @@ class BusContext:
         # checks source membership, so collision_srcs must store sources.
         collision: set[LocationAddress] = set()
         for loc in src_locs:
-            lane = LaneAddress(
-                move_type, loc.word_id, loc.site_id, bus_id, direction, loc.zone_id
-            )
+            lane = src_to_lane.get(loc)
+            if lane is None:
+                continue
             _, dst = arch_spec.get_endpoints(lane)
             if dst in occupied:
                 collision.add(loc)
@@ -123,6 +129,7 @@ class BusContext:
             direction=direction,
             arch_spec=arch_spec,
             pos_to_loc=pos_to_loc,
+            src_to_lane=src_to_lane,
             collision_srcs=frozenset(collision),
         )
 
@@ -147,8 +154,9 @@ class BusContext:
             for y in ys:
                 loc = self.pos_to_loc.get((x, y))
                 if loc is not None:
-                    lanes.append(
-                        LaneAddress(
+                    lane = self.src_to_lane.get(loc)
+                    if lane is None:
+                        lane = LaneAddress(
                             self.move_type,
                             loc.word_id,
                             loc.site_id,
@@ -156,7 +164,7 @@ class BusContext:
                             self.direction,
                             loc.zone_id,
                         )
-                    )
+                    lanes.append(lane)
         return frozenset(lanes)
 
     def lane_position(self, lane: LaneAddress) -> tuple[float, float]:

--- a/python/tests/search/test_greedy_generator.py
+++ b/python/tests/search/test_greedy_generator.py
@@ -50,6 +50,7 @@ def _make_bus_context(
         direction=Direction.FORWARD,
         arch_spec=arch_spec,
         pos_to_loc=pos_to_loc,
+        src_to_lane={},
         collision_srcs=collision_srcs,
     )
 
@@ -118,6 +119,27 @@ def test_from_tree_collision_sources_store_sources_not_destinations():
     destination = LocationAddress(1, 0)
     assert source in ctx.collision_srcs
     assert destination not in ctx.collision_srcs
+
+
+def test_from_tree_backward_word_bus_uses_backward_sources():
+    """Backward bus contexts should map positions for backward source words."""
+    _gen, tree = _make_setup(
+        placement={0: LocationAddress(3, 0), 1: LocationAddress(7, 0)}
+    )
+    occupied = tree.root.occupied_locations | tree.blocked_locations
+
+    ctx = BusContext.from_tree(
+        tree=tree,
+        occupied=occupied,
+        move_type=MoveType.WORD,
+        bus_id=9,
+        direction=Direction.BACKWARD,
+        zone_id=0,
+    )
+
+    # These are backward-source words for word bus 9 in logical Gemini.
+    assert tree.arch_spec.get_position(LocationAddress(3, 0)) in ctx.pos_to_loc
+    assert tree.arch_spec.get_position(LocationAddress(7, 0)) in ctx.pos_to_loc
 
 
 # --- BusContext.rect_to_lanes ---

--- a/python/tests/search/test_greedy_generator.py
+++ b/python/tests/search/test_greedy_generator.py
@@ -1,5 +1,7 @@
 """Tests for GreedyMoveGenerator."""
 
+import pytest
+
 from bloqade.lanes.arch.gemini import logical
 from bloqade.lanes.layout import Direction, LaneAddress, LocationAddress, MoveType
 from bloqade.lanes.search.generators import (
@@ -41,16 +43,27 @@ def test_satisfies_protocol():
 def _make_bus_context(
     pos_to_loc: dict[tuple[float, float], LocationAddress],
     collision_srcs: frozenset[LocationAddress] = frozenset(),
+    include_lane_map: bool = True,
 ) -> BusContext:
     """Create a minimal BusContext for unit tests."""
     arch_spec = logical.get_arch_spec()
+    src_to_lane = (
+        {
+            loc: LaneAddress(
+                MoveType.SITE, loc.word_id, loc.site_id, 0, Direction.FORWARD
+            )
+            for loc in pos_to_loc.values()
+        }
+        if include_lane_map
+        else {}
+    )
     return BusContext(
         move_type=MoveType.SITE,
         bus_id=0,
         direction=Direction.FORWARD,
         arch_spec=arch_spec,
         pos_to_loc=pos_to_loc,
-        src_to_lane={},
+        src_to_lane=src_to_lane,
         collision_srcs=collision_srcs,
     )
 
@@ -165,6 +178,16 @@ def test_rect_to_lanes_skips_missing_positions():
     ctx = _make_bus_context({(0.0, 0.0): LocationAddress(0, 0)})
     lanes = ctx.rect_to_lanes({0.0, 1.0}, {0.0})
     assert len(lanes) == 1
+
+
+def test_rect_to_lanes_asserts_when_source_lane_missing():
+    """BusContext should fail fast when src_to_lane is inconsistent."""
+    ctx = _make_bus_context(
+        {(0.0, 0.0): LocationAddress(0, 0)},
+        include_lane_map=False,
+    )
+    with pytest.raises(AssertionError):
+        ctx.rect_to_lanes({0.0}, {0.0})
 
 
 # --- merge_clusters ---


### PR DESCRIPTION
## Summary
- fix backward bus rectangle source construction by deriving source locations from direction-aware lane endpoints
- preserve a `src_to_lane` map so rectangle emission reuses valid lane identities instead of reconstructing potentially invalid backward lanes
- add a regression test proving backward word-bus contexts include true backward source coordinates

## Test plan
- [x] `uv run pytest python/tests/search/test_greedy_generator.py`
- [x] regenerate `debug/steane_physical_impl.py --gif` and confirm the previously split backward rows are merged

Closes #460

Made with [Cursor](https://cursor.com)