### PR TITLE
fix(search): make Rust candidate ordering deterministic

### DIFF
--- a/crates/bloqade-lanes-search/src/entropy.rs
+++ b/crates/bloqade-lanes-search/src/entropy.rs
@@ -11,7 +11,8 @@
 //! file and the one-line references in `lib.rs`, `solve.rs`, and the Python
 //! bindings.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::hash::{Hash, Hasher};
 
 use bloqade_lanes_bytecode_core::arch::addr::{LaneAddr, LocationAddr};
@@ -90,6 +91,38 @@ struct EntropyState {
     failed_candidates: HashSet<Vec<u64>>,
     /// Number of actually-created children (is_new=true from graph.insert).
     n_children: usize,
+}
+
+type TripletKey = (u8, u32, u8);
+
+struct ScoredEntry {
+    qubit_id: u32,
+    score: f64,
+    lane_encoded: u64,
+    dst_encoded: u64,
+}
+
+fn cmp_scored_entries(a: &(TripletKey, ScoredEntry), b: &(TripletKey, ScoredEntry)) -> Ordering {
+    b.1.score
+        .total_cmp(&a.1.score)
+        .then_with(|| a.0.cmp(&b.0))
+        .then_with(|| a.1.qubit_id.cmp(&b.1.qubit_id))
+        .then_with(|| a.1.lane_encoded.cmp(&b.1.lane_encoded))
+        .then_with(|| a.1.dst_encoded.cmp(&b.1.dst_encoded))
+}
+
+fn cmp_group_entries(a: &ScoredEntry, b: &ScoredEntry) -> Ordering {
+    b.score
+        .total_cmp(&a.score)
+        .then_with(|| a.qubit_id.cmp(&b.qubit_id))
+        .then_with(|| a.lane_encoded.cmp(&b.lane_encoded))
+        .then_with(|| a.dst_encoded.cmp(&b.dst_encoded))
+}
+
+fn cmp_scored_candidates(a: &(f64, MoveSet, Config), b: &(f64, MoveSet, Config)) -> Ordering {
+    b.0.total_cmp(&a.0)
+        .then_with(|| a.1.encoded_lanes().cmp(b.1.encoded_lanes()))
+        .then_with(|| a.2.as_entries().cmp(b.2.as_entries()))
 }
 
 impl Default for EntropyState {
@@ -183,16 +216,6 @@ pub(crate) fn generate_candidates(
 
     if unresolved.is_empty() {
         return Vec::new();
-    }
-
-    // Step 2: score (qubit, bus triplet) pairs with entropy weighting.
-    type TripletKey = (u8, u32, u8);
-
-    struct ScoredEntry {
-        qubit_id: u32,
-        score: f64,
-        lane_encoded: u64,
-        dst_encoded: u64,
     }
 
     let mut raw_deltas: Vec<(TripletKey, u32, f64, f64, u64, u64)> = Vec::new();
@@ -317,7 +340,7 @@ pub(crate) fn generate_candidates(
         .collect();
 
     // Step 3: per qubit, keep top C.
-    let mut per_qubit: HashMap<u32, Vec<(TripletKey, ScoredEntry)>> = HashMap::new();
+    let mut per_qubit: BTreeMap<u32, Vec<(TripletKey, ScoredEntry)>> = BTreeMap::new();
     for entry in all_scores.drain(..) {
         per_qubit.entry(entry.1.qubit_id).or_default().push(entry);
     }
@@ -326,7 +349,7 @@ pub(crate) fn generate_candidates(
     let mut has_positive = false;
 
     for entries in per_qubit.values_mut() {
-        entries.sort_by(|a, b| b.1.score.total_cmp(&a.1.score));
+        entries.sort_by(cmp_scored_entries);
         entries.truncate(params.top_c);
         for e in entries.drain(..) {
             if e.1.score > 0.0 {
@@ -337,14 +360,14 @@ pub(crate) fn generate_candidates(
     }
 
     if !has_positive {
-        selected.sort_by(|a, b| b.1.score.total_cmp(&a.1.score));
+        selected.sort_by(cmp_scored_entries);
         selected.truncate(1);
     } else {
         selected.retain(|e| e.1.score > 0.0);
     }
 
     // Step 4: group by bus triplet.
-    let mut groups: HashMap<TripletKey, Vec<ScoredEntry>> = HashMap::new();
+    let mut groups: BTreeMap<TripletKey, Vec<ScoredEntry>> = BTreeMap::new();
     for (key, entry) in selected {
         groups.entry(key).or_default().push(entry);
     }
@@ -353,7 +376,7 @@ pub(crate) fn generate_candidates(
     let mut candidates: Vec<(f64, MoveSet, Config)> = Vec::new();
 
     for (_key, mut qubits) in groups {
-        qubits.sort_by(|a, b| b.score.total_cmp(&a.score));
+        qubits.sort_by(cmp_group_entries);
         let n = qubits.len().min(params.max_movesets_per_group);
 
         for start in 0..n {
@@ -396,7 +419,7 @@ pub(crate) fn generate_candidates(
             (ms_score + ms_perturbation, ms, new_cfg)
         })
         .collect();
-    scored.sort_by(|a, b| b.0.total_cmp(&a.0));
+    scored.sort_by(cmp_scored_candidates);
 
     scored
         .into_iter()
@@ -938,5 +961,79 @@ mod tests {
         let blocked: HashSet<u64> = [loc(0, 5).encode()].into_iter().collect();
         let path = find_path_occupied(loc(0, 0), loc(0, 5), &blocked, &index);
         assert!(path.is_none());
+    }
+
+    #[test]
+    fn scored_entry_tie_break_is_deterministic() {
+        let mut entries = vec![
+            (
+                (1, 2, 1),
+                ScoredEntry {
+                    qubit_id: 8,
+                    score: 3.0,
+                    lane_encoded: 19,
+                    dst_encoded: 40,
+                },
+            ),
+            (
+                (1, 1, 1),
+                ScoredEntry {
+                    qubit_id: 4,
+                    score: 3.0,
+                    lane_encoded: 12,
+                    dst_encoded: 40,
+                },
+            ),
+            (
+                (1, 1, 1),
+                ScoredEntry {
+                    qubit_id: 4,
+                    score: 3.0,
+                    lane_encoded: 10,
+                    dst_encoded: 40,
+                },
+            ),
+        ];
+
+        entries.sort_by(cmp_scored_entries);
+
+        assert_eq!(entries[0].0, (1, 1, 1));
+        assert_eq!(entries[0].1.lane_encoded, 10);
+        assert_eq!(entries[1].0, (1, 1, 1));
+        assert_eq!(entries[1].1.lane_encoded, 12);
+        assert_eq!(entries[2].0, (1, 2, 1));
+    }
+
+    #[test]
+    fn generate_candidates_seed_zero_tie_fallback_is_stable() {
+        let index = make_index();
+        let config = Config::new([(0, loc(0, 0))]).unwrap();
+        let target_encoded = vec![(0u32, loc(0, 5).encode())];
+        let target_locs: Vec<u64> = target_encoded.iter().map(|&(_, enc)| enc).collect();
+        let dist_table = DistanceTable::new(&target_locs, &index);
+        let blocked = HashSet::new();
+        let ctx = SearchContext {
+            index: &index,
+            dist_table: &dist_table,
+            blocked: &blocked,
+            targets: &target_encoded,
+        };
+        let params = EntropyParams {
+            w_d: 0.0,
+            w_m: 0.0,
+            top_c: 8,
+            max_movesets_per_group: 8,
+            ..EntropyParams::default()
+        };
+
+        let out1 = generate_candidates(&config, 1, &params, &ctx, 0);
+        let out2 = generate_candidates(&config, 1, &params, &ctx, 0);
+
+        assert!(!out1.is_empty());
+        assert_eq!(out1.len(), out2.len());
+        for ((ms_a, cfg_a, _), (ms_b, cfg_b, _)) in out1.iter().zip(out2.iter()) {
+            assert_eq!(ms_a, ms_b);
+            assert_eq!(cfg_a.as_entries(), cfg_b.as_entries());
+        }
     }
 }

--- a/crates/bloqade-lanes-search/src/entropy.rs
+++ b/crates/bloqade-lanes-search/src/entropy.rs
@@ -25,6 +25,10 @@ use crate::context::SearchContext;
 use crate::graph::{MoveSet, NodeId, SearchGraph};
 use crate::heuristic::DistanceTable;
 use crate::lane_index::LaneIndex;
+use crate::ordering::{
+    TripletKey, cmp_moveset_config_tiebreak, cmp_qubit_lane_dst_tiebreak,
+    cmp_triplet_entry_tiebreak,
+};
 use crate::traits::Goal;
 
 // ── Parameters ─────────────────────────────────────────────────────
@@ -93,8 +97,6 @@ struct EntropyState {
     n_children: usize,
 }
 
-type TripletKey = (u8, u32, u8);
-
 struct ScoredEntry {
     qubit_id: u32,
     score: f64,
@@ -103,26 +105,36 @@ struct ScoredEntry {
 }
 
 fn cmp_scored_entries(a: &(TripletKey, ScoredEntry), b: &(TripletKey, ScoredEntry)) -> Ordering {
-    b.1.score
-        .total_cmp(&a.1.score)
-        .then_with(|| a.0.cmp(&b.0))
-        .then_with(|| a.1.qubit_id.cmp(&b.1.qubit_id))
-        .then_with(|| a.1.lane_encoded.cmp(&b.1.lane_encoded))
-        .then_with(|| a.1.dst_encoded.cmp(&b.1.dst_encoded))
+    b.1.score.total_cmp(&a.1.score).then_with(|| {
+        cmp_triplet_entry_tiebreak(
+            &a.0,
+            a.1.qubit_id,
+            a.1.lane_encoded,
+            a.1.dst_encoded,
+            &b.0,
+            b.1.qubit_id,
+            b.1.lane_encoded,
+            b.1.dst_encoded,
+        )
+    })
 }
 
 fn cmp_group_entries(a: &ScoredEntry, b: &ScoredEntry) -> Ordering {
-    b.score
-        .total_cmp(&a.score)
-        .then_with(|| a.qubit_id.cmp(&b.qubit_id))
-        .then_with(|| a.lane_encoded.cmp(&b.lane_encoded))
-        .then_with(|| a.dst_encoded.cmp(&b.dst_encoded))
+    b.score.total_cmp(&a.score).then_with(|| {
+        cmp_qubit_lane_dst_tiebreak(
+            a.qubit_id,
+            a.lane_encoded,
+            a.dst_encoded,
+            b.qubit_id,
+            b.lane_encoded,
+            b.dst_encoded,
+        )
+    })
 }
 
 fn cmp_scored_candidates(a: &(f64, MoveSet, Config), b: &(f64, MoveSet, Config)) -> Ordering {
     b.0.total_cmp(&a.0)
-        .then_with(|| a.1.encoded_lanes().cmp(b.1.encoded_lanes()))
-        .then_with(|| a.2.as_entries().cmp(b.2.as_entries()))
+        .then_with(|| cmp_moveset_config_tiebreak(&a.1, &a.2, &b.1, &b.2))
 }
 
 impl Default for EntropyState {

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -20,6 +20,7 @@ use crate::context::{MoveCandidate, SearchContext, SearchState};
 use crate::graph::{MoveSet, NodeId};
 use crate::heuristic::DistanceTable;
 use crate::lane_index::LaneIndex;
+use crate::ordering::{TripletKey, cmp_moveset_config_tiebreak, cmp_triplet_entry_tiebreak};
 use crate::traits::MoveGenerator;
 
 /// Policy for handling deadlocks (no improving moves available).
@@ -42,21 +43,24 @@ struct ScoredTriple {
     dst_encoded: u64,
 }
 
-type TripletKey = (u8, u32, u8); // (move_type as u8, bus_id, direction as u8)
-
 fn cmp_scored_triples(a: &(TripletKey, ScoredTriple), b: &(TripletKey, ScoredTriple)) -> Ordering {
-    b.1.score
-        .cmp(&a.1.score)
-        .then_with(|| a.0.cmp(&b.0))
-        .then_with(|| a.1.lane_encoded.cmp(&b.1.lane_encoded))
-        .then_with(|| a.1.dst_encoded.cmp(&b.1.dst_encoded))
-        .then_with(|| a.1.qubit_id.cmp(&b.1.qubit_id))
+    b.1.score.cmp(&a.1.score).then_with(|| {
+        cmp_triplet_entry_tiebreak(
+            &a.0,
+            a.1.qubit_id,
+            a.1.lane_encoded,
+            a.1.dst_encoded,
+            &b.0,
+            b.1.qubit_id,
+            b.1.lane_encoded,
+            b.1.dst_encoded,
+        )
+    })
 }
 
 fn cmp_candidates(a: &(i32, MoveSet, Config), b: &(i32, MoveSet, Config)) -> Ordering {
     b.0.cmp(&a.0)
-        .then_with(|| a.1.encoded_lanes().cmp(b.1.encoded_lanes()))
-        .then_with(|| a.2.as_entries().cmp(b.2.as_entries()))
+        .then_with(|| cmp_moveset_config_tiebreak(&a.1, &a.2, &b.1, &b.2))
 }
 
 /// Heuristic move generator that produces a small number of high-quality
@@ -974,7 +978,7 @@ mod tests {
     fn scored_triple_tie_break_is_deterministic() {
         let mut entries = vec![
             (
-                (1, 2, 3, 0),
+                (1, 2, 3),
                 ScoredTriple {
                     qubit_id: 9,
                     score: 7,
@@ -983,7 +987,7 @@ mod tests {
                 },
             ),
             (
-                (1, 1, 3, 0),
+                (1, 1, 3),
                 ScoredTriple {
                     qubit_id: 2,
                     score: 7,
@@ -992,7 +996,7 @@ mod tests {
                 },
             ),
             (
-                (1, 1, 3, 0),
+                (1, 1, 3),
                 ScoredTriple {
                     qubit_id: 1,
                     score: 7,
@@ -1004,11 +1008,11 @@ mod tests {
 
         entries.sort_by(cmp_scored_triples);
 
-        assert_eq!(entries[0].0, (1, 1, 3, 0));
+        assert_eq!(entries[0].0, (1, 1, 3));
         assert_eq!(entries[0].1.lane_encoded, 13);
-        assert_eq!(entries[1].0, (1, 1, 3, 0));
+        assert_eq!(entries[1].0, (1, 1, 3));
         assert_eq!(entries[1].1.lane_encoded, 15);
-        assert_eq!(entries[2].0, (1, 2, 3, 0));
+        assert_eq!(entries[2].0, (1, 2, 3));
     }
 
     #[test]

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -8,7 +8,8 @@
 //! and seeded score perturbation for restart diversity.
 
 use std::cell::Cell;
-use std::collections::{HashMap, HashSet};
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use bloqade_lanes_bytecode_core::arch::addr::{Direction, LaneAddr, LocationAddr, MoveType};
 use rand::rngs::SmallRng;
@@ -42,6 +43,21 @@ struct ScoredTriple {
 }
 
 type TripletKey = (u8, u32, u8); // (move_type as u8, bus_id, direction as u8)
+
+fn cmp_scored_triples(a: &(TripletKey, ScoredTriple), b: &(TripletKey, ScoredTriple)) -> Ordering {
+    b.1.score
+        .cmp(&a.1.score)
+        .then_with(|| a.0.cmp(&b.0))
+        .then_with(|| a.1.lane_encoded.cmp(&b.1.lane_encoded))
+        .then_with(|| a.1.dst_encoded.cmp(&b.1.dst_encoded))
+        .then_with(|| a.1.qubit_id.cmp(&b.1.qubit_id))
+}
+
+fn cmp_candidates(a: &(i32, MoveSet, Config), b: &(i32, MoveSet, Config)) -> Ordering {
+    b.0.cmp(&a.0)
+        .then_with(|| a.1.encoded_lanes().cmp(b.1.encoded_lanes()))
+        .then_with(|| a.2.as_entries().cmp(b.2.as_entries()))
+}
 
 /// Heuristic move generator that produces a small number of high-quality
 /// movesets per expansion.
@@ -292,7 +308,7 @@ impl MoveGenerator for HeuristicGenerator {
         }
 
         // Step 3: per qubit, keep top C triples.
-        let mut per_qubit: HashMap<u32, Vec<(TripletKey, ScoredTriple)>> = HashMap::new();
+        let mut per_qubit: BTreeMap<u32, Vec<(TripletKey, ScoredTriple)>> = BTreeMap::new();
         for entry in all_scores {
             per_qubit.entry(entry.1.qubit_id).or_default().push(entry);
         }
@@ -300,8 +316,8 @@ impl MoveGenerator for HeuristicGenerator {
         let mut selected: Vec<(TripletKey, ScoredTriple)> = Vec::new();
         let mut has_positive = false;
 
-        for (_, entries) in per_qubit.iter_mut() {
-            entries.sort_by(|a, b| b.1.score.cmp(&a.1.score));
+        for entries in per_qubit.values_mut() {
+            entries.sort_by(cmp_scored_triples);
             entries.truncate(self.top_c);
             for e in entries.iter() {
                 if e.1.score > 0 {
@@ -313,14 +329,14 @@ impl MoveGenerator for HeuristicGenerator {
 
         // Fallback: if no positive scores, keep only the single best entry.
         if !has_positive {
-            selected.sort_by(|a, b| b.1.score.cmp(&a.1.score));
+            selected.sort_by(cmp_scored_triples);
             selected.truncate(1);
         } else {
             selected.retain(|e| e.1.score > 0);
         }
 
         // Step 4: group by bus triplet.
-        let mut groups: HashMap<TripletKey, Vec<ScoredTriple>> = HashMap::new();
+        let mut groups: BTreeMap<TripletKey, Vec<ScoredTriple>> = BTreeMap::new();
         for (key, triple) in selected {
             groups.entry(key).or_default().push(triple);
         }
@@ -404,7 +420,7 @@ impl MoveGenerator for HeuristicGenerator {
         }
 
         // Step 6: sort by total score descending, emit.
-        candidates.sort_by(|a, b| b.0.cmp(&a.0));
+        candidates.sort_by(cmp_candidates);
 
         for (_, move_set, new_config) in candidates {
             out.push(MoveCandidate {
@@ -952,6 +968,62 @@ mod tests {
             result_la.nodes_expanded,
             result_no_la.nodes_expanded
         );
+    }
+
+    #[test]
+    fn scored_triple_tie_break_is_deterministic() {
+        let mut entries = vec![
+            (
+                (1, 2, 3, 0),
+                ScoredTriple {
+                    qubit_id: 9,
+                    score: 7,
+                    lane_encoded: 12,
+                    dst_encoded: 90,
+                },
+            ),
+            (
+                (1, 1, 3, 0),
+                ScoredTriple {
+                    qubit_id: 2,
+                    score: 7,
+                    lane_encoded: 15,
+                    dst_encoded: 88,
+                },
+            ),
+            (
+                (1, 1, 3, 0),
+                ScoredTriple {
+                    qubit_id: 1,
+                    score: 7,
+                    lane_encoded: 13,
+                    dst_encoded: 88,
+                },
+            ),
+        ];
+
+        entries.sort_by(cmp_scored_triples);
+
+        assert_eq!(entries[0].0, (1, 1, 3, 0));
+        assert_eq!(entries[0].1.lane_encoded, 13);
+        assert_eq!(entries[1].0, (1, 1, 3, 0));
+        assert_eq!(entries[1].1.lane_encoded, 15);
+        assert_eq!(entries[2].0, (1, 2, 3, 0));
+    }
+
+    #[test]
+    fn candidate_tie_break_uses_moveset_then_config() {
+        let cfg_a = Config::new([(0, loc(0, 1))]).unwrap();
+        let cfg_b = Config::new([(0, loc(0, 2))]).unwrap();
+        let mut candidates = vec![
+            (5, MoveSet::from_encoded(vec![9]), cfg_b),
+            (5, MoveSet::from_encoded(vec![3]), cfg_a),
+        ];
+
+        candidates.sort_by(cmp_candidates);
+
+        assert_eq!(candidates[0].1.encoded_lanes(), &[3]);
+        assert_eq!(candidates[1].1.encoded_lanes(), &[9]);
     }
 
     // -- Seed perturbation tests --

--- a/crates/bloqade-lanes-search/src/lib.rs
+++ b/crates/bloqade-lanes-search/src/lib.rs
@@ -19,6 +19,7 @@ pub mod heuristics;
 
 pub mod lane_index;
 pub mod observer;
+pub(crate) mod ordering;
 pub mod scorers;
 pub mod solve;
 #[cfg(test)]

--- a/crates/bloqade-lanes-search/src/ordering.rs
+++ b/crates/bloqade-lanes-search/src/ordering.rs
@@ -1,0 +1,51 @@
+use std::cmp::Ordering;
+
+use crate::config::Config;
+use crate::graph::MoveSet;
+
+pub(crate) type TripletKey = (u8, u32, u8);
+
+/// Shared deterministic tie-breaker for triplet-scored entries.
+pub(crate) fn cmp_triplet_entry_tiebreak(
+    a_key: &TripletKey,
+    a_qubit: u32,
+    a_lane: u64,
+    a_dst: u64,
+    b_key: &TripletKey,
+    b_qubit: u32,
+    b_lane: u64,
+    b_dst: u64,
+) -> Ordering {
+    a_key
+        .cmp(b_key)
+        .then_with(|| a_qubit.cmp(&b_qubit))
+        .then_with(|| a_lane.cmp(&b_lane))
+        .then_with(|| a_dst.cmp(&b_dst))
+}
+
+/// Shared deterministic tie-breaker for score-group entries.
+pub(crate) fn cmp_qubit_lane_dst_tiebreak(
+    a_qubit: u32,
+    a_lane: u64,
+    a_dst: u64,
+    b_qubit: u32,
+    b_lane: u64,
+    b_dst: u64,
+) -> Ordering {
+    a_qubit
+        .cmp(&b_qubit)
+        .then_with(|| a_lane.cmp(&b_lane))
+        .then_with(|| a_dst.cmp(&b_dst))
+}
+
+/// Shared deterministic tie-breaker for candidate ordering.
+pub(crate) fn cmp_moveset_config_tiebreak(
+    a_ms: &MoveSet,
+    a_cfg: &Config,
+    b_ms: &MoveSet,
+    b_cfg: &Config,
+) -> Ordering {
+    a_ms.encoded_lanes()
+        .cmp(b_ms.encoded_lanes())
+        .then_with(|| a_cfg.as_entries().cmp(b_cfg.as_entries()))
+}


### PR DESCRIPTION
## Summary
- remove hash-order dependence in Rust candidate grouping/selection for search by introducing deterministic ordering and explicit tie-breakers
- apply deterministic ordering in both `entropy.rs` and `generators/heuristic.rs` so equal-score cases explore candidates consistently across runs
- add targeted regression tests that assert stable candidate ordering and repeatable behavior for identical inputs

## Why this fixes nondeterminism
The prior implementation relied on `HashMap` iteration and score-only sorts at key stages. For equal/near-equal candidates, process-level hash randomization could change exploration order, which in turn changed outcomes under expansion budgets. This patch enforces a stable ordering via deterministic maps and tie-break sorting keys, making repeated runs reproducible.

## Test plan
- pre-commit hooks passed on commit (`cargo fmt`, `cargo clippy`, `pyright-check`)
- added/updated Rust tests in the modified files to validate deterministic ordering

Closes #520

Made with [Cursor](https://cursor.com)