### PR TITLE
fix(search): add time-aware distance to entropy scoring

### DIFF
--- a/python/bloqade/lanes/search/scoring.py
+++ b/python/bloqade/lanes/search/scoring.py
@@ -7,7 +7,7 @@ Two-level scoring:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from bloqade.lanes.layout import Direction, LaneAddress, LocationAddress, MoveType
@@ -42,6 +42,28 @@ class CandidateScorer:
 
     params: SearchParams
     target: dict[int, LocationAddress]
+    _fastest_lane_duration_cache: dict[int, float] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    def _fastest_lane_duration_us(self, tree: ConfigurationTree) -> float:
+        """Return fastest lane duration for a tree (cached)."""
+        tree_id = id(tree)
+        cached = self._fastest_lane_duration_cache.get(tree_id)
+        if cached is not None:
+            return cached
+
+        fastest = float("inf")
+        for lanes in tree._lanes_by_triplet.values():
+            for lane in lanes:
+                duration = tree.path_finder.metrics.get_lane_duration_us(lane)
+                if duration > 0.0:
+                    fastest = min(fastest, duration)
+
+        if fastest == float("inf"):
+            fastest = 1.0
+        self._fastest_lane_duration_cache[tree_id] = fastest
+        return fastest
 
     def _distance_to_target(
         self,
@@ -49,24 +71,49 @@ class CandidateScorer:
         target_loc: LocationAddress,
         tree: ConfigurationTree,
     ) -> float:
-        """Shortest path length in number of lanes (hops) from current to target.
+        """Blended shortest-path distance from current to target.
 
-        Uses uniform edge weight so the path minimizes hop count, not wall-clock
-        move time. That keeps scoring aligned with “how many moves remain” and
-        avoids underweighting short but slow lanes relative to mobility.
-        Does not pass an occupied set — paths are computed over the full
-        graph, which is appropriate for a heuristic distance estimate.
+        Combines:
+        - hop-count shortest path (uniform lane cost 1.0), and
+        - approximate move-time shortest path (lane duration in microseconds),
+          normalized into hop-like units by dividing by the fastest lane duration.
+
+        Blend weight is controlled by SearchParams.w_t:
+        - w_t = 0.0 => hop-count only
+        - w_t = 1.0 => move-time only (normalized)
+
+        Occupancy is intentionally ignored for this heuristic estimate.
         Returns float('inf') if no path.
         """
-        result = tree.path_finder.find_path(
+        hop_result = tree.path_finder.find_path(
             current,
             target_loc,
             edge_weight=lambda _lane: 1.0,
         )
-        if result is None:
+        if hop_result is None:
             return float("inf")
-        lanes, _ = result
-        return float(len(lanes))
+        hop_lanes, _ = hop_result
+        hop_distance = float(len(hop_lanes))
+
+        if self.params.w_t <= 0.0:
+            return hop_distance
+
+        time_result = tree.path_finder.find_path(
+            current,
+            target_loc,
+            edge_weight=tree.path_finder.metrics.get_lane_duration_us,
+        )
+        if time_result is None:
+            return float("inf")
+        time_lanes, _ = time_result
+        time_us = sum(
+            tree.path_finder.metrics.get_lane_duration_us(lane) for lane in time_lanes
+        )
+        fastest_lane_us = self._fastest_lane_duration_us(tree)
+        time_distance = time_us / fastest_lane_us
+
+        w_t = self.params.w_t
+        return (1.0 - w_t) * hop_distance + w_t * time_distance
 
     def _mobility_at(
         self,

--- a/python/bloqade/lanes/search/search_params.py
+++ b/python/bloqade/lanes/search/search_params.py
@@ -13,6 +13,8 @@ class SearchParams:
     Attributes:
         w_d: Distance weight in per-qubit lane scoring.
         w_m: Mobility weight in per-qubit lane scoring.
+        w_t: Time-distance blend weight for distance computation.
+            0.0 => hop-count only, 1.0 => approximate move-time only.
         alpha: Distance weight in moveset scoring.
         beta: Arrived-gain weight in moveset scoring.
         gamma: Mobility weight in moveset scoring.
@@ -30,9 +32,12 @@ class SearchParams:
     MIN_MAX_CANDIDATES: ClassVar[int] = 1
     MIN_REVERSION_STEPS: ClassVar[int] = 1
     MIN_MAX_GOAL_CANDIDATES: ClassVar[int] = 1
+    MIN_W_T: ClassVar[float] = 0.0
+    MAX_W_T: ClassVar[float] = 1.0
 
     w_d: float = 1.0
     w_m: float = 0.3
+    w_t: float = 0.05
     alpha: float = 100.0
     beta: float = 2.0
     gamma: float = 0.5
@@ -60,3 +65,5 @@ class SearchParams:
             raise ValueError(
                 f"max_goal_candidates must be >= {self.MIN_MAX_GOAL_CANDIDATES}"
             )
+        if not (self.MIN_W_T <= self.w_t <= self.MAX_W_T):
+            raise ValueError(f"w_t must be in [{self.MIN_W_T}, {self.MAX_W_T}]")

--- a/python/tests/search/test_search_params.py
+++ b/python/tests/search/test_search_params.py
@@ -25,3 +25,11 @@ class TestSearchParams:
     def test_reversion_steps_minimum_enforced(self):
         with pytest.raises(ValueError, match="reversion_steps"):
             SearchParams(reversion_steps=SearchParams.MIN_REVERSION_STEPS - 1)
+
+    def test_w_t_minimum_enforced(self):
+        with pytest.raises(ValueError, match="w_t"):
+            SearchParams(w_t=SearchParams.MIN_W_T - 0.01)
+
+    def test_w_t_maximum_enforced(self):
+        with pytest.raises(ValueError, match="w_t"):
+            SearchParams(w_t=SearchParams.MAX_W_T + 0.01)


### PR DESCRIPTION
## Summary
- Add a time-aware distance term to entropy candidate scoring by blending hop-count shortest-path distance with approximate move-time shortest-path distance.
- Introduce `SearchParams.w_t` (`0.0..1.0`) to control the blend and keep the heuristic tunable across workloads.
- Add bounds constants/validation for `w_t` and tests for min/max enforcement in search-params unit tests.

## Distance Math
For each qubit distance estimate used during candidate scoring, we now compute:

`d_hop = shortest_path(current, target; edge_weight = 1.0)` (lane-count / hops)

`d_time = shortest_path(current, target; edge_weight = lane_duration_us)`

`d_time_norm = d_time / min_lane_duration_us`

`d_blend = (1 - w_t) * d_hop + w_t * d_time_norm`

Where:
- `w_t = 0.0` reproduces the previous hop-only behavior.
- `w_t = 1.0` uses fully time-based distance (normalized into hop-like units).
- normalization by fastest lane duration keeps hop and time terms on comparable scales.

This blended distance feeds per-qubit bus scoring (`delta_d`) and therefore candidate move evaluation/ranking, so moves that improve physical travel cost can be favored even when hop counts are similar.

Closes #468

## Test plan
- [x] `uv run pytest python/tests/search/test_search_params.py`
- [x] pre-commit checks passed during commit (isort, black, ruff, pyright)

Made with [Cursor](https://cursor.com)