### PR TITLE
fix(test): correct import path for _validation_squin_kernels

### DIFF
--- a/python/tests/test_validation_squin_kernels.py
+++ b/python/tests/test_validation_squin_kernels.py
@@ -1,5 +1,5 @@
 import pytest
-from tests._validation_squin_kernels import (
+from _validation_squin_kernels import (
     KernelSpec,
     select_kernels,
 )


### PR DESCRIPTION
## Summary
- Fix broken import in `test_validation_squin_kernels.py` — it used `from tests._validation_squin_kernels` but `python/tests/` has no `__init__.py`, so pytest collection fails with `ModuleNotFoundError`
- Changed to bare `from _validation_squin_kernels` which works because pytest adds the test directory to `sys.path`

## Test plan
- [x] `pytest --collect-only python/tests/test_validation_squin_kernels.py` succeeds (was failing before)
- [x] Full test suite passes: 619 passed, 4 skipped on `release-0-7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)