### PR TITLE
Backport PR #485 to release-0-8

### DIFF
--- a/crates/bloqade-lanes-bytecode-core/src/arch/query.rs
+++ b/crates/bloqade-lanes-bytecode-core/src/arch/query.rs
@@ -256,7 +256,7 @@ impl ArchSpec {
 
     /// Return the set of "home" word IDs — the lower word in each entangling
     /// pair, plus any word not appearing in any pair.
-    pub fn home_word_ids(&self) -> Vec<u32> {
+    pub fn left_cz_word_ids(&self) -> Vec<u32> {
         let partner = self.word_partner_map();
         let mut paired: HashSet<u32> = HashSet::new();
         let mut home: HashSet<u32> = HashSet::new();
@@ -1525,9 +1525,9 @@ mod tests {
     }
 
     #[test]
-    fn test_home_word_ids() {
+    fn test_left_cz_word_ids() {
         let spec = make_valid_two_zone_spec();
-        let home = spec.home_word_ids();
+        let home = spec.left_cz_word_ids();
         // Pair [0, 1] -> home word is 0. Word 1 is the staging word.
         // But there are only 2 words and they're all paired, so home = [0].
         assert_eq!(home, vec![0]);

--- a/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
@@ -1063,6 +1063,37 @@ impl PyArchSpec {
             .map(|l| PyLocationAddr { inner: l })
     }
 
+    // -- Derived topology queries (#464 phase 2) --
+
+    /// Build a bidirectional word-partner map from entangling pairs.
+    ///
+    /// Returns a dict mapping each word_id to its CZ partner word_id.
+    fn word_partner_map(&self) -> std::collections::HashMap<u32, u32> {
+        self.inner.word_partner_map()
+    }
+
+    /// Map each word_id to the zone_id that owns it.
+    ///
+    /// Returns a dict mapping word_id → zone_id.
+    fn word_zone_map(&self) -> std::collections::HashMap<u32, u32> {
+        self.inner.word_zone_map()
+    }
+
+    /// Return sorted left-CZ word IDs (lower word of each CZ pair + unpaired).
+    fn left_cz_word_ids(&self) -> Vec<u32> {
+        self.inner.left_cz_word_ids()
+    }
+
+    /// Reverse-lookup: find the lane connecting src → dst.
+    ///
+    /// Returns the ``LaneAddress`` if found, or None.
+    #[pyo3(text_signature = "(self, src, dst)")]
+    fn lane_for_endpoints(&self, src: &PyLocationAddr, dst: &PyLocationAddr) -> Option<PyLaneAddr> {
+        self.inner
+            .lane_for_endpoints(&src.inner, &dst.inner)
+            .map(|l| PyLaneAddr { inner: l })
+    }
+
     fn check_zone(&self, addr: &PyZoneAddr) -> Option<String> {
         self.inner.check_zone(&addr.inner)
     }

--- a/python/bloqade/lanes/bytecode/_native.pyi
+++ b/python/bloqade/lanes/bytecode/_native.pyi
@@ -789,6 +789,57 @@ class ArchSpec:
                 in any entangling pair within its zone.
         """
         ...
+    # -- Derived topology queries (#464 phase 2) --
+
+    def word_partner_map(self) -> dict[int, int]:
+        """Bidirectional word partner map from entangling pairs.
+
+        Returns:
+            dict[int, int]: word_id → partner_word_id for every word
+                appearing in any zone's ``entangling_pairs``.
+        """
+        ...
+
+    def word_zone_map(self) -> dict[int, int]:
+        """Map each word_id to the zone_id that owns it.
+
+        Derived from each zone's ``entangling_pairs``, ``word_buses``,
+        and ``words_with_site_buses``. Words not referenced by any zone
+        default to zone 0.
+
+        Returns:
+            dict[int, int]: word_id → zone_id.
+        """
+        ...
+
+    def left_cz_word_ids(self) -> list[int]:
+        """Sorted left-CZ word IDs.
+
+        The lower word of each entangling pair, plus any word not
+        appearing in any pair.
+
+        Returns:
+            list[int]: Sorted word IDs.
+        """
+        ...
+
+    def lane_for_endpoints(
+        self, src: LocationAddress, dst: LocationAddress
+    ) -> Optional[LaneAddress]:
+        """Reverse-lookup: find the lane connecting ``src`` to ``dst``.
+
+        Searches SiteBus, WordBus, and ZoneBus lanes. Exploits the
+        LaneAddr encoding to narrow the search to
+        ``O(site_buses + word_buses + zone_buses)`` per direction.
+
+        Args:
+            src (LocationAddress): Source location.
+            dst (LocationAddress): Destination location.
+
+        Returns:
+            LaneAddress: The lane, or None if no lane connects them.
+        """
+        ...
 
     def check_zone(self, addr: ZoneAddress) -> Optional[str]:
         """Check whether a zone address is valid.

--- a/python/bloqade/lanes/layout/arch.py
+++ b/python/bloqade/lanes/layout/arch.py
@@ -21,8 +21,6 @@ from bloqade.lanes.layout.encoding import (
     LaneAddress,
     LocationAddress,
     MoveType,
-    SiteLaneAddress,
-    WordLaneAddress,
     ZoneAddress,
 )
 
@@ -80,38 +78,57 @@ class ArchSpec:
                     index += 1
         return dict(result)
 
-    @cached_property
-    def _lane_map(self) -> dict[tuple[LocationAddress, LocationAddress], LaneAddress]:
-        lane_map: dict[tuple[LocationAddress, LocationAddress], LaneAddress] = {}
+    def iter_all_lanes(self) -> Iterator[LaneAddress]:
+        """Yield every valid lane address in the architecture.
+
+        Enumerates site-bus, word-bus, and zone-bus lanes in both forward
+        and backward directions. Used by
+        :class:`~bloqade.lanes.layout.MoveMetricCalculator` to compute
+        max-duration bounds. Prefer ``get_lane_address(src, dst)`` for
+        single-pair lookups.
+        """
+        sites_per_word = self.sites_per_word
+
+        # Intra-zone: site buses and word buses.
         for zone_id, zone in enumerate(self._inner.zones):
             for bus_id, bus in enumerate(zone.site_buses):
-                bus_word_ids = zone.words_with_site_buses
-                for word_id in bus_word_ids:
+                for word_id in zone.words_with_site_buses:
                     for i in range(len(bus.src)):
                         for direction in (Direction.FORWARD, Direction.BACKWARD):
-                            lane_addr = SiteLaneAddress(
-                                zone_id=zone_id,
-                                word_id=word_id,
-                                site_id=bus.src[i],
-                                bus_id=bus_id,
-                                direction=direction,
+                            yield LaneAddress(
+                                MoveType.SITE,
+                                word_id,
+                                bus.src[i],
+                                bus_id,
+                                direction,
+                                zone_id,
                             )
-                            src, dst = self.get_endpoints(lane_addr)
-                            lane_map[(src, dst)] = lane_addr
             for bus_id, bus in enumerate(zone.word_buses):
                 for site_id in zone.sites_with_word_buses:
                     for word_id in bus.src:
                         for direction in (Direction.FORWARD, Direction.BACKWARD):
-                            lane_addr = WordLaneAddress(
-                                zone_id=zone_id,
-                                word_id=word_id,
-                                site_id=site_id,
-                                bus_id=bus_id,
-                                direction=direction,
+                            yield LaneAddress(
+                                MoveType.WORD,
+                                word_id,
+                                site_id,
+                                bus_id,
+                                direction,
+                                zone_id,
                             )
-                            src, dst = self.get_endpoints(lane_addr)
-                            lane_map[(src, dst)] = lane_addr
-        return lane_map
+
+        # Inter-zone: zone buses.
+        for bus_id, zb in enumerate(self._inner.zone_buses):
+            for (src_zone, src_word), (_dst_zone, _dst_word) in zip(zb.src, zb.dst):
+                for site_id in range(sites_per_word):
+                    for direction in (Direction.FORWARD, Direction.BACKWARD):
+                        yield LaneAddress(
+                            MoveType.ZONE,
+                            src_word,
+                            site_id,
+                            bus_id,
+                            direction,
+                            src_zone,
+                        )
 
     # ── Properties derived from Rust inner ──
 
@@ -126,16 +143,7 @@ class ArchSpec:
     @cached_property
     def _home_words(self) -> frozenset[int]:
         """Words that are 'home' (not CZ-staging) -- lower word_id in each pair."""
-        home: set[int] = set()
-        paired: set[int] = set()
-        for w_a, w_b in self._word_partner_map.items():
-            paired.add(w_a)
-            paired.add(w_b)
-            home.add(min(w_a, w_b))
-        # Unpaired words are also home
-        all_words = set(range(len(self.words)))
-        home |= all_words - paired
-        return frozenset(home)
+        return frozenset(self._inner.left_cz_word_ids())
 
     def is_home_position(self, addr: LocationAddress) -> bool:
         """True if this address is at a home (non-CZ-staging) word."""
@@ -145,26 +153,9 @@ class ArchSpec:
     def word_zone_map(self) -> dict[int, int]:
         """Map each word_id to the zone_id it belongs to.
 
-        Derived from each zone's entangling_pairs, word_buses, and
-        words_with_site_buses. A word may only appear in one zone; if
-        multiple zones claim the same word the first match wins.
+        Delegates to Rust ``ArchSpec.word_zone_map()``.
         """
-        mapping: dict[int, int] = {}
-        for zone_id, zone in enumerate(self._inner.zones):
-            for w_a, w_b in zone.entangling_pairs:
-                mapping.setdefault(w_a, zone_id)
-                mapping.setdefault(w_b, zone_id)
-            for bus in zone.word_buses:
-                for w in bus.src:
-                    mapping.setdefault(w, zone_id)
-                for w in bus.dst:
-                    mapping.setdefault(w, zone_id)
-            for w in zone.words_with_site_buses:
-                mapping.setdefault(w, zone_id)
-        # Any unreferenced word is (conservatively) assigned to zone 0.
-        for word_id in range(len(self.words)):
-            mapping.setdefault(word_id, 0)
-        return mapping
+        return self._inner.word_zone_map()
 
     @cached_property
     def home_sites(self) -> frozenset[LocationAddress]:
@@ -654,8 +645,14 @@ class ArchSpec:
     def get_lane_address(
         self, src: LocationAddress, dst: LocationAddress
     ) -> LaneAddress | None:
-        """Given an input tuple of locations, gets the lane (w/direction)."""
-        return self._lane_map.get((src, dst))
+        """Given an input tuple of locations, gets the lane (w/direction).
+
+        Delegates to Rust ``ArchSpec.lane_for_endpoints()``.
+        """
+        result = self._inner.lane_for_endpoints(src._inner, dst._inner)
+        if result is None:
+            return None
+        return LaneAddress.from_inner(result)
 
     def get_endpoints(
         self, lane_address: LaneAddress
@@ -698,12 +695,6 @@ class ArchSpec:
     def _word_partner_map(self) -> dict[int, int]:
         """Map word_id -> partner_word_id from each zone's entangling_pairs.
 
-        Iterates entangling_pairs on each zone and builds a bidirectional
-        word partner mapping.
+        Delegates to Rust ``ArchSpec.word_partner_map()``.
         """
-        partner_map: dict[int, int] = {}
-        for zone in self._inner.zones:
-            for w_a, w_b in zone.entangling_pairs:
-                partner_map[w_a] = w_b
-                partner_map[w_b] = w_a
-        return partner_map
+        return self._inner.word_partner_map()

--- a/python/bloqade/lanes/layout/move_metric.py
+++ b/python/bloqade/lanes/layout/move_metric.py
@@ -71,7 +71,7 @@ class MoveMetricCalculator:
         return duration_us
 
     def _iter_lane_addresses(self) -> tuple[Any, ...]:
-        return tuple(self.arch_spec._lane_map.values())
+        return tuple(self.arch_spec.iter_all_lanes())
 
     def _max_lane_duration_us(self, *, amplitude_delta: float = 1.0) -> float:
         normalized_amp = abs(float(amplitude_delta))

--- a/python/tests/layout/test_metrics.py
+++ b/python/tests/layout/test_metrics.py
@@ -11,7 +11,7 @@ def _build_move_calc() -> MoveMetricCalculator:
 
 def test_metrics_get_lane_duration_us_positive():
     move_calc = _build_move_calc()
-    lanes = tuple(move_calc.arch_spec._lane_map.values())
+    lanes = tuple(move_calc.arch_spec.iter_all_lanes())
     assert lanes
     for lane in lanes:
         duration = move_calc.get_lane_duration_us(lane)
@@ -20,7 +20,7 @@ def test_metrics_get_lane_duration_us_positive():
 
 def test_metrics_get_lane_duration_cost_bounds_and_anchor():
     move_calc = _build_move_calc()
-    lanes = tuple(move_calc.arch_spec._lane_map.values())
+    lanes = tuple(move_calc.arch_spec.iter_all_lanes())
     assert lanes
     costs = [move_calc.get_lane_duration_cost(lane) for lane in lanes]
     assert all(0.0 <= cost <= 1.0 for cost in costs)
@@ -29,7 +29,7 @@ def test_metrics_get_lane_duration_cost_bounds_and_anchor():
 
 def test_metrics_get_lane_duration_cost_monotonic():
     move_calc = _build_move_calc()
-    lanes = tuple(move_calc.arch_spec._lane_map.values())
+    lanes = tuple(move_calc.arch_spec.iter_all_lanes())
     assert lanes
     pairs = sorted(
         (move_calc.get_lane_duration_us(lane), move_calc.get_lane_duration_cost(lane))
@@ -41,7 +41,7 @@ def test_metrics_get_lane_duration_cost_monotonic():
 
 def test_metrics_get_lane_duration_cost_identical_durations_match():
     move_calc = _build_move_calc()
-    lanes = tuple(move_calc.arch_spec._lane_map.values())
+    lanes = tuple(move_calc.arch_spec.iter_all_lanes())
     assert lanes
 
     duration_groups: dict[float, list] = {}
@@ -61,7 +61,7 @@ def test_metrics_get_lane_duration_cost_identical_durations_match():
 
 def test_metrics_caching():
     move_calc = _build_move_calc()
-    lanes = tuple(move_calc.arch_spec._lane_map.values())
+    lanes = tuple(move_calc.arch_spec.iter_all_lanes())
     lane = lanes[0]
     d1 = move_calc.get_lane_duration_us(lane)
     d2 = move_calc.get_lane_duration_us(lane)


### PR DESCRIPTION
Cherry-pick of 62410bc (PR #485) onto release-0-8.

Closes #486.

The automated backport failed because the cherry-pick conflicted on `query.rs`, but PR #482 (the prerequisite Rust core changes) was already backported in #484. With #484 on the branch, #485 applies cleanly — no conflicts.

Contents: PyO3 bindings for `word_partner_map`, `word_zone_map`, `left_cz_word_ids`, `lane_for_endpoints` + Python-side migration replacing `_lane_map` dict and cached properties with Rust delegations.