### PR TITLE
build(deps): pin bloqade-circuit ~=0.14.1 (upstream SQRT_Y fix; refs #554)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "Phillip Weinberg", email = "pweinberg@quera.com" }
 ]
 dependencies = [
-    "bloqade-circuit[cirq, qasm2, tsim]~=0.14.0",
+    "bloqade-circuit[cirq, qasm2, tsim]~=0.14.1",
     "bloqade-tsim~=0.1.3",
     "bloqade-geometry~=0.5.0",
     "deprecated>=1.3.1",

--- a/uv.lock
+++ b/uv.lock
@@ -156,7 +156,7 @@ wheels = [
 
 [[package]]
 name = "bloqade-circuit"
-version = "0.14.0"
+version = "0.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bloqade-decoders" },
@@ -169,9 +169,9 @@ dependencies = [
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/bf/8e2a7f3bcec5007a82f27261a46edf9ff37c9159a3cf22629a8ece23a044/bloqade_circuit-0.14.0.tar.gz", hash = "sha256:fd1b130a8970375b1b044fc1e62880b776b2226c36c23b9d7bec7fff71288927", size = 418320, upload-time = "2026-03-23T13:27:46.03Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/89/614e30797ebacf79f878da0803367d61f92f6be799bf99bfe6eef4c7a543/bloqade_circuit-0.14.1.tar.gz", hash = "sha256:0d28f973831e7ac3151a44ef6cb7476e38d464251a4639f4cce920466968ba7b", size = 435163, upload-time = "2026-04-24T19:48:20.765Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/58/36d527f7e4504a51788b962e1b1195d81ff66f644eeb99b30d0767668305/bloqade_circuit-0.14.0-py3-none-any.whl", hash = "sha256:008fc875fe2ee5febab7b562c4a8e737af6d54608a3d60f1026800d5550a1b3f", size = 254811, upload-time = "2026-03-23T13:27:44.138Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5f/ac12a12048ac4c00c0c772141a776f755e06904ee3921609e58f37396beb/bloqade_circuit-0.14.1-py3-none-any.whl", hash = "sha256:018e2342994c7c016c49af69ff85b2a130873fec37ed2ac176ebf657d98bf598", size = 254761, upload-time = "2026-04-24T19:48:19.19Z" },
 ]
 
 [package.optional-dependencies]
@@ -283,7 +283,7 @@ doc = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bloqade-circuit", extras = ["cirq", "qasm2", "tsim"], specifier = "~=0.14.0" },
+    { name = "bloqade-circuit", extras = ["cirq", "qasm2", "tsim"], specifier = "~=0.14.1" },
     { name = "bloqade-geometry", specifier = "~=0.5.0" },
     { name = "bloqade-tsim", specifier = "~=0.1.3" },
     { name = "cudaq", marker = "extra == 'cudaq'", specifier = ">=0.13.0" },


### PR DESCRIPTION
## Summary

Pin `bloqade-circuit` from `~=0.14.0` to `~=0.14.1`, picking up the upstream `SQRT_Y` / `SQRT_Y_DAG` unitary fix landed in [QuEraComputing/bloqade-circuit#751](https://github.com/QuEraComputing/bloqade-circuit/pull/751). First step toward resolving #554.

## Verification of the move2squin Rotation lowering

Before pushing I numerically verified the four `move → squin` rotation rewrites (`LocalR`, `GlobalR`, `LocalRz`, `GlobalRz`) against the pyqrack ground truth:

| Layer | Angle unit |
|---|---|
| `move.LocalR` / `move.GlobalR` / `move.LocalRz` / `move.GlobalRz` (`axis_angle`, `rotation_angle`) | **turns** (fractions of 2π) — confirmed by `bloqade/pyqrack/native.py:30-36` scaling by `2π` before applying `Rz · Rx · Rz` |
| `squin.U3` | **turns** too — confirmed by `bloqade/pyqrack/squin/gate/gate.py:127-129` scaling `theta` / `phi` / `lam` by `2π` before computing `Rz(phi) · Ry(theta) · Rz(lam)` |
| `0.25` "quarter_turn" constant in the rewrite | **turns** (0.25 turn = π/2) — consistent with the above |

Running `move.LocalR(axis, angle) → squin.U3(angle, axis-0.25, 0.25-axis)` through pyqrack yields the exact same 2×2 unitary as pyqrack's native `LocalR` implementation across a range of concrete `(axis, angle)` values in turn units. Same holds for `GlobalR`/`LocalRz`/`GlobalRz`. **The rewrite itself does not need changes.**

The `squin.stdlib.simple.gate.u3` docstring mis-claims radians — that's stdlib docstring drift at a layer above the statement's actual pyqrack interpretation, and is out of scope for this PR.

## Why the upstream #751 fix still matters for bloqade-lanes

`squin.U3` is also decomposed by `squin.rewrite.U3_to_clifford` into `SqrtY`-based Clifford sequences when the U3 angles are Clifford-valued (multiples of 0.25 turn), for emission into Stim / Tsim. *That* decomposition path was wrong pre-#751 because `SqrtY` and `SqrtY_DAG` were swapped. Any `move.LocalR` with Clifford-valued angles flowing through this path would have produced the wrong Clifford sequence under Stim or Tsim simulation. Picking up 0.14.1 restores correctness.

## Follow-ups

- Add a unitary regression test covering `move.LocalR → squin.U3 → U3_to_clifford → Stim` for Clifford-valued angles, so the Clifford-path semantics are locked in post-#751.
- Fix the mis-documented radian/turn convention in `bloqade-circuit`'s `squin.stdlib.simple.gate.u3` docstring (upstream concern).

These will land separately; tracked via #554.

## Test plan

- [x] `uv run pytest python/tests/` — **1085 passed, 9 skipped** with the bumped pin.
- [x] Numerical verification of all four rotation rewrites against the pyqrack ground truth (see description).
- [x] `uv run pyright python/` — clean.
- [x] Lint / black / isort — clean.

Closes part of #554 (the pin). Leaves the Clifford / Stim-path unitary regression test for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
