### PR TITLE
feat(arch): split ZoneBuilder indexing into zone-local and cross-zone forms

### DIFF
--- a/python/bloqade/lanes/arch/arch_builder.py
+++ b/python/bloqade/lanes/arch/arch_builder.py
@@ -84,14 +84,21 @@ class _SiteGridQuery:
 
 
 class _WordGridQuery:
-    """Query word indices by grid region on a ZoneBuilder."""
+    """Query word indices by grid region on a ZoneBuilder.
+
+    Returns a plain ``list[int]`` of zone-local word IDs for intra-zone
+    operations like ``add_word_bus`` and ``add_entangling_pairs``.  For
+    cross-zone operations that need a name-qualified reference (e.g.,
+    ``ArchBuilder.connect``), use ``zone[...]`` directly — that form
+    returns ``(name, list[int])``.
+    """
 
     def __init__(self, zone: ZoneBuilder):
         self._zone = zone
 
     def __getitem__(
         self, key: tuple[slice | int | Sequence[int], slice | int | Sequence[int]]
-    ) -> tuple[str, list[int]]:
+    ) -> list[int]:
         x_idx, y_idx = key
         xs = _normalize_index(x_idx, self._zone._grid.num_x)
         ys = _normalize_index(y_idx, self._zone._grid.num_y)
@@ -100,7 +107,7 @@ class _WordGridQuery:
         for pos, word_id in self._zone._position_to_word.items():
             if pos in query_positions:
                 hits.add(word_id)
-        return (self._zone._name, sorted(hits))
+        return sorted(hits)
 
 
 # ── ZoneBuilder ──
@@ -284,14 +291,31 @@ class ZoneBuilder:
 
     @property
     def words(self) -> _WordGridQuery:
-        """Query word indices by grid region.
+        """Query word indices by grid region for intra-zone use.
 
-        Returns ``(zone_name, list[int])`` — the zone name and zone-local
-        word indices whose sites intersect the queried region.
+        Returns a plain ``list[int]`` of zone-local word indices whose
+        sites intersect the queried region — suitable for passing
+        directly to ``add_word_bus`` / ``add_entangling_pairs``.
 
-        The returned tuple can be passed directly to ``ArchBuilder.connect()``.
+        For cross-zone references (e.g. ``ArchBuilder.connect``), index
+        the zone itself (``zone[region]``) to get a name-qualified
+        ``(name, list[int])`` tuple.
         """
         return _WordGridQuery(self)
+
+    def __getitem__(
+        self, key: tuple[slice | int | Sequence[int], slice | int | Sequence[int]]
+    ) -> tuple[str, list[int]]:
+        """Query word indices by grid region, name-qualified for cross-zone use.
+
+        Returns ``(self.name, zone.words[key])`` so the result can be
+        passed directly to ``ArchBuilder.connect(src=..., dst=...)``,
+        which expects ``(zone_name, zone_local_indices)``.
+
+        For intra-zone use (passing indices to ``add_word_bus`` etc.),
+        use ``zone.words[key]`` which returns just the index list.
+        """
+        return (self._name, self.words[key])
 
     @property
     def sites(self) -> _SiteGridQuery:
@@ -355,7 +379,8 @@ class ArchBuilder:
 
         Args:
             src: ``(zone_name, zone_local_word_indices)`` — typically
-                from ``zone.words[...]``.
+                from ``zone[...]`` (indexing the zone itself, which
+                returns a name-qualified tuple).
             dst: ``(zone_name, zone_local_word_indices)`` — same format.
 
         Validates AOD Cartesian product across the two zone grids.

--- a/python/tests/arch/test_arch_builder.py
+++ b/python/tests/arch/test_arch_builder.py
@@ -132,9 +132,7 @@ class TestZoneBuilderQueries:
         zone.add_word(slice(2, 4), [0])
         zone.add_word(slice(0, 2), [1])
         zone.add_word(slice(2, 4), [1])
-        name, ids = zone.words[:, :]
-        assert name == "gate"
-        assert ids == [0, 1, 2, 3]
+        assert zone.words[:, :] == [0, 1, 2, 3]
 
     def test_words_query_first_column(self):
         zone = ZoneBuilder("gate", _make_grid(4, 2), word_shape=(2, 1))
@@ -142,15 +140,25 @@ class TestZoneBuilderQueries:
         zone.add_word(slice(2, 4), [0])
         zone.add_word(slice(0, 2), [1])
         zone.add_word(slice(2, 4), [1])
-        name, ids = zone.words[slice(0, 2), :]
-        assert name == "gate"
-        assert ids == [0, 2]
+        assert zone.words[slice(0, 2), :] == [0, 2]
 
-    def test_words_query_returns_zone_name(self):
+    def test_zone_getitem_returns_name_qualified(self):
         zone = ZoneBuilder("proc", _make_grid(2, 1), word_shape=(2, 1))
         zone.add_word(slice(0, 2), [0])
-        name, _ = zone.words[:, :]
+        name, ids = zone[:, :]
         assert name == "proc"
+        assert ids == [0]
+
+    def test_zone_getitem_matches_words_query(self):
+        """zone[key] and zone.words[key] return compatible views."""
+        zone = ZoneBuilder("gate", _make_grid(4, 2), word_shape=(2, 1))
+        zone.add_word(slice(0, 2), [0])
+        zone.add_word(slice(2, 4), [0])
+        zone.add_word(slice(0, 2), [1])
+        zone.add_word(slice(2, 4), [1])
+        name, ids = zone[slice(0, 2), :]
+        assert name == "gate"
+        assert ids == zone.words[slice(0, 2), :]
 
     def test_sites_query(self):
         zone = ZoneBuilder("gate", _make_grid(4, 2), word_shape=(3, 2))
@@ -265,7 +273,7 @@ class TestArchBuilder:
         arch = ArchBuilder()
         arch.add_zone(proc)
         arch.add_zone(mem)
-        arch.connect(src=proc.words[:, :], dst=mem.words[:, :])
+        arch.connect(src=proc[:, :], dst=mem[:, :])
         arch.add_mode("all", ["proc", "mem"])
         spec = arch.build()
         assert len(spec.zones) == 2
@@ -357,7 +365,7 @@ class TestArchBuilderMultiZoneOffsets:
         arch = ArchBuilder()
         arch.add_zone(proc)
         arch.add_zone(mem)
-        arch.connect(src=proc.words[:, :], dst=mem.words[:, :])
+        arch.connect(src=proc[:, :], dst=mem[:, :])
         arch.add_mode("all", ["proc", "mem"])
         return arch.build()
 
@@ -432,6 +440,6 @@ class TestBuilderEdgeCases:
         zone = ZoneBuilder("z", _make_grid(4, 2), word_shape=(2, 1))
         zone.add_word(slice(0, 2), [0])
         # Query a region with no words
-        name, ids = zone.words[:, 1]
-        assert name == "z"
-        assert ids == []
+        assert zone.words[:, 1] == []
+        # Name-qualified form still returns empty list
+        assert zone[:, 1] == ("z", [])


### PR DESCRIPTION
## Summary

Closes #498.

Splits the `ZoneBuilder` word-query indexing into two forms, so each is directly usable at the call site where it's needed:

| Expression | Returns | Drop-in for |
|---|---|---|
| `zone.words[region]` | `list[int]` | `add_word_bus`, `add_entangling_pairs` (intra-zone) |
| `zone[region]` | `tuple[str, list[int]]` | `ArchBuilder.connect(src=..., dst=...)` (cross-zone) |

Before: `zone.words[region]` always returned `(name, list[int])`, which meant users had to manually unpack for intra-zone ops that expect a plain `Sequence[int]`.

`ArchBuilder.connect` signature is unchanged — it still takes `tuple[str, Sequence[int]]`, it just gets that tuple from `zone[...]` now.

## Breaking change (Python API)

`zone.words[region]` now returns `list[int]` instead of `tuple[str, list[int]]`. Call sites that want the name qualifier should switch to `zone[region]`:

```python
# before
arch.connect(src=proc.words[:, :], dst=mem.words[:, :])
name, ids = zone.words[:, 0]

# after
arch.connect(src=proc[:, :], dst=mem[:, :])
name, ids = zone[:, 0]     # name-qualified
ids = zone.words[:, 0]     # zone-local only
```

Rust / C APIs unaffected.

## Test plan

- [x] `uv run pytest python/tests/arch` — 131 passed
- [x] Tests updated: covers both `zone.words[region]` (list form) and `zone[region]` (tuple form), plus regression test that the two forms return compatible indices

🤖 Generated with [Claude Code](https://claude.com/claude-code)