### PR TITLE
feat(arch): infer CZ entangling pairs from blockade_radius

### DIFF
--- a/crates/bloqade-lanes-bytecode-core/src/arch/query.rs
+++ b/crates/bloqade-lanes-bytecode-core/src/arch/query.rs
@@ -930,6 +930,7 @@ mod tests {
             paths: None,
             feed_forward: false,
             atom_reloading: false,
+            blockade_radius: None,
         }
     }
 

--- a/crates/bloqade-lanes-bytecode-core/src/arch/types.rs
+++ b/crates/bloqade-lanes-bytecode-core/src/arch/types.rs
@@ -112,6 +112,15 @@ pub struct ArchSpec {
     /// Defaults to `false` when absent in JSON.
     #[serde(default)]
     pub atom_reloading: bool,
+    /// Rydberg blockade radius in micrometers, if specified.
+    ///
+    /// When present, indicates that every entangling word pair in every
+    /// zone was derived from — and validated against — this radius (all
+    /// matching-index site pairs within radius, no crossed-index or
+    /// multi-partner cases). Absent means pairs were specified manually
+    /// without a geometric derivation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blockade_radius: Option<f64>,
 }
 
 impl ArchSpec {
@@ -135,6 +144,7 @@ impl ArchSpec {
         paths: Option<Vec<TransportPath>>,
         feed_forward: bool,
         atom_reloading: bool,
+        blockade_radius: Option<f64>,
     ) -> Result<Self, Vec<super::validate::ArchSpecError>> {
         let spec = Self {
             version,
@@ -145,6 +155,7 @@ impl ArchSpec {
             paths,
             feed_forward,
             atom_reloading,
+            blockade_radius,
         };
         spec.validate()?;
         Ok(spec)
@@ -474,6 +485,7 @@ mod tests {
             paths: None,
             feed_forward: false,
             atom_reloading: false,
+            blockade_radius: None,
         };
         assert_eq!(spec.sites_per_word(), 2);
     }
@@ -489,7 +501,47 @@ mod tests {
             paths: None,
             feed_forward: false,
             atom_reloading: false,
+            blockade_radius: None,
         };
         assert_eq!(spec.sites_per_word(), 0);
+    }
+
+    #[test]
+    fn blockade_radius_roundtrip_none() {
+        let spec = ArchSpec {
+            version: Version::new(2, 0),
+            words: vec![],
+            zones: vec![],
+            zone_buses: vec![],
+            modes: vec![],
+            paths: None,
+            feed_forward: false,
+            atom_reloading: false,
+            blockade_radius: None,
+        };
+        let json = serde_json::to_string(&spec).unwrap();
+        // None is skipped in serialization.
+        assert!(!json.contains("blockade_radius"));
+        let parsed: ArchSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.blockade_radius, None);
+    }
+
+    #[test]
+    fn blockade_radius_roundtrip_some() {
+        let spec = ArchSpec {
+            version: Version::new(2, 0),
+            words: vec![],
+            zones: vec![],
+            zone_buses: vec![],
+            modes: vec![],
+            paths: None,
+            feed_forward: false,
+            atom_reloading: false,
+            blockade_radius: Some(2.0),
+        };
+        let json = serde_json::to_string(&spec).unwrap();
+        assert!(json.contains("\"blockade_radius\":2.0"));
+        let parsed: ArchSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.blockade_radius, Some(2.0));
     }
 }

--- a/crates/bloqade-lanes-bytecode-core/src/arch/types.rs
+++ b/crates/bloqade-lanes-bytecode-core/src/arch/types.rs
@@ -114,11 +114,12 @@ pub struct ArchSpec {
     pub atom_reloading: bool,
     /// Rydberg blockade radius in micrometers, if specified.
     ///
-    /// When present, indicates that every entangling word pair in every
-    /// zone was derived from — and validated against — this radius (all
-    /// matching-index site pairs within radius, no crossed-index or
-    /// multi-partner cases). Absent means pairs were specified manually
-    /// without a geometric derivation.
+    /// Metadata: when present, this is the radius associated with the
+    /// architecture, typically used by consumers to interpret the
+    /// entangling word pairs. This struct does not itself enforce any
+    /// relationship between the pairs and the radius — derivation /
+    /// validation happens at the builder layer (see
+    /// `ZoneBuilder.set_blockade_radius` on the Python side).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub blockade_radius: Option<f64>,
 }

--- a/crates/bloqade-lanes-bytecode-core/src/arch/validate.rs
+++ b/crates/bloqade-lanes-bytecode-core/src/arch/validate.rs
@@ -578,6 +578,7 @@ mod tests {
             paths: None,
             feed_forward: false,
             atom_reloading: false,
+            blockade_radius: None,
         }
     }
 

--- a/crates/bloqade-lanes-bytecode-core/src/atom_state.rs
+++ b/crates/bloqade-lanes-bytecode-core/src/atom_state.rs
@@ -347,6 +347,7 @@ mod tests {
             paths: None,
             feed_forward: false,
             atom_reloading: false,
+            blockade_radius: None,
         }
     }
 

--- a/crates/bloqade-lanes-bytecode-core/src/bytecode/validate.rs
+++ b/crates/bloqade-lanes-bytecode-core/src/bytecode/validate.rs
@@ -918,6 +918,7 @@ mod tests {
             paths: None,
             feed_forward: false,
             atom_reloading: false,
+            blockade_radius: None,
         }
     }
 
@@ -1055,6 +1056,7 @@ mod tests {
             paths: None,
             feed_forward: false,
             atom_reloading: false,
+            blockade_radius: None,
         }
     }
 
@@ -1178,6 +1180,7 @@ mod tests {
             paths: None,
             feed_forward: false,
             atom_reloading: false,
+            blockade_radius: None,
         };
 
         let lane0 = make_lane(Direction::Forward, MoveType::SiteBus, 1, 0, 0);

--- a/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
@@ -902,7 +902,7 @@ pub struct PyArchSpec {
 #[pymethods]
 impl PyArchSpec {
     #[new]
-    #[pyo3(signature = (version, words, zones, zone_buses, modes, paths=None, feed_forward=false, atom_reloading=false))]
+    #[pyo3(signature = (version, words, zones, zone_buses, modes, paths=None, feed_forward=false, atom_reloading=false, blockade_radius=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         version: (u16, u16),
@@ -913,6 +913,7 @@ impl PyArchSpec {
         paths: Option<Vec<PyRef<'_, PyTransportPath>>>,
         feed_forward: bool,
         atom_reloading: bool,
+        blockade_radius: Option<f64>,
     ) -> PyResult<Self> {
         Ok(Self {
             inner: rs::ArchSpec {
@@ -924,6 +925,7 @@ impl PyArchSpec {
                 paths: paths.map(|v| v.iter().map(|p| p.inner.clone()).collect()),
                 feed_forward,
                 atom_reloading,
+                blockade_radius,
             },
         })
     }
@@ -1002,6 +1004,11 @@ impl PyArchSpec {
     #[getter]
     fn atom_reloading(&self) -> bool {
         self.inner.atom_reloading
+    }
+
+    #[getter]
+    fn blockade_radius(&self) -> Option<f64> {
+        self.inner.blockade_radius
     }
 
     #[getter]

--- a/python/bloqade/lanes/arch/arch_builder.py
+++ b/python/bloqade/lanes/arch/arch_builder.py
@@ -391,7 +391,9 @@ class ZoneBuilder:
         """
         n = self.num_words
         spw = self.sites_per_word
-        if n < 2:
+        if n * spw < 2:
+            # Need at least two sites anywhere in the zone before a pair
+            # can even exist; skip the KDTree build.
             return []
 
         from scipy.spatial import KDTree
@@ -417,8 +419,16 @@ class ZoneBuilder:
             w1, s1 = owners[i]
             w2, s2 = owners[j]
             if w1 == w2:
-                # Two sites of the same word — not a CZ pair relationship.
-                continue
+                # Two sites of the same word are within blockade — the
+                # layout can't support a CZ at this radius (it would
+                # entangle atoms inside a single word).
+                raise ValueError(
+                    f"Zone '{self._name}' blockade scan: word {w1} "
+                    f"has two intra-word sites ({s1} and {s2}) within "
+                    f"radius {radius_um} µm. Entanglement within a "
+                    f"single word is not allowed — tighten "
+                    f"blockade_radius or space the word's sites apart."
+                )
             # Canonicalize (a, b) with a < b; track which site-index of `a`
             # matches which of `b`.
             if w1 < w2:

--- a/python/bloqade/lanes/arch/arch_builder.py
+++ b/python/bloqade/lanes/arch/arch_builder.py
@@ -415,17 +415,7 @@ class ZoneBuilder:
         # site-indices fell within (and bail immediately on crossed-index).
         matching_sites: dict[tuple[int, int], set[int]] = {}
         radius_um = radius_nm / _NM_PER_UM
-        for i, j, *extra in raw_pairs:
-            if extra:
-                # KDTree.query_pairs currently emits 2-tuples only, but
-                # if scipy ever returns a larger cluster here the
-                # pair-wise classification below wouldn't apply.
-                raise ValueError(
-                    f"Zone '{self._name}' blockade scan: unexpected "
-                    f"cluster of {2 + len(extra)} sites within radius "
-                    f"{radius_um} µm (indices {(i, j, *extra)}); "
-                    f"query_pairs returned more than a pair."
-                )
+        for i, j in raw_pairs:
             w1, s1 = owners[i]
             w2, s2 = owners[j]
             if w1 == w2:

--- a/python/bloqade/lanes/arch/arch_builder.py
+++ b/python/bloqade/lanes/arch/arch_builder.py
@@ -28,6 +28,23 @@ if TYPE_CHECKING:
 
 # ── Helpers ──
 
+# All internal lengths are stored as integer nm counts so that distance
+# comparisons for blockade-radius inference are exact (no floating-point
+# edge cases when a site sits right at the radius boundary).
+_NM_PER_UM = 1000
+
+
+def _to_nm(value_um: float, name: str) -> int:
+    """Convert a µm length to an integer nm count, validating precision.
+
+    Raises ``ValueError`` if *value_um* has sub-nm resolution.
+    """
+    scaled = value_um * _NM_PER_UM
+    rounded = round(scaled)
+    if abs(scaled - rounded) > 1e-6:
+        raise ValueError(f"{name} {value_um} µm is not representable at 1 nm precision")
+    return int(rounded)
+
 
 def _normalize_index(idx: slice | int | Sequence[int], size: int) -> list[int]:
     """Convert a slice, int, or list to a sorted list of indices."""
@@ -131,6 +148,7 @@ class ZoneBuilder:
         self._site_buses: list[tuple[list[int], list[int]]] = []
         self._word_buses: list[tuple[list[int], list[int]]] = []
         self._entangling_pairs: list[tuple[int, int]] = []
+        self._blockade_radius_nm: int | None = None
 
     @property
     def name(self) -> str:
@@ -269,6 +287,10 @@ class ZoneBuilder:
 
         ``words_a[i]`` is paired with ``words_b[i]``. The two sequences
         must have the same length.
+
+        For most users, prefer :meth:`set_blockade_radius` — it derives
+        the pair list directly from geometry and validates the word
+        layout against the CZ-pairing convention.
         """
         if len(words_a) != len(words_b):
             raise ValueError(
@@ -281,6 +303,141 @@ class ZoneBuilder:
             if b < 0 or b >= n:
                 raise ValueError(f"word index {b} out of range [0, {n})")
             self._entangling_pairs.append((a, b))
+
+    @property
+    def blockade_radius(self) -> float | None:
+        """Rydberg blockade radius (µm) used to derive entangling pairs, or None."""
+        if self._blockade_radius_nm is None:
+            return None
+        return self._blockade_radius_nm / _NM_PER_UM
+
+    def set_blockade_radius(self, radius: float) -> None:
+        """Derive entangling word pairs from the Rydberg blockade radius.
+
+        Scans every pair of distinct words in the zone and classifies
+        each under the matching-site-index CZ convention:
+
+        * All matching-index site distances ``<= radius`` and all
+          non-matching-index site distances ``> radius``: valid CZ pair.
+        * Some matching-index distances within radius, some outside:
+          ``ValueError`` (partial blockade — the word layout doesn't
+          cleanly map onto the CZ-pairing convention).
+        * Some non-matching-index distance within radius (but the
+          matching-index one isn't): ``ValueError`` (crossed-index —
+          two words are arranged such that site ``i`` of one word sits
+          next to site ``j != i`` of the other).
+        * All distances outside radius: words ignore each other, no
+          pair recorded.
+
+        After classification, every word must appear in **at most one**
+        valid pair; multiple partners raise ``ValueError``.
+
+        This call **overwrites** ``_entangling_pairs`` with the scan
+        result. The radius is stored on the zone and flows into
+        ``ArchSpec.blockade_radius`` at build time.
+
+        Args:
+            radius: Blockade radius in micrometers. Must be positive and
+                representable at 1 nm precision.
+
+        Raises:
+            ValueError: if the layout is inconsistent with the radius
+                (partial blockade / crossed-index / multi-partner) or
+                if ``radius`` is not positive / nm-precise.
+        """
+        if radius <= 0:
+            raise ValueError(f"blockade_radius must be positive, got {radius}")
+        radius_nm = _to_nm(radius, "blockade_radius")
+        self._entangling_pairs = self._scan_blockade_pairs(radius_nm)
+        self._blockade_radius_nm = radius_nm
+
+    def _site_nm(self, word_id: int, site_id: int) -> tuple[int, int]:
+        """Physical (x, y) position of a site, in nm integers."""
+        x_idx, y_idx = self._words[word_id][site_id]
+        return (
+            _to_nm(self._grid.x_positions[x_idx], "grid x-position"),
+            _to_nm(self._grid.y_positions[y_idx], "grid y-position"),
+        )
+
+    def _scan_blockade_pairs(self, radius_nm: int) -> list[tuple[int, int]]:
+        """Scan word pairs and classify under the matching-index CZ rule.
+
+        Returns the list of valid ``(a, b)`` word pairs with ``a < b``.
+        Raises ``ValueError`` on partial blockade, crossed-index, or
+        multi-partner cases.
+        """
+        n = self.num_words
+        spw = self.sites_per_word
+        r2 = radius_nm * radius_nm
+
+        # Cache site positions (nm) for each word so _site_nm isn't called
+        # O(n^2 * spw^2) times.
+        site_positions: list[list[tuple[int, int]]] = [
+            [self._site_nm(w, s) for s in range(spw)] for w in range(n)
+        ]
+
+        def _sq_dist(p1: tuple[int, int], p2: tuple[int, int]) -> int:
+            dx = p1[0] - p2[0]
+            dy = p1[1] - p2[1]
+            return dx * dx + dy * dy
+
+        valid_pairs: list[tuple[int, int]] = []
+        for a in range(n):
+            for b in range(a + 1, n):
+                sites_a = site_positions[a]
+                sites_b = site_positions[b]
+                same_within = [
+                    _sq_dist(sites_a[i], sites_b[i]) <= r2 for i in range(spw)
+                ]
+                cross_within = any(
+                    _sq_dist(sites_a[i], sites_b[j]) <= r2
+                    for i in range(spw)
+                    for j in range(spw)
+                    if i != j
+                )
+
+                n_same_within = sum(same_within)
+                if n_same_within == spw and not cross_within:
+                    # Clean CZ pair.
+                    valid_pairs.append((a, b))
+                elif n_same_within == 0 and not cross_within:
+                    # Words are outside each other's blockade — skip.
+                    continue
+                elif 0 < n_same_within < spw:
+                    raise ValueError(
+                        f"Zone '{self._name}' blockade scan: words "
+                        f"{a} and {b} have {n_same_within}/{spw} "
+                        f"matching-index site pairs within radius "
+                        f"{radius_nm / _NM_PER_UM} µm (partial blockade). "
+                        f"The layout cannot be cleanly paired under the "
+                        f"CZ matching-index convention."
+                    )
+                else:
+                    # n_same_within == 0 and cross_within (or spw same
+                    # but cross also within — violates exclusivity).
+                    raise ValueError(
+                        f"Zone '{self._name}' blockade scan: words "
+                        f"{a} and {b} have a non-matching-index site "
+                        f"pair within radius {radius_nm / _NM_PER_UM} µm "
+                        f"(crossed-index blockade). The layout cannot "
+                        f"be cleanly paired under the CZ matching-index "
+                        f"convention."
+                    )
+
+        # Each word in at most one valid pair.
+        partner: dict[int, int] = {}
+        for a, b in valid_pairs:
+            for x, y in ((a, b), (b, a)):
+                if x in partner and partner[x] != y:
+                    raise ValueError(
+                        f"Zone '{self._name}' blockade scan: word {x} "
+                        f"has multiple blockade partners: "
+                        f"{partner[x]}, {y}. Tighten blockade_radius "
+                        f"or adjust the word layout."
+                    )
+                partner[x] = y
+
+        return valid_pairs
 
     @property
     def words(self) -> _WordGridQuery:
@@ -323,6 +480,7 @@ class ArchBuilder:
         ] = []
         self._modes: list[tuple[str, list[str]]] = []
         self._total_words: int = 0
+        self._blockade_radius: float | None = None
 
     def add_zone(self, zone: ZoneBuilder) -> int:
         """Add a zone. Returns zone_id. Assigns global word IDs.
@@ -387,6 +545,31 @@ class ArchBuilder:
             if z not in self._zone_name_to_id:
                 raise ValueError(f"Unknown zone: '{z}'")
         self._modes.append((name, list(zones)))
+
+    def set_blockade_radius(self, radius: float) -> None:
+        """Apply ``radius`` to every zone by calling
+        :meth:`ZoneBuilder.set_blockade_radius` on each.
+
+        Overwrites every zone's entangling pairs with the scan result.
+        The radius is stored on the builder and flows to
+        ``ArchSpec.blockade_radius`` at :meth:`build` time.
+
+        Args:
+            radius: Rydberg blockade radius in micrometers.
+
+        Raises:
+            ValueError: if any zone's layout is inconsistent with the
+                radius. The error message includes the zone name and
+                offending word IDs.
+        """
+        for zone in self._zones:
+            zone.set_blockade_radius(radius)
+        self._blockade_radius = radius
+
+    @property
+    def blockade_radius(self) -> float | None:
+        """Rydberg blockade radius (µm) applied to all zones, or None."""
+        return self._blockade_radius
 
     def build(self) -> ArchSpec:
         """Assemble the ArchSpec and validate via Rust.
@@ -474,4 +657,5 @@ class ArchBuilder:
             zones=tuple(rust_zones),
             modes=modes,
             zone_buses=zone_buses,
+            blockade_radius=self._blockade_radius,
         )

--- a/python/bloqade/lanes/arch/arch_builder.py
+++ b/python/bloqade/lanes/arch/arch_builder.py
@@ -429,22 +429,18 @@ class ZoneBuilder:
                     f"single word is not allowed — tighten "
                     f"blockade_radius or space the word's sites apart."
                 )
-            # Canonicalize (a, b) with a < b; track which site-index of `a`
-            # matches which of `b`.
-            if w1 < w2:
-                a, sa, b, sb = w1, s1, w2, s2
-            else:
-                a, sa, b, sb = w2, s2, w1, s1
-            if sa != sb:
+            if s1 != s2:
                 raise ValueError(
                     f"Zone '{self._name}' blockade scan: words "
-                    f"{a} and {b} have a non-matching-index site pair "
-                    f"(site {sa} ↔ site {sb}) within radius "
-                    f"{radius_um} µm (crossed-index blockade). The "
-                    f"layout cannot be cleanly paired under the CZ "
-                    f"matching-index convention."
+                    f"{min(w1, w2)} and {max(w1, w2)} have a "
+                    f"non-matching-index site pair (site {s1} ↔ "
+                    f"site {s2}) within radius {radius_um} µm "
+                    f"(crossed-index blockade). The layout cannot "
+                    f"be cleanly paired under the CZ matching-index "
+                    f"convention."
                 )
-            matching_sites.setdefault((a, b), set()).add(sa)
+            # Matching-index pair. Canonicalize only the word pair.
+            matching_sites.setdefault((min(w1, w2), max(w1, w2)), set()).add(s1)
 
         # A clean CZ pair has all `spw` matching-index site-pairs within
         # radius; fewer is a partial blockade.

--- a/python/bloqade/lanes/arch/arch_builder.py
+++ b/python/bloqade/lanes/arch/arch_builder.py
@@ -400,12 +400,8 @@ class ZoneBuilder:
 
         # Flatten every site into one KDTree, tracking (word, site_index)
         # so we can classify each returned pair.
-        positions: list[tuple[int, int]] = []
-        owners: list[tuple[int, int]] = []
-        for w in range(n):
-            for s in range(spw):
-                positions.append(self._site_nm(w, s))
-                owners.append((w, s))
+        positions = [self._site_nm(w, s) for w in range(n) for s in range(spw)]
+        owners = [(w, s) for w in range(n) for s in range(spw)]
 
         tree = KDTree(positions)
         # query_pairs returns (i, j) with i < j and dist(p_i, p_j) <= radius_nm.

--- a/python/bloqade/lanes/arch/arch_builder.py
+++ b/python/bloqade/lanes/arch/arch_builder.py
@@ -7,6 +7,7 @@ The high-level ``build_arch()`` function uses these internally.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -37,8 +38,11 @@ _NM_PER_UM = 1000
 def _to_nm(value_um: float, name: str) -> int:
     """Convert a µm length to an integer nm count, validating precision.
 
-    Raises ``ValueError`` if *value_um* has sub-nm resolution.
+    Raises ``ValueError`` if *value_um* is NaN, infinite, or has sub-nm
+    resolution.
     """
+    if not math.isfinite(value_um):
+        raise ValueError(f"{name} must be finite, got {value_um}")
     scaled = value_um * _NM_PER_UM
     rounded = round(scaled)
     if abs(scaled - rounded) > 1e-6:
@@ -291,6 +295,10 @@ class ZoneBuilder:
         For most users, prefer :meth:`set_blockade_radius` — it derives
         the pair list directly from geometry and validates the word
         layout against the CZ-pairing convention.
+
+        Any ``blockade_radius`` previously recorded on this zone (via
+        :meth:`set_blockade_radius`) is cleared, since a manual append
+        means the pair list is no longer purely radius-derived.
         """
         if len(words_a) != len(words_b):
             raise ValueError(
@@ -303,6 +311,9 @@ class ZoneBuilder:
             if b < 0 or b >= n:
                 raise ValueError(f"word index {b} out of range [0, {n})")
             self._entangling_pairs.append((a, b))
+        # Pair list was just manually modified; the cached radius no
+        # longer describes its full state.
+        self._blockade_radius_nm = None
 
     @property
     def blockade_radius(self) -> float | None:
@@ -322,10 +333,11 @@ class ZoneBuilder:
         * Some matching-index distances within radius, some outside:
           ``ValueError`` (partial blockade — the word layout doesn't
           cleanly map onto the CZ-pairing convention).
-        * Some non-matching-index distance within radius (but the
-          matching-index one isn't): ``ValueError`` (crossed-index —
-          two words are arranged such that site ``i`` of one word sits
-          next to site ``j != i`` of the other).
+        * Any non-matching-index site distance within radius (regardless
+          of whether the matching-index distances also fall within):
+          ``ValueError`` (crossed-index — two words are arranged such
+          that site ``i`` of one word sits next to site ``j != i`` of
+          the other, violating the exclusivity the convention requires).
         * All distances outside radius: words ignore each other, no
           pair recorded.
 
@@ -333,8 +345,13 @@ class ZoneBuilder:
         valid pair; multiple partners raise ``ValueError``.
 
         This call **overwrites** ``_entangling_pairs`` with the scan
-        result. The radius is stored on the zone and flows into
-        ``ArchSpec.blockade_radius`` at build time.
+        result and stores the radius on the zone.  To have it flow into
+        the final ``ArchSpec.blockade_radius``, either call
+        :meth:`ArchBuilder.set_blockade_radius` (which applies to every
+        zone and records the value at builder scope) or, for a single
+        zone already set via ``ZoneBuilder.set_blockade_radius``,
+        ``ArchBuilder.build()`` will pick up a consistent zone-level
+        radius automatically.
 
         Args:
             radius: Blockade radius in micrometers. Must be positive and
@@ -554,16 +571,35 @@ class ArchBuilder:
         The radius is stored on the builder and flows to
         ``ArchSpec.blockade_radius`` at :meth:`build` time.
 
+        The radius is validated up-front (positive, finite, nm-precise)
+        *before* any zone is touched, and the scan is run two-phase:
+        every zone is scanned before any pair list is overwritten, so
+        a layout error in a later zone cannot leave earlier zones in a
+        partially-updated state.
+
         Args:
             radius: Rydberg blockade radius in micrometers.
 
         Raises:
-            ValueError: if any zone's layout is inconsistent with the
-                radius. The error message includes the zone name and
-                offending word IDs.
+            ValueError: if ``radius`` itself is invalid (non-positive,
+                non-finite, sub-nm), or if any zone's layout is
+                inconsistent with the radius. The error message
+                includes the zone name and offending word IDs.
         """
-        for zone in self._zones:
-            zone.set_blockade_radius(radius)
+        if radius <= 0:
+            raise ValueError(f"blockade_radius must be positive, got {radius}")
+        radius_nm = _to_nm(radius, "blockade_radius")
+
+        # Phase 1: scan every zone.  Any zone-level failure raises here
+        # before we've mutated anything.
+        scan_results: list[list[tuple[int, int]]] = [
+            zone._scan_blockade_pairs(radius_nm) for zone in self._zones
+        ]
+
+        # Phase 2: commit.  No further failures possible.
+        for zone, pairs in zip(self._zones, scan_results):
+            zone._entangling_pairs = pairs
+            zone._blockade_radius_nm = radius_nm
         self._blockade_radius = radius
 
     @property
@@ -651,11 +687,57 @@ class ArchBuilder:
                 )
             )
 
-        # 5. Assemble and validate.
+        # 5. Determine the blockade radius to record on the ArchSpec.
+        # Builder-level radius (set via ArchBuilder.set_blockade_radius)
+        # takes precedence.  Otherwise, pick up a zone-level radius if
+        # every zone with a radius agrees on the value (if some zones
+        # have a radius and others don't, or zones disagree, error out
+        # — the single-spec blockade_radius field can't represent that).
+        blockade_radius = self._resolve_blockade_radius()
+
+        # 6. Assemble and validate.
         return ArchSpec.from_components(
             words=tuple(all_words),
             zones=tuple(rust_zones),
             modes=modes,
             zone_buses=zone_buses,
-            blockade_radius=self._blockade_radius,
+            blockade_radius=blockade_radius,
         )
+
+    def _resolve_blockade_radius(self) -> float | None:
+        """Pick the blockade_radius value for the final ArchSpec.
+
+        Precedence:
+
+        1. ``self._blockade_radius`` (builder-scope value from
+           :meth:`set_blockade_radius`) — always authoritative when set.
+        2. A unique radius shared by all zones that have one set; zones
+           without a radius must also agree (i.e., no zone opt-out) for
+           this branch to apply.
+        3. ``None`` otherwise.
+
+        Raises ``ValueError`` if zones disagree on a radius or if some
+        zones have a radius set and others don't.
+        """
+        if self._blockade_radius is not None:
+            return self._blockade_radius
+        zone_radii = [zone.blockade_radius for zone in self._zones]
+        if all(r is None for r in zone_radii):
+            return None
+        missing = [z.name for z, r in zip(self._zones, zone_radii) if r is None]
+        if missing:
+            raise ValueError(
+                "blockade_radius is set on some zones but not others; "
+                f"missing on: {missing}. Either call "
+                "ArchBuilder.set_blockade_radius to apply uniformly, "
+                "or leave it unset on every zone."
+            )
+        # Every zone has a non-None radius here.
+        present = [r for r in zone_radii if r is not None]
+        unique = sorted(set(present))
+        if len(unique) > 1:
+            raise ValueError(
+                f"Zones disagree on blockade_radius: {unique}. "
+                "The ArchSpec can only carry a single value."
+            )
+        return unique[0]

--- a/python/bloqade/lanes/arch/arch_builder.py
+++ b/python/bloqade/lanes/arch/arch_builder.py
@@ -192,6 +192,7 @@ class ZoneBuilder:
             _to_nm(y, "grid y-position") for y in grid.y_positions
         ]
         self._words: list[list[tuple[int, int]]] = []
+        self._word_has_site_bus: list[bool] = []
         self._position_to_word: dict[tuple[int, int], int] = {}
         self._site_buses: list[tuple[list[int], list[int]]] = []
         self._word_buses: list[tuple[list[int], list[int]]] = []
@@ -232,11 +233,25 @@ class ZoneBuilder:
         self,
         x_sites: slice | Sequence[int],
         y_sites: slice | Sequence[int],
+        *,
+        has_site_bus: bool = True,
     ) -> int:
         """Add a word occupying the given grid positions.
 
         The number of x-indices and y-indices must match word_shape.
         Grid positions must not overlap with any existing word.
+
+        Args:
+            x_sites: Grid x-indices for the word's sites.
+            y_sites: Grid y-indices for the word's sites.
+            has_site_bus: Whether this word participates in site-bus
+                transport. Feeds the zone-level
+                ``words_with_site_buses`` list on the final ``ArchSpec``
+                — only words with ``has_site_bus=True`` are eligible to
+                have site buses applied to them. Defaults to ``True``,
+                which preserves the historical "all words opt-in"
+                behavior. Set to ``False`` on storage words that
+                shouldn't participate in site-level routing.
 
         Returns:
             Zone-local word index.
@@ -283,6 +298,7 @@ class ZoneBuilder:
 
         word_id = len(self._words)
         self._words.append(positions)
+        self._word_has_site_bus.append(has_site_bus)
         for pos in positions:
             self._position_to_word[pos] = word_id
         return word_id
@@ -1108,8 +1124,18 @@ class ArchBuilder:
                 )
                 for s, d in zone._word_buses
             ]
+            # Only words flagged at add_word(has_site_bus=True) are
+            # eligible for site-bus transport. Default is True, so the
+            # historical "all words opt-in when any site bus exists"
+            # behavior is preserved unless the caller overrides.
             words_with_site_buses = (
-                [offset + w for w in range(zone.num_words)] if site_buses else []
+                [
+                    offset + w
+                    for w in range(zone.num_words)
+                    if zone._word_has_site_bus[w]
+                ]
+                if site_buses
+                else []
             )
             sites_with_word_buses = (
                 list(range(zone.sites_per_word)) if word_buses else []

--- a/python/bloqade/lanes/arch/arch_builder.py
+++ b/python/bloqade/lanes/arch/arch_builder.py
@@ -382,66 +382,79 @@ class ZoneBuilder:
         Returns the list of valid ``(a, b)`` word pairs with ``a < b``.
         Raises ``ValueError`` on partial blockade, crossed-index, or
         multi-partner cases.
+
+        Uses ``scipy.spatial.KDTree.query_pairs`` to enumerate only the
+        site pairs within ``radius_nm`` (O(n log n + k) over all sites
+        in the zone, rather than O(n² · spw²) all-to-all).  Coordinates
+        are fed in as nm integers so the ``<= radius_nm`` cutoff lands
+        on exact boundaries without float drift.
         """
         n = self.num_words
         spw = self.sites_per_word
-        r2 = radius_nm * radius_nm
+        if n < 2:
+            return []
 
-        # Cache site positions (nm) for each word so _site_nm isn't called
-        # O(n^2 * spw^2) times.
-        site_positions: list[list[tuple[int, int]]] = [
-            [self._site_nm(w, s) for s in range(spw)] for w in range(n)
-        ]
+        from scipy.spatial import KDTree
 
-        def _sq_dist(p1: tuple[int, int], p2: tuple[int, int]) -> int:
-            dx = p1[0] - p2[0]
-            dy = p1[1] - p2[1]
-            return dx * dx + dy * dy
+        # Flatten every site into one KDTree, tracking (word, site_index)
+        # so we can classify each returned pair.
+        positions: list[tuple[int, int]] = []
+        owners: list[tuple[int, int]] = []
+        for w in range(n):
+            for s in range(spw):
+                positions.append(self._site_nm(w, s))
+                owners.append((w, s))
 
-        valid_pairs: list[tuple[int, int]] = []
-        for a in range(n):
-            for b in range(a + 1, n):
-                sites_a = site_positions[a]
-                sites_b = site_positions[b]
-                same_within = [
-                    _sq_dist(sites_a[i], sites_b[i]) <= r2 for i in range(spw)
-                ]
-                cross_within = any(
-                    _sq_dist(sites_a[i], sites_b[j]) <= r2
-                    for i in range(spw)
-                    for j in range(spw)
-                    if i != j
+        tree = KDTree(positions)
+        # query_pairs returns (i, j) with i < j and dist(p_i, p_j) <= radius_nm.
+        raw_pairs = tree.query_pairs(radius_nm, output_type="set")
+
+        # For each cross-word pair within the radius, record which matching
+        # site-indices fell within (and bail immediately on crossed-index).
+        matching_sites: dict[tuple[int, int], set[int]] = {}
+        radius_um = radius_nm / _NM_PER_UM
+        for i, j in raw_pairs:
+            w1, s1 = owners[i]
+            w2, s2 = owners[j]
+            if w1 == w2:
+                # Two sites of the same word — not a CZ pair relationship.
+                continue
+            # Canonicalize (a, b) with a < b; track which site-index of `a`
+            # matches which of `b`.
+            if w1 < w2:
+                a, sa, b, sb = w1, s1, w2, s2
+            else:
+                a, sa, b, sb = w2, s2, w1, s1
+            if sa != sb:
+                raise ValueError(
+                    f"Zone '{self._name}' blockade scan: words "
+                    f"{a} and {b} have a non-matching-index site pair "
+                    f"(site {sa} ↔ site {sb}) within radius "
+                    f"{radius_um} µm (crossed-index blockade). The "
+                    f"layout cannot be cleanly paired under the CZ "
+                    f"matching-index convention."
                 )
+            matching_sites.setdefault((a, b), set()).add(sa)
 
-                n_same_within = sum(same_within)
-                if n_same_within == spw and not cross_within:
-                    # Clean CZ pair.
-                    valid_pairs.append((a, b))
-                elif n_same_within == 0 and not cross_within:
-                    # Words are outside each other's blockade — skip.
-                    continue
-                elif 0 < n_same_within < spw:
-                    raise ValueError(
-                        f"Zone '{self._name}' blockade scan: words "
-                        f"{a} and {b} have {n_same_within}/{spw} "
-                        f"matching-index site pairs within radius "
-                        f"{radius_nm / _NM_PER_UM} µm (partial blockade). "
-                        f"The layout cannot be cleanly paired under the "
-                        f"CZ matching-index convention."
-                    )
-                else:
-                    # n_same_within == 0 and cross_within (or spw same
-                    # but cross also within — violates exclusivity).
-                    raise ValueError(
-                        f"Zone '{self._name}' blockade scan: words "
-                        f"{a} and {b} have a non-matching-index site "
-                        f"pair within radius {radius_nm / _NM_PER_UM} µm "
-                        f"(crossed-index blockade). The layout cannot "
-                        f"be cleanly paired under the CZ matching-index "
-                        f"convention."
-                    )
+        # A clean CZ pair has all `spw` matching-index site-pairs within
+        # radius; fewer is a partial blockade.
+        valid_pairs: list[tuple[int, int]] = []
+        for (a, b), sites in matching_sites.items():
+            if len(sites) != spw:
+                raise ValueError(
+                    f"Zone '{self._name}' blockade scan: words "
+                    f"{a} and {b} have {len(sites)}/{spw} "
+                    f"matching-index site pairs within radius "
+                    f"{radius_um} µm (partial blockade). The layout "
+                    f"cannot be cleanly paired under the CZ "
+                    f"matching-index convention."
+                )
+            valid_pairs.append((a, b))
 
-        # Each word in at most one valid pair.
+        # Deterministic order (`query_pairs` returns a set).
+        valid_pairs.sort()
+
+        # Each word must appear in at most one valid pair.
         partner: dict[int, int] = {}
         for a, b in valid_pairs:
             for x, y in ((a, b), (b, a)):

--- a/python/bloqade/lanes/arch/arch_builder.py
+++ b/python/bloqade/lanes/arch/arch_builder.py
@@ -415,7 +415,17 @@ class ZoneBuilder:
         # site-indices fell within (and bail immediately on crossed-index).
         matching_sites: dict[tuple[int, int], set[int]] = {}
         radius_um = radius_nm / _NM_PER_UM
-        for i, j in raw_pairs:
+        for i, j, *extra in raw_pairs:
+            if extra:
+                # KDTree.query_pairs currently emits 2-tuples only, but
+                # if scipy ever returns a larger cluster here the
+                # pair-wise classification below wouldn't apply.
+                raise ValueError(
+                    f"Zone '{self._name}' blockade scan: unexpected "
+                    f"cluster of {2 + len(extra)} sites within radius "
+                    f"{radius_um} µm (indices {(i, j, *extra)}); "
+                    f"query_pairs returned more than a pair."
+                )
             w1, s1 = owners[i]
             w2, s2 = owners[j]
             if w1 == w2:

--- a/python/bloqade/lanes/bytecode/_native.pyi
+++ b/python/bloqade/lanes/bytecode/_native.pyi
@@ -619,6 +619,9 @@ class ArchSpec:
         paths (Optional[list[TransportPath]]): AOD transport paths, default = None.
         feed_forward (bool): Whether the device supports mid-circuit measurement. Default = False.
         atom_reloading (bool): Whether the device supports atom reloading. Default = False.
+        blockade_radius (Optional[float]): Rydberg blockade radius (µm). When set, the ArchSpec
+            was constructed from a scan over this radius and entangling pairs were
+            validated against the matching-site-index convention. Default = None.
     """
 
     def __init__(
@@ -631,6 +634,7 @@ class ArchSpec:
         paths: Optional[list[TransportPath]] = None,
         feed_forward: bool = False,
         atom_reloading: bool = False,
+        blockade_radius: Optional[float] = None,
     ) -> None: ...
     @staticmethod
     def from_json(json: str) -> ArchSpec:
@@ -716,6 +720,11 @@ class ArchSpec:
     @property
     def atom_reloading(self) -> bool:
         """Whether the device supports reloading atoms after initial fill."""
+        ...
+
+    @property
+    def blockade_radius(self) -> Optional[float]:
+        """Rydberg blockade radius (µm), or None if pairs were specified manually."""
         ...
 
     @property

--- a/python/bloqade/lanes/bytecode/_native.pyi
+++ b/python/bloqade/lanes/bytecode/_native.pyi
@@ -619,9 +619,10 @@ class ArchSpec:
         paths (Optional[list[TransportPath]]): AOD transport paths, default = None.
         feed_forward (bool): Whether the device supports mid-circuit measurement. Default = False.
         atom_reloading (bool): Whether the device supports atom reloading. Default = False.
-        blockade_radius (Optional[float]): Rydberg blockade radius (µm). When set, the ArchSpec
-            was constructed from a scan over this radius and entangling pairs were
-            validated against the matching-site-index convention. Default = None.
+        blockade_radius (Optional[float]): Rydberg blockade radius (µm). When set, this
+            indicates the radius associated with the architecture and is typically
+            used to interpret entangling pairs. It is metadata; this constructor
+            does not itself verify that the pairs match the radius. Default = None.
     """
 
     def __init__(
@@ -724,7 +725,7 @@ class ArchSpec:
 
     @property
     def blockade_radius(self) -> Optional[float]:
-        """Rydberg blockade radius (µm), or None if pairs were specified manually."""
+        """Rydberg blockade radius (µm), or None if not provided."""
         ...
 
     @property

--- a/python/bloqade/lanes/layout/arch.py
+++ b/python/bloqade/lanes/layout/arch.py
@@ -186,8 +186,16 @@ class ArchSpec(RustWrapper[_RustArchSpec]):
 
     @property
     def blockade_radius(self) -> float | None:
-        """Rydberg blockade radius (µm), or None if entangling pairs were
-        specified manually without a geometric derivation."""
+        """Rydberg blockade radius (µm), or ``None`` if not provided.
+
+        This is metadata — when present, it indicates the radius
+        associated with the architecture and is typically used to
+        interpret the entangling pairs.  It is **not** independently
+        verified at the ArchSpec level; use
+        :meth:`ZoneBuilder.set_blockade_radius` /
+        :meth:`ArchBuilder.set_blockade_radius` if you want the pair
+        list to be derived from and checked against a radius.
+        """
         return self._inner.blockade_radius
 
     @cached_property

--- a/python/bloqade/lanes/layout/arch.py
+++ b/python/bloqade/lanes/layout/arch.py
@@ -184,6 +184,12 @@ class ArchSpec(RustWrapper[_RustArchSpec]):
         """Whether the device supports reloading atoms after initial fill."""
         return self._inner.atom_reloading
 
+    @property
+    def blockade_radius(self) -> float | None:
+        """Rydberg blockade radius (µm), or None if entangling pairs were
+        specified manually without a geometric derivation."""
+        return self._inner.blockade_radius
+
     @cached_property
     def site_buses(self) -> tuple[SiteBus, ...]:
         """Aggregate all site buses across all zones.
@@ -226,6 +232,7 @@ class ArchSpec(RustWrapper[_RustArchSpec]):
         paths: dict[LaneAddress, tuple[tuple[float, float], ...]] | None = None,
         feed_forward: bool = False,
         atom_reloading: bool = False,
+        blockade_radius: float | None = None,
     ) -> ArchSpec:
         """Construct an ArchSpec from Python component types."""
 
@@ -255,6 +262,7 @@ class ArchSpec(RustWrapper[_RustArchSpec]):
             paths=rust_paths,
             feed_forward=feed_forward,
             atom_reloading=atom_reloading,
+            blockade_radius=blockade_radius,
         )
         return cls(inner)
 

--- a/python/tests/arch/test_arch_builder.py
+++ b/python/tests/arch/test_arch_builder.py
@@ -528,6 +528,17 @@ class TestZoneBuilderBlockadeRadius:
         with pytest.raises(ValueError, match="multiple blockade partners"):
             zone.set_blockade_radius(1.5)
 
+    def test_intra_word_blockade_raises(self):
+        """Two sites of the same word within radius — invalid layout."""
+        # Word with 2 sites at x=0 and x=1; radius 1.5 puts them within
+        # blockade of each other. That would entangle atoms inside the
+        # same word, which isn't allowed.
+        grid = Grid.from_positions([0.0, 1.0], [0.0])
+        zone = ZoneBuilder("z", grid, word_shape=(2, 1))
+        zone.add_word([0, 1], [0])
+        with pytest.raises(ValueError, match="intra-word sites"):
+            zone.set_blockade_radius(1.5)
+
     def test_non_positive_radius_raises(self):
         zone = _make_gate_zone()
         with pytest.raises(ValueError, match="must be positive"):

--- a/python/tests/arch/test_arch_builder.py
+++ b/python/tests/arch/test_arch_builder.py
@@ -180,6 +180,30 @@ class TestZoneBuilderAddWord:
         )
         assert zone.sites_per_word == 6
 
+    def test_has_site_bus_default_true(self):
+        zone = ZoneBuilder(
+            "gate",
+            _make_grid(4, 1),
+            word_shape=(2, 1),
+            x_clearance=_DEFAULT_CL,
+            y_clearance=_DEFAULT_CL,
+        )
+        zone.add_word(slice(0, 2), [0])
+        zone.add_word(slice(2, 4), [0])
+        assert zone._word_has_site_bus == [True, True]
+
+    def test_has_site_bus_explicit_false(self):
+        zone = ZoneBuilder(
+            "gate",
+            _make_grid(4, 1),
+            word_shape=(2, 1),
+            x_clearance=_DEFAULT_CL,
+            y_clearance=_DEFAULT_CL,
+        )
+        zone.add_word(slice(0, 2), [0], has_site_bus=False)
+        zone.add_word(slice(2, 4), [0])
+        assert zone._word_has_site_bus == [False, True]
+
 
 # ── ZoneBuilder: grid queries ──
 
@@ -531,6 +555,45 @@ class TestArchBuilder:
         arch.add_mode("all", ["gate"])
         spec = arch.build()
         assert spec.zones[0].entangling_pairs == [(0, 1)]
+
+    def test_words_with_site_buses_default_all(self):
+        """Default has_site_bus=True → every word is in words_with_site_buses."""
+        zone = ZoneBuilder(
+            "gate",
+            _make_grid(4, 1),
+            word_shape=(2, 1),
+            x_clearance=_DEFAULT_CL,
+            y_clearance=_DEFAULT_CL,
+        )
+        zone.add_word(slice(0, 2), [0])
+        zone.add_word(slice(2, 4), [0])
+        zone.add_site_bus(src=[0], dst=[1])
+
+        arch = ArchBuilder()
+        arch.add_zone(zone)
+        arch.add_mode("all", ["gate"])
+        spec = arch.build()
+        assert spec.zones[0].words_with_site_buses == [0, 1]
+
+    def test_words_with_site_buses_respects_opt_out(self):
+        """has_site_bus=False excludes that word from words_with_site_buses."""
+        zone = ZoneBuilder(
+            "gate",
+            _make_grid(4, 1),
+            word_shape=(2, 1),
+            x_clearance=_DEFAULT_CL,
+            y_clearance=_DEFAULT_CL,
+        )
+        zone.add_word(slice(0, 2), [0])
+        zone.add_word(slice(2, 4), [0], has_site_bus=False)
+        zone.add_site_bus(src=[0], dst=[1])
+
+        arch = ArchBuilder()
+        arch.add_zone(zone)
+        arch.add_mode("all", ["gate"])
+        spec = arch.build()
+        # Only word 0 opted in.
+        assert spec.zones[0].words_with_site_buses == [0]
 
     def test_rust_validation_passes(self):
         """Build a realistic arch and verify Rust validation."""

--- a/python/tests/arch/test_arch_builder.py
+++ b/python/tests/arch/test_arch_builder.py
@@ -435,3 +435,153 @@ class TestBuilderEdgeCases:
         name, ids = zone.words[:, 1]
         assert name == "z"
         assert ids == []
+
+
+# ── ZoneBuilder: blockade-radius inference ──
+
+
+def _gate_zone_grid() -> Grid:
+    """Gate-zone style grid: 3 CZ pairs on one row, intra-pair 2 µm, inter-pair 8 µm."""
+    # x=[0, 2, 10, 12, 20, 22], y=[0]
+    xs = [0.0, 2.0, 10.0, 12.0, 20.0, 22.0]
+    ys = [0.0]
+    return Grid.from_positions(xs, ys)
+
+
+def _make_gate_zone() -> ZoneBuilder:
+    """Zone with 6 interleaved CZ-pair words (word_shape (1, 1))."""
+    zone = ZoneBuilder("gate", _gate_zone_grid(), word_shape=(1, 1))
+    # 6 words, one per grid x-position.
+    for x in range(6):
+        zone.add_word([x], [0])
+    return zone
+
+
+class TestZoneBuilderBlockadeRadius:
+    def test_derives_interleaved_cz_pairs(self):
+        zone = _make_gate_zone()
+        zone.set_blockade_radius(2.0)
+        # Pairs: (0,1) at dist 2, (2,3) at 2, (4,5) at 2.
+        # Inter-pair dist = 8, outside radius.
+        assert zone._entangling_pairs == [(0, 1), (2, 3), (4, 5)]
+
+    def test_blockade_radius_property(self):
+        zone = _make_gate_zone()
+        assert zone.blockade_radius is None
+        zone.set_blockade_radius(2.0)
+        assert zone.blockade_radius == 2.0
+
+    def test_overwrites_explicit_pairs(self):
+        zone = _make_gate_zone()
+        # Bogus pre-existing pair — should be replaced by the scan.
+        zone.add_entangling_pairs([0], [3])
+        zone.set_blockade_radius(2.0)
+        assert zone._entangling_pairs == [(0, 1), (2, 3), (4, 5)]
+
+    def test_no_pairs_when_radius_too_tight(self):
+        zone = _make_gate_zone()
+        zone.set_blockade_radius(1.0)  # all gaps > 1 µm
+        assert zone._entangling_pairs == []
+        assert zone.blockade_radius == 1.0
+
+    def test_partial_blockade_raises(self):
+        """2-site words where only one matching pair is within radius."""
+        # Grid: x=[0, 10, 2, 12] giving two words with sites at x-indices
+        # (0, 1) and (2, 3) → positions [(0, 10)] and [(2, 12)]. Same-index
+        # distances: |0-2|=2, |10-12|=2 → all within radius=3 → clean pair.
+        # For the partial case, make word B's second site far:
+        # x=[0, 10, 2, 30] → B = [2, 30]. Same-index dist: 2, 20.
+        grid = Grid.from_positions([0.0, 10.0, 2.0, 30.0], [0.0])
+        zone = ZoneBuilder("z", grid, word_shape=(2, 1))
+        zone.add_word([0, 1], [0])
+        zone.add_word([2, 3], [0])
+        with pytest.raises(ValueError, match="partial blockade"):
+            zone.set_blockade_radius(3.0)
+
+    def test_crossed_index_raises(self):
+        """Two words where site 0 of A is near site 1 of B (not site 0)."""
+        # Grid x=[0, 5, 1, 100]. Word A at indices [0, 1] → sites (0, 5).
+        # Word B at indices [2, 3] → sites (1, 100).
+        # Matching: |0-1|=1, |5-100|=95 → not all within radius 2.
+        # Crossed: |0-100|=100, |5-1|=4 → not within radius 2 either.
+        # Need to construct a case where crossed IS within but matching
+        # IS NOT.
+        # Grid x=[0, 100, 101, 5]. Word A at indices [0, 1] → sites (0, 100).
+        # Word B at indices [2, 3] → sites (101, 5).
+        # Matching: |0-101|=101, |100-5|=95 → both outside radius 2.
+        # Crossed: |0-5|=5 → outside, |100-101|=1 → INSIDE.
+        # So site_a[0] paired with site_b[1] — crossed index.
+        grid = Grid.from_positions([0.0, 100.0, 101.0, 5.0], [0.0])
+        zone = ZoneBuilder("z", grid, word_shape=(2, 1))
+        zone.add_word([0, 1], [0])
+        zone.add_word([2, 3], [0])
+        with pytest.raises(ValueError, match="crossed-index"):
+            zone.set_blockade_radius(2.0)
+
+    def test_multi_partner_raises(self):
+        """Three words all mutually within radius — ambiguous pairing."""
+        # 3 words at x=[0, 1, 2], single site each. Radius 1.5: all within.
+        grid = Grid.from_positions([0.0, 1.0, 2.0], [0.0])
+        zone = ZoneBuilder("z", grid, word_shape=(1, 1))
+        for x in range(3):
+            zone.add_word([x], [0])
+        with pytest.raises(ValueError, match="multiple blockade partners"):
+            zone.set_blockade_radius(1.5)
+
+    def test_non_positive_radius_raises(self):
+        zone = _make_gate_zone()
+        with pytest.raises(ValueError, match="must be positive"):
+            zone.set_blockade_radius(0.0)
+        with pytest.raises(ValueError, match="must be positive"):
+            zone.set_blockade_radius(-1.0)
+
+    def test_non_nm_precise_radius_raises(self):
+        zone = _make_gate_zone()
+        with pytest.raises(ValueError, match="1 nm precision"):
+            zone.set_blockade_radius(1.2345)  # sub-nm
+
+
+class TestArchBuilderBlockadeRadius:
+    def test_applies_to_all_zones(self):
+        gate_a = _make_gate_zone()
+        gate_b = _make_gate_zone()
+        # Second zone needs distinct name and y_offset to avoid clashes
+        gate_b._name = "gate_b"
+        arch = ArchBuilder()
+        arch.add_zone(gate_a)
+        arch.add_zone(gate_b)
+        arch.set_blockade_radius(2.0)
+        assert gate_a._entangling_pairs == [(0, 1), (2, 3), (4, 5)]
+        assert gate_b._entangling_pairs == [(0, 1), (2, 3), (4, 5)]
+        assert arch.blockade_radius == 2.0
+
+    def test_arch_spec_exposes_blockade_radius(self):
+        zone = _make_gate_zone()
+        arch = ArchBuilder()
+        arch.add_zone(zone)
+        arch.add_mode("all", ["gate"])
+        arch.set_blockade_radius(2.0)
+        spec = arch.build()
+        assert spec.blockade_radius == 2.0
+
+    def test_build_without_blockade_radius_is_none(self):
+        zone = _make_gate_zone()
+        zone.add_entangling_pairs([0, 2, 4], [1, 3, 5])
+        arch = ArchBuilder()
+        arch.add_zone(zone)
+        arch.add_mode("all", ["gate"])
+        spec = arch.build()
+        assert spec.blockade_radius is None
+
+    def test_set_before_add_zone_has_no_effect(self):
+        """set_blockade_radius operates on currently-added zones; zones added
+        later are not automatically scanned."""
+        arch = ArchBuilder()
+        arch.set_blockade_radius(2.0)  # no zones yet
+        zone = _make_gate_zone()
+        arch.add_zone(zone)
+        # The radius is stored; zones added afterward were not scanned.
+        assert zone._entangling_pairs == []
+        # Caller can re-set to apply:
+        arch.set_blockade_radius(2.0)
+        assert zone._entangling_pairs == [(0, 1), (2, 3), (4, 5)]

--- a/python/tests/arch/test_arch_builder.py
+++ b/python/tests/arch/test_arch_builder.py
@@ -545,7 +545,7 @@ class TestArchBuilderBlockadeRadius:
     def test_applies_to_all_zones(self):
         gate_a = _make_gate_zone()
         gate_b = _make_gate_zone()
-        # Second zone needs distinct name and y_offset to avoid clashes
+        # Second zone needs a distinct name to avoid clashes
         gate_b._name = "gate_b"
         arch = ArchBuilder()
         arch.add_zone(gate_a)
@@ -585,3 +585,84 @@ class TestArchBuilderBlockadeRadius:
         # Caller can re-set to apply:
         arch.set_blockade_radius(2.0)
         assert zone._entangling_pairs == [(0, 1), (2, 3), (4, 5)]
+
+    def test_nan_radius_raises(self):
+        """NaN / Inf on ArchBuilder.set_blockade_radius are rejected up-front."""
+        import math
+
+        arch = ArchBuilder()  # no zones: validation must still fire
+        with pytest.raises(ValueError, match="must be positive"):
+            arch.set_blockade_radius(0.0)
+        with pytest.raises(ValueError, match="must be finite"):
+            arch.set_blockade_radius(math.nan)
+        with pytest.raises(ValueError, match="must be finite"):
+            arch.set_blockade_radius(math.inf)
+
+    def test_rollback_on_partial_failure(self):
+        """If a later zone's scan fails, earlier zones must stay untouched."""
+        good = _make_gate_zone()
+        # Give `good` an existing explicit pairing so we can see whether
+        # the failed set_blockade_radius call overwrote it.
+        good.add_entangling_pairs([0, 2, 4], [1, 3, 5])
+        # A zone whose layout fails the scan under radius=1.5.
+        bad = ZoneBuilder("bad", Grid.from_positions([0.0, 1.0, 2.0], [0.0]), (1, 1))
+        for x in range(3):
+            bad.add_word([x], [0])
+        # 3 mutually-within-radius words → multi-partner ValueError on bad.
+        arch = ArchBuilder()
+        arch.add_zone(good)
+        arch.add_zone(bad)
+        with pytest.raises(ValueError, match="multiple blockade partners"):
+            arch.set_blockade_radius(1.5)
+        # `good` must still have its original pairs.
+        assert good._entangling_pairs == [(0, 1), (2, 3), (4, 5)]
+        # And no radius recorded on the builder (the call failed).
+        assert arch.blockade_radius is None
+
+    def test_zone_radius_flows_to_spec(self):
+        """A radius set only on a ZoneBuilder propagates to ArchSpec."""
+        zone = _make_gate_zone()
+        zone.set_blockade_radius(2.0)
+        arch = ArchBuilder()
+        arch.add_zone(zone)
+        arch.add_mode("all", ["gate"])
+        spec = arch.build()
+        assert spec.blockade_radius == 2.0
+
+    def test_inconsistent_zone_radii_raises(self):
+        """Two zones with different radii cannot be composed into one spec."""
+        z1 = _make_gate_zone()
+        z1.set_blockade_radius(2.0)
+        z2 = _make_gate_zone()
+        z2._name = "gate_b"
+        z2.set_blockade_radius(3.0)
+        arch = ArchBuilder()
+        arch.add_zone(z1)
+        arch.add_zone(z2)
+        arch.add_mode("all", ["gate", "gate_b"])
+        with pytest.raises(ValueError, match="disagree on blockade_radius"):
+            arch.build()
+
+    def test_mixed_zone_radii_raises(self):
+        """If some zones have a radius and others don't, ArchBuilder.build fails."""
+        z1 = _make_gate_zone()
+        z1.set_blockade_radius(2.0)
+        z2 = _make_gate_zone()
+        z2._name = "gate_b"
+        # z2 has no radius.
+        arch = ArchBuilder()
+        arch.add_zone(z1)
+        arch.add_zone(z2)
+        arch.add_mode("all", ["gate", "gate_b"])
+        with pytest.raises(ValueError, match="some zones but not others"):
+            arch.build()
+
+
+class TestZoneBuilderBlockadeMetadata:
+    def test_add_entangling_pairs_clears_radius(self):
+        """Manual append after set_blockade_radius clears the cached radius."""
+        zone = _make_gate_zone()
+        zone.set_blockade_radius(2.0)
+        assert zone.blockade_radius == 2.0
+        zone.add_entangling_pairs([0], [5])  # manual override
+        assert zone.blockade_radius is None

--- a/python/tests/bytecode/test_arch_spec.py
+++ b/python/tests/bytecode/test_arch_spec.py
@@ -106,6 +106,7 @@ class TestCapabilityFlags:
         spec = _build_spec_from_python()
         assert spec.feed_forward is False
         assert spec.atom_reloading is False
+        assert spec.blockade_radius is None
 
     def test_construct_from_python_explicit(self):
         word0 = _make_word()
@@ -140,9 +141,11 @@ class TestCapabilityFlags:
             modes=[mode],
             feed_forward=True,
             atom_reloading=True,
+            blockade_radius=2.0,
         )
         assert spec.feed_forward is True
         assert spec.atom_reloading is True
+        assert spec.blockade_radius == 2.0
 
 
 class TestPropertyAccess:


### PR DESCRIPTION
## Summary

Adds `set_blockade_radius(radius)` on `ZoneBuilder` and `ArchBuilder` to derive CZ entangling word pairs from the Rydberg blockade radius, replacing the need to list pairs manually. The scan also validates that the word layout is compatible with the matching-site-index CZ convention.

The old `add_entangling_pairs(words_a, words_b)` API is unchanged (backwards compatible).

## Design

For every pair of distinct words `(a, b)` in a zone, classify under the rule:

| Condition                                           | Outcome                         |
|-----------------------------------------------------|---------------------------------|
| all matching-index distances ≤ r AND all non-matching-index distances > r | Valid pair → record `(a, b)` |
| some matching-index within / some outside           | `ValueError` (partial blockade) |
| a non-matching-index distance within radius while matching aren't | `ValueError` (crossed-index) |
| all distances outside radius                        | Skip (words ignore each other)  |

After the scan, every word must appear in **at most one** valid pair (else: `ValueError` — multiple partners).

Distances compared on **nm integers** (1 µm = 1000 nm) so the radius boundary is exact.

## API additions

```python
zone = ZoneBuilder("gate", grid, word_shape=(1, 1))
for x in range(6):
    zone.add_word([x], [0])
zone.set_blockade_radius(2.0)
# zone._entangling_pairs == [(0, 1), (2, 3), (4, 5)]
# zone.blockade_radius == 2.0

arch = ArchBuilder()
arch.add_zone(zone)
arch.add_mode("all", ["gate"])
arch.set_blockade_radius(2.0)   # sweeps every already-added zone
spec = arch.build()
# spec.blockade_radius == 2.0
```

`set_blockade_radius` **overwrites** any pairs added via `add_entangling_pairs` — the radius is the single source of truth once set (per user preference). Behaviour if `set_blockade_radius` is called before any zones are added: it records the radius but doesn't scan; zones added later aren't retroactively updated (caller can re-call to apply).

## ArchSpec plumbing

`blockade_radius: Option<f64>` is now a field on:

- **Rust** `ArchSpec` struct (`crates/.../arch/types.rs`) with `#[serde(default, skip_serializing_if = "Option::is_none")]`. The schema (`docs/.../archspec-schema.json`) already reserved the name; the Rust struct now actually carries the value.
- **PyO3** `PyArchSpec.__new__` kwarg + `#[getter]`.
- **Python** `ArchSpec.from_components(..., blockade_radius=None)` + `@property blockade_radius`.
- **Type stubs** `_native.pyi`.

All existing `rs::ArchSpec { ... }` struct-literal sites in the codebase (`atom_state.rs`, `bytecode/validate.rs`, `arch/validate.rs`, `arch/query.rs`, `arch/types.rs` tests) get the new field as `None`.

No Rust-side validation logic — Python enforces geometric consistency at scan time; Rust just carries the value. A follow-up can add Rust-side enforcement once per-zone radii are on the table.

## Tests

`python/tests/arch/test_arch_builder.py`:
- `TestZoneBuilderBlockadeRadius` — 9 cases covering interleaved gate-zone pairing, overwrite of explicit pairs, tight-radius empty result, partial blockade, crossed-index, multi-partner, property get/set, and input validation.
- `TestArchBuilderBlockadeRadius` — multi-zone sweep, spec roundtrip, no-set path returns `None`, order-of-calls semantics.

`crates/.../arch/types.rs` — serde roundtrip for `None` and `Some(2.0)`.

`python/tests/bytecode/test_arch_spec.py` — constructor + property for the new kwarg.

## Test plan

- [x] `cargo test -p bloqade-lanes-bytecode-core -p bloqade-lanes-bytecode-cli` — 227 + 19 + 17 pass
- [x] `cargo clippy ... -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `uv run pytest python/tests` — 836 passed, 4 skipped
- [x] `just develop-python` — builds clean

## Out of scope / follow-ups

- Rust-side `validate.rs` enforcement (needs zone grid access; deferred).
- Per-zone blockade radii (single-radius API lands first; schema evolves later).
- Migrating `build_arch()` / `WordGrid.cz_pairs()` away from column-adjacency to use blockade inference automatically — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)