### PR TITLE
chore(search): document debug-only AOD lane-group validation convention

### DIFF
--- a/crates/bloqade-lanes-search/src/frontier.rs
+++ b/crates/bloqade-lanes-search/src/frontier.rs
@@ -440,6 +440,46 @@ impl<H: crate::traits::Heuristic> Frontier for IdsFrontier<H> {
 
 // ── Trait-based search loop (v2) ────────────────────────────────────
 
+/// Debug-only AOD lane-group validation for generator output.
+///
+/// ## Convention
+///
+/// Every candidate emitted by a [`MoveGenerator`] must represent a legal
+/// AOD move: a single `(move_type, bus_id, direction)` group whose source
+/// positions form a complete X×Y rectangle, with no duplicate or unknown
+/// lane addresses. The generators enforce this structurally (by how they
+/// build rectangles), but this helper acts as a **debug-only safety net**
+/// that re-validates each candidate against `ArchSpec::check_lanes` before
+/// it is inserted into the search graph.
+///
+/// Call this once, right after `MoveGenerator::generate`, from any new
+/// search loop. Under `#[cfg(debug_assertions)]` it verifies every
+/// candidate; in release builds it is a zero-cost no-op.
+///
+/// Do **not** call this from hot production paths outside the search loop
+/// — `ArchSpec::check_lanes` is linear in the group size and allocates.
+#[inline]
+fn debug_assert_candidates_valid(candidates: &[MoveCandidate], ctx: &SearchContext<'_>) {
+    #[cfg(debug_assertions)]
+    {
+        let arch = ctx.index.arch_spec();
+        for candidate in candidates {
+            let lanes = candidate.move_set.decode();
+            let errors = arch.check_lanes(&lanes);
+            debug_assert!(
+                errors.is_empty(),
+                "generator emitted invalid AOD lane group: {:?} (lanes={:?})",
+                errors,
+                lanes,
+            );
+        }
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        let _ = (candidates, ctx);
+    }
+}
+
 /// Run a search using the composable trait-based API.
 ///
 /// Uses separate [`MoveGenerator`], [`CandidateScorer`], [`CostFn`], and
@@ -537,6 +577,7 @@ where
 
         candidates.clear();
         generator.generate(graph.config(node_id), node_id, ctx, state, &mut candidates);
+        debug_assert_candidates_valid(&candidates, ctx);
 
         observer.on_event(
             SearchEvent::NodeExpanded {


### PR DESCRIPTION
## Summary

- Add a `#[cfg(debug_assertions)]`-gated safety net in `run_search` that re-validates every `MoveGenerator` candidate against `ArchSpec::check_lanes` (the existing `arch/query.rs:769` API) before the candidate is inserted into the search graph.
- Document the calling convention on the helper so future search loops can apply the same check in one line.
- Zero cost in release builds.

## Context

The existing generators (exhaustive, heuristic, entropy, greedy) already enforce the AOD rectangle invariant *by construction* — they build X×Y rectangles from bus positions and never emit partial grids. Until now, however, there was no independent verification that this invariant held: a bug in a generator, or a new generator added later, could silently insert a malformed `MoveSet` into the search graph.

`ArchSpec::check_lanes` already exists and is used by bytecode validation (`crates/bloqade-lanes-bytecode-core/src/bytecode/validate.rs:474`) and from Python (`python/bloqade/lanes/validation/address.py:43`). It covers: duplicate addresses, invalid lane addresses, group consistency (single `(move_type, bus_id, direction)`), word/site bus membership, and the AOD rectangle constraint (`check_lane_group_geometry`).

This PR just wires that API into the one production call site for `MoveGenerator::generate` — `frontier.rs:run_search` — as a debug-build safety net, and documents the convention so future loops follow the pattern.

## Test plan

- [x] `cargo build -p bloqade-lanes-search` — clean
- [x] `cargo test -p bloqade-lanes-search` — 148/148 pass (debug_assert fires through every real search code path, confirming current generators emit valid groups)
- [x] `cargo fmt --check` — clean
- [x] Pre-commit hooks — all passed

## API surface

- No breaking changes (Python, Rust, C)
- No new public items

🤖 Generated with [Claude Code](https://claude.com/claude-code)