### PR TITLE
fix(search): use BTreeMap at PyO3 boundary for deterministic search

### DIFF
--- a/crates/bloqade-lanes-bytecode-python/src/search_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/search_python.rs
@@ -305,8 +305,8 @@ impl PyMoveSolver {
     fn solve(
         &self,
         py: Python<'_>,
-        initial: std::collections::HashMap<u32, PyRef<'_, PyLocationAddr>>,
-        target: std::collections::HashMap<u32, PyRef<'_, PyLocationAddr>>,
+        initial: std::collections::BTreeMap<u32, PyRef<'_, PyLocationAddr>>,
+        target: std::collections::BTreeMap<u32, PyRef<'_, PyLocationAddr>>,
         blocked: Vec<PyRef<'_, PyLocationAddr>>,
         max_expansions: Option<u32>,
         options: Option<&PySolveOptions>,
@@ -352,7 +352,7 @@ impl PyMoveSolver {
     fn solve_with_generator(
         &self,
         py: Python<'_>,
-        initial: std::collections::HashMap<u32, PyRef<'_, PyLocationAddr>>,
+        initial: std::collections::BTreeMap<u32, PyRef<'_, PyLocationAddr>>,
         blocked: Vec<PyRef<'_, PyLocationAddr>>,
         controls: Vec<u32>,
         targets: Vec<u32>,
@@ -398,7 +398,7 @@ impl PyMoveSolver {
     #[pyo3(signature = (initial, controls, targets, generator=None))]
     fn generate_candidates(
         &self,
-        initial: std::collections::HashMap<u32, PyRef<'_, PyLocationAddr>>,
+        initial: std::collections::BTreeMap<u32, PyRef<'_, PyLocationAddr>>,
         controls: Vec<u32>,
         targets: Vec<u32>,
         generator: Option<&PyDefaultTargetGenerator>,


### PR DESCRIPTION
## Summary

- Replace the three `std::collections::HashMap` parameter types in `crates/bloqade-lanes-bytecode-python/src/search_python.rs` with `std::collections::BTreeMap` so that PyO3 extraction yields a deterministic iteration order.

This is the minimal fix for the entropy-search nondeterminism traced in #549. Root cause recap: Rust's `HashMap` uses `RandomState::new()`, which increments the thread-local hasher seed on every call — so even within a single process, successive HashMaps built from the same Python dict iterate keys in different orders. That order was flowing into `target_pairs` → `ctx.targets`, whose iteration order determined the summation order of floats in `score_moveset`. Non-associative f64 addition produced 1-2 ULP score differences, which flipped bit-exact `total_cmp` tiebreaks in the entropy search's resume buffer (only used when `max_goal_candidates > 1`), yielding different `nodes_expanded` counts across otherwise-identical runs.

`BTreeMap` extracts from a Python `dict` the same way as `HashMap` (PyO3 implements `FromPyObject` for both) but iterates in key-sorted order. No Python-side changes are needed, and the downstream `.iter().map(...).collect::<Vec<_>>()` patterns are unchanged — they just iterate in sorted-by-qid order now.

Scope kept minimal per request: one file, three parameter sites.

Closes #549

## Test plan

- [ ] `cargo test -p bloqade-lanes-bytecode-python` passes (22/22 locally)
- [ ] `cargo test -p bloqade-lanes-search` passes (158/158 locally)
- [ ] `just benchmark-physical` run twice in a row yields byte-identical CSVs (no row diffs via `--compare`)
- [ ] `python -m benchmarks.diag_intra_process` (the diagnostic from #549) reports all rows as INTRA-PROCESS DETERMINISTIC
- [ ] No behavior change for non-entropy strategies or `rust_entropy_1`