### PR TITLE
fix: make python/tests a package and satisfy clippy 1.95

### DIFF
--- a/crates/bloqade-lanes-bytecode-core/src/bytecode/validate.rs
+++ b/crates/bloqade-lanes-bytecode-core/src/bytecode/validate.rs
@@ -221,10 +221,10 @@ pub fn validate_capabilities(program: &Program, arch: &ArchSpec) -> Vec<Validati
                     errors.push(ValidationError::FeedForwardNotSupported { pc });
                 }
             }
-            Instruction::AtomArrangement(AtomArrangementInstruction::Fill { .. }) => {
-                if !arch.atom_reloading {
-                    errors.push(ValidationError::AtomReloadingNotSupported { pc });
-                }
+            Instruction::AtomArrangement(AtomArrangementInstruction::Fill { .. })
+                if !arch.atom_reloading =>
+            {
+                errors.push(ValidationError::AtomReloadingNotSupported { pc });
             }
             _ => {}
         }

--- a/python/tests/test_validation_squin_kernels.py
+++ b/python/tests/test_validation_squin_kernels.py
@@ -1,5 +1,5 @@
 import pytest
-from _validation_squin_kernels import (
+from tests._validation_squin_kernels import (
     KernelSpec,
     select_kernels,
 )


### PR DESCRIPTION
## Summary
- Adds empty `python/tests/__init__.py` so `from tests._validation_squin_kernels` resolves for both pytest and pyright
- Reverts the import workaround from #514 (`from _validation_squin_kernels`) which broke pyright
- Collapses a nested `if` in `validate_capabilities` into a match guard to satisfy clippy 1.95's `collapsible-match` lint

## Context
#514 changed the import to a bare module form to fix pytest collection because `python/tests/` lacked an `__init__.py`. The bare import works for pytest (via `rootdir`/`sys.path` manipulation) but pyright cannot resolve it, producing a `reportMissingImports` error. Making `tests` a proper package fixes both tools with a single change.

Clippy 1.95 (used on CI) promoted `collapsible-match` — the existing nested `if` in `validate_capabilities` now trips it under `-D warnings`.

## Test plan
- [x] `uv run pyright python` → 0 errors
- [x] `uv run pytest python/tests/test_validation_squin_kernels.py --collect-only` → 23 tests collected
- [x] `cargo clippy -p bloqade-lanes-bytecode-core -p bloqade-lanes-bytecode-cli --all-targets -- -D warnings` → clean
- [ ] CI lint + tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)