### PR TITLE
fix(heuristics): add missing MoveType.ZONE to _MT_MAP

### DIFF
--- a/python/bloqade/lanes/heuristics/physical_movement.py
+++ b/python/bloqade/lanes/heuristics/physical_movement.py
@@ -323,7 +323,7 @@ class PhysicalPlacementStrategy(PlacementStrategyABC):
         return self._rust_nodes_expanded_total
 
     _DIR_MAP = {0: Direction.FORWARD, 1: Direction.BACKWARD}
-    _MT_MAP = {0: MoveType.SITE, 1: MoveType.WORD}
+    _MT_MAP = {0: MoveType.SITE, 1: MoveType.WORD, 2: MoveType.ZONE}
 
     def _cz_placements_rust(
         self,

--- a/python/tests/heuristics/test_physical_placement.py
+++ b/python/tests/heuristics/test_physical_placement.py
@@ -234,3 +234,39 @@ def test_cz_placements_rust_with_blocked_locations():
     )
     out = strategy.cz_placements(state, controls=(0,), targets=(1,))
     assert isinstance(out, ExecuteCZ)
+
+
+def test_cz_placements_rust_handles_zone_move_type(monkeypatch):
+    """Regression test for #510: _MT_MAP must include MoveType.ZONE (2)."""
+    from bloqade.lanes.bytecode import Direction as BytecodeDirection
+    from bloqade.lanes.bytecode import MoveType
+    from bloqade.lanes.layout.encoding import LaneAddress
+
+    strategy = PhysicalPlacementStrategy(
+        arch_spec=logical.get_arch_spec(), traversal=RustPlacementTraversal()
+    )
+    state = _make_state()
+
+    class _FakeResult:
+        status = "solved"
+        # move_layers format: list[list[tuple[dir, move_type, zone, word, site, bus]]]
+        # move_type=2 is MoveType.ZONE — the variant that was missing from _MT_MAP
+        move_layers = [[(0, 2, 0, 0, 0, 0)]]
+        goal_config = [(0, 0, 0, 0), (1, 0, 1, 0)]
+
+    class _FakeSolver:
+        def solve(self, *_args, **_kwargs):
+            return _FakeResult()
+
+    monkeypatch.setattr(
+        PhysicalPlacementStrategy,
+        "_get_rust_solver",
+        lambda _self: _FakeSolver(),
+    )
+    out = strategy.cz_placements(state, controls=(0,), targets=(1,))
+    assert isinstance(out, ExecuteCZ)
+    assert len(out.move_layers) == 1
+    lane = out.move_layers[0][0]
+    assert isinstance(lane, LaneAddress)
+    assert lane.move_type == MoveType.ZONE
+    assert lane.direction == BytecodeDirection.FORWARD

--- a/python/tests/heuristics/test_physical_placement.py
+++ b/python/tests/heuristics/test_physical_placement.py
@@ -248,6 +248,7 @@ def test_cz_placements_rust_handles_zone_move_type(monkeypatch):
 
     class _FakeResult:
         status = "solved"
+        nodes_expanded = 1
         # move_layers format: list[list[tuple[dir, move_type, zone, word, site, bus]]]
         # move_type=2 is MoveType.ZONE — the variant that was missing from _MT_MAP
         move_layers = [[(0, 2, 0, 0, 0, 0)]]

--- a/python/tests/heuristics/test_physical_placement.py
+++ b/python/tests/heuristics/test_physical_placement.py
@@ -238,8 +238,7 @@ def test_cz_placements_rust_with_blocked_locations():
 
 def test_cz_placements_rust_handles_zone_move_type(monkeypatch):
     """Regression test for #510: _MT_MAP must include MoveType.ZONE (2)."""
-    from bloqade.lanes.bytecode import Direction as BytecodeDirection
-    from bloqade.lanes.bytecode import MoveType
+    from bloqade.lanes.bytecode import Direction as BytecodeDirection, MoveType
     from bloqade.lanes.layout.encoding import LaneAddress
 
     strategy = PhysicalPlacementStrategy(


### PR DESCRIPTION
## Summary

Closes #510.

- `_MT_MAP` in `PhysicalPlacementStrategy` was missing the `MoveType.ZONE` (value `2`) entry, causing a `KeyError` when the Rust solver emits a `ZoneBus` move in `result.move_layers`
- Added `2: MoveType.ZONE` to the mapping
- Added a regression test that exercises a zone-bus move through `_cz_placements_rust`

## Test plan

- [x] New test `test_cz_placements_rust_handles_zone_move_type` passes
- [x] All existing tests in `test_physical_placement.py` still pass (13/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)