### PR TITLE
feat(atom): get_shot_remapping — full-Zone-0-bitstring → per-logical-qubit indices

### DIFF
--- a/python/bloqade/lanes/analysis/atom/__init__.py
+++ b/python/bloqade/lanes/analysis/atom/__init__.py
@@ -1,5 +1,4 @@
 from . import impl as impl
-from ._shot_remapping import get_shot_remapping as get_shot_remapping
 from .analysis import (
     AtomInterpreter as AtomInterpreter,
     PostProcessing as PostProcessing,

--- a/python/bloqade/lanes/analysis/atom/__init__.py
+++ b/python/bloqade/lanes/analysis/atom/__init__.py
@@ -1,4 +1,5 @@
 from . import impl as impl
+from ._shot_remapping import get_shot_remapping as get_shot_remapping
 from .analysis import (
     AtomInterpreter as AtomInterpreter,
     PostProcessing as PostProcessing,

--- a/python/bloqade/lanes/analysis/atom/__init__.py
+++ b/python/bloqade/lanes/analysis/atom/__init__.py
@@ -1,4 +1,8 @@
 from . import impl as impl
+from ._shot_remapping import (
+    ShotMappingResult as ShotMappingResult,
+    ShotRemappingDiagnostic as ShotRemappingDiagnostic,
+)
 from .analysis import (
     AtomInterpreter as AtomInterpreter,
     PostProcessing as PostProcessing,

--- a/python/bloqade/lanes/analysis/atom/__init__.py
+++ b/python/bloqade/lanes/analysis/atom/__init__.py
@@ -1,7 +1,8 @@
 from . import impl as impl
 from ._shot_remapping import (
-    ShotMappingResult as ShotMappingResult,
     ShotRemappingDiagnostic as ShotRemappingDiagnostic,
+    ShotRemappingErr as ShotRemappingErr,
+    ShotRemappingOk as ShotRemappingOk,
 )
 from .analysis import (
     AtomInterpreter as AtomInterpreter,

--- a/python/bloqade/lanes/analysis/atom/_shot_remapping.py
+++ b/python/bloqade/lanes/analysis/atom/_shot_remapping.py
@@ -55,38 +55,34 @@ class ShotRemappingDiagnostic:
 
 
 @dataclass(frozen=True)
-class ShotMappingResult:
-    """Result of computing the Zone-0 bitstring index list for a
-    move kernel's ``terminal_measure`` SSA value.
+class ShotRemappingOk:
+    """Successful shot-remapping result.
 
-    On success ``mapping`` holds the flat list of indices and
-    ``diagnostic`` is ``None``. On failure ``mapping`` is ``None``
-    and ``diagnostic`` carries the debug context.
+    ``mapping`` is the flat list of Zone-0 bitstring indices in
+    row-major order over the input
+    ``IListResult[IListResult[MeasureResult]]`` analysis output.
+    Index directly into the post-processing flat array.
     """
 
-    mapping: list[int] | None
-    diagnostic: ShotRemappingDiagnostic | None = None
+    mapping: list[int]
 
-    @property
-    def ok(self) -> bool:
-        """``True`` iff the mapping was derived successfully."""
-        return self.mapping is not None
 
-    def get(self) -> list[int]:
-        """Return the mapping or raise ``RuntimeError`` (carrying the
-        diagnostic) if the computation failed."""
-        if self.mapping is None:
-            raise RuntimeError(
-                f"ShotMappingResult: mapping unavailable; "
-                f"diagnostic: {self.diagnostic}"
-            )
-        return self.mapping
+@dataclass(frozen=True)
+class ShotRemappingErr:
+    """Failed shot-remapping result.
+
+    ``diagnostic`` carries the contextual message and the offending
+    lattice value or address, aimed at the compiler developer
+    debugging the failed lowering.
+    """
+
+    diagnostic: ShotRemappingDiagnostic
 
 
 def get_shot_remapping(
     return_value: MoveExecution,
     arch_spec: ArchSpec,
-) -> ShotMappingResult:
+) -> ShotRemappingOk | ShotRemappingErr:
     """Project an analysis ``IListResult[IListResult[MeasureResult]]``
     value onto a flat list of Zone-0 bitstring indices.
 
@@ -101,17 +97,23 @@ def get_shot_remapping(
             is flat.
         arch_spec: architecture spec; ``arch_spec.yield_zone_locations(
             ZoneAddress(0))`` defines the canonical Zone-0 bitstring
-            layout that hardware shots are reported against.
+            layout that hardware shots are reported against. Must
+            contain at least one zone (``zone 0`` is the projection
+            target).
 
     Returns:
-        ``ShotMappingResult`` whose ``mapping`` is the flat list of
-        Zone-0 indices in row-major order on success, or ``None`` with
-        a populated ``diagnostic`` on failure. Failure modes:
+        ``ShotRemappingOk`` carrying the flat list of Zone-0 indices
+        on success, or ``ShotRemappingErr`` carrying a
+        ``ShotRemappingDiagnostic`` on failure. Failure modes:
 
-        - ``return_value`` (or any nested element) does not have the
-          expected ``IListResult[IListResult[MeasureResult]]`` shape
-          — most often a sign that the analysis didn't refine the
-          lattice value past ``Bottom`` / ``Unknown``.
+        - ``return_value`` is not an ``IListResult`` (any other
+          ``MoveExecution`` lattice element — ``Bottom``, ``Unknown``,
+          ``Value``, ``MeasureFuture``, ``MeasureResult``,
+          ``DetectorResult``, ``ObservableResult``, ``TupleResult``).
+        - Any element of the outer ``IListResult.data`` is not itself
+          an ``IListResult`` (same set of rejected types as above).
+        - Any element of an inner ``IListResult.data`` is not a
+          ``MeasureResult``.
         - A ``MeasureResult.location_address`` resolves outside
           ``arch_spec``'s Zone-0 iteration — i.e. the analysis and
           arch spec disagree about hardware layout.
@@ -120,11 +122,18 @@ def get_shot_remapping(
         developers, not end users; failures here indicate pipeline
         regressions rather than malformed kernels.
     """
+    # Zone-0 is the projection target. ``ArchSpec.get_zone_index``
+    # returns ``None`` both for addresses outside Zone-0 *and* when
+    # the spec has no Zone-0 at all; assert the second case up front
+    # so the diagnostic's "address is not in Zone-0" wording stays
+    # truthful.
+    assert (
+        len(arch_spec.zones) > 0
+    ), "arch spec invariant violation: no zones (zone 0 expected)"
     zone0 = ZoneAddress(0)
 
     if not isinstance(return_value, IListResult):
-        return ShotMappingResult(
-            mapping=None,
+        return ShotRemappingErr(
             diagnostic=ShotRemappingDiagnostic(
                 message=(
                     "outer return value did not refine to IListResult; "
@@ -137,8 +146,7 @@ def get_shot_remapping(
     remapping: list[int] = []
     for i, logical in enumerate(return_value.data):
         if not isinstance(logical, IListResult):
-            return ShotMappingResult(
-                mapping=None,
+            return ShotRemappingErr(
                 diagnostic=ShotRemappingDiagnostic(
                     message=(
                         f"logical[{i}] did not refine to IListResult; "
@@ -149,8 +157,7 @@ def get_shot_remapping(
             )
         for j, physical in enumerate(logical.data):
             if not isinstance(physical, MeasureResult):
-                return ShotMappingResult(
-                    mapping=None,
+                return ShotRemappingErr(
                     diagnostic=ShotRemappingDiagnostic(
                         message=(
                             f"logical[{i}].physical[{j}] did not refine "
@@ -163,8 +170,7 @@ def get_shot_remapping(
             # and returns ``None`` for addresses outside Zone-0.
             idx = arch_spec.get_zone_index(physical.location_address, zone0)
             if idx is None:
-                return ShotMappingResult(
-                    mapping=None,
+                return ShotRemappingErr(
                     diagnostic=ShotRemappingDiagnostic(
                         message=(
                             f"logical[{i}].physical[{j}]: "
@@ -175,4 +181,4 @@ def get_shot_remapping(
                     ),
                 )
             remapping.append(idx)
-    return ShotMappingResult(mapping=remapping)
+    return ShotRemappingOk(mapping=remapping)

--- a/python/bloqade/lanes/analysis/atom/_shot_remapping.py
+++ b/python/bloqade/lanes/analysis/atom/_shot_remapping.py
@@ -5,14 +5,16 @@ bit per ``LocationAddress`` in ``arch_spec.yield_zone_locations(
 ZoneAddress(0))``, including bits for sites that no atom is ever
 moved into. Downstream post-processing (detector / observable
 synthesis, user-level result reconstruction) operates on a *per-
-measurement* array — typically shape ``(n_shots, n_measurements)``
+measurement* flat array — typically shape ``(n_shots, n_measurements)``
 — that's been projected out of the full bitstring at exactly the
-sites the program actually measures.
+sites the program actually measures, in the order the post-processing
+callable expects.
 
 This module provides the bridge: given the analysis output for a
 ``terminal_measure`` (or equivalent) ``IListResult[IListResult[
-MeasureResult]]`` value, plus the architecture spec, build the
-``logical_mapping[i]`` index table the original #98 spec called for.
+MeasureResult]]`` value, plus the architecture spec, produce a flat
+list of Zone-0 bitstring indices whose order matches the per-
+measurement array consumed by ``generate_post_processing``.
 
 See: issue #563.
 """
@@ -28,9 +30,9 @@ from .lattice import IListResult, MeasureResult, MoveExecution
 def get_shot_remapping(
     return_value: MoveExecution,
     arch_spec: ArchSpec,
-) -> list[list[int]] | None:
+) -> list[int] | None:
     """Project an analysis ``IListResult[IListResult[MeasureResult]]``
-    value onto the corresponding Zone-0 bitstring indices.
+    value onto a flat list of Zone-0 bitstring indices.
 
     Args:
         return_value: lattice value for the SSA result of a
@@ -38,16 +40,19 @@ def get_shot_remapping(
             shape produced by lowering a logical-qubit measurement
             through the atom-analysis chain). The outer ``IListResult``
             indexes logical qubits; each inner ``IListResult`` indexes
-            the physical qubits making up that logical block.
+            the physical qubits making up that logical block. The
+            nested structure is walked in row-major order; the result
+            is flat.
         arch_spec: architecture spec; ``arch_spec.yield_zone_locations(
             ZoneAddress(0))`` defines the canonical Zone-0 bitstring
             layout that hardware shots are reported against.
 
     Returns:
-        ``list[list[int]]`` where ``result[i][j]`` is the position in
-        the Zone-0 bitstring corresponding to the ``j``-th physical
-        qubit of the ``i``-th logical qubit, **or** ``None`` if the
-        mapping cannot be derived. Reasons the mapping may fail:
+        ``list[int]`` whose ``k``-th entry is the Zone-0 bitstring
+        index for the ``k``-th physical measurement in row-major order
+        across the nested ``IListResult[IListResult[MeasureResult]]``,
+        **or** ``None`` if the mapping cannot be derived. Reasons the
+        mapping may fail:
 
         - ``return_value`` (or any nested element) does not have the
           expected ``IListResult[IListResult[MeasureResult]]`` shape
@@ -66,11 +71,10 @@ def get_shot_remapping(
     if not isinstance(return_value, IListResult):
         return None
 
-    remapping: list[list[int]] = []
+    remapping: list[int] = []
     for logical in return_value.data:
         if not isinstance(logical, IListResult):
             return None
-        per_qubit: list[int] = []
         for physical in logical.data:
             if not isinstance(physical, MeasureResult):
                 return None
@@ -80,6 +84,5 @@ def get_shot_remapping(
             idx = arch_spec.get_zone_index(physical.location_address, zone0)
             if idx is None:
                 return None
-            per_qubit.append(idx)
-        remapping.append(per_qubit)
+            remapping.append(idx)
     return remapping

--- a/python/bloqade/lanes/analysis/atom/_shot_remapping.py
+++ b/python/bloqade/lanes/analysis/atom/_shot_remapping.py
@@ -19,13 +19,10 @@ See: issue #563.
 
 from __future__ import annotations
 
-from bloqade.lanes.analysis.atom.lattice import (
-    IListResult,
-    MeasureResult,
-    MoveExecution,
-)
 from bloqade.lanes.layout.arch import ArchSpec
 from bloqade.lanes.layout.encoding import ZoneAddress
+
+from .lattice import IListResult, MeasureResult, MoveExecution
 
 
 def get_shot_remapping(

--- a/python/bloqade/lanes/analysis/atom/_shot_remapping.py
+++ b/python/bloqade/lanes/analysis/atom/_shot_remapping.py
@@ -21,16 +21,72 @@ See: issue #563.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from bloqade.lanes.layout.arch import ArchSpec
-from bloqade.lanes.layout.encoding import ZoneAddress
+from bloqade.lanes.layout.encoding import LocationAddress, ZoneAddress
 
 from .lattice import IListResult, MeasureResult, MoveExecution
+
+
+@dataclass(frozen=True)
+class ShotRemappingDiagnostic:
+    """Compiler-developer-facing diagnostic emitted when
+    ``get_shot_remapping`` cannot derive a Zone-0 index list.
+
+    A failure here indicates an analysis or pipeline regression
+    rather than a user error — the user supplied a kernel, the
+    compiler service lowered it, and somewhere along the way the
+    analysis output drifted away from the expected
+    ``IListResult[IListResult[MeasureResult]]`` shape (or pointed
+    to a hardware location the architecture doesn't know about).
+    The fields below carry enough context for a compiler developer
+    to find the offending pass.
+
+    Attributes:
+        message: human-readable description with the failure path
+            baked in (e.g. ``"logical[2].physical[5]: …"``).
+        offending_value: the lattice value or address that triggered
+            the failure.
+    """
+
+    message: str
+    offending_value: MoveExecution | LocationAddress
+
+
+@dataclass(frozen=True)
+class ShotMappingResult:
+    """Result of computing the Zone-0 bitstring index list for a
+    move kernel's ``terminal_measure`` SSA value.
+
+    On success ``mapping`` holds the flat list of indices and
+    ``diagnostic`` is ``None``. On failure ``mapping`` is ``None``
+    and ``diagnostic`` carries the debug context.
+    """
+
+    mapping: list[int] | None
+    diagnostic: ShotRemappingDiagnostic | None = None
+
+    @property
+    def ok(self) -> bool:
+        """``True`` iff the mapping was derived successfully."""
+        return self.mapping is not None
+
+    def get(self) -> list[int]:
+        """Return the mapping or raise ``RuntimeError`` (carrying the
+        diagnostic) if the computation failed."""
+        if self.mapping is None:
+            raise RuntimeError(
+                f"ShotMappingResult: mapping unavailable; "
+                f"diagnostic: {self.diagnostic}"
+            )
+        return self.mapping
 
 
 def get_shot_remapping(
     return_value: MoveExecution,
     arch_spec: ArchSpec,
-) -> list[int] | None:
+) -> ShotMappingResult:
     """Project an analysis ``IListResult[IListResult[MeasureResult]]``
     value onto a flat list of Zone-0 bitstring indices.
 
@@ -48,11 +104,9 @@ def get_shot_remapping(
             layout that hardware shots are reported against.
 
     Returns:
-        ``list[int]`` whose ``k``-th entry is the Zone-0 bitstring
-        index for the ``k``-th physical measurement in row-major order
-        across the nested ``IListResult[IListResult[MeasureResult]]``,
-        **or** ``None`` if the mapping cannot be derived. Reasons the
-        mapping may fail:
+        ``ShotMappingResult`` whose ``mapping`` is the flat list of
+        Zone-0 indices in row-major order on success, or ``None`` with
+        a populated ``diagnostic`` on failure. Failure modes:
 
         - ``return_value`` (or any nested element) does not have the
           expected ``IListResult[IListResult[MeasureResult]]`` shape
@@ -62,27 +116,63 @@ def get_shot_remapping(
           ``arch_spec``'s Zone-0 iteration — i.e. the analysis and
           arch spec disagree about hardware layout.
 
-        Callers are expected to surface a meaningful diagnostic when
-        ``None`` is returned; this function does not raise on either
-        condition.
+        The diagnostic is aimed at the compiler service / compiler
+        developers, not end users; failures here indicate pipeline
+        regressions rather than malformed kernels.
     """
     zone0 = ZoneAddress(0)
 
     if not isinstance(return_value, IListResult):
-        return None
+        return ShotMappingResult(
+            mapping=None,
+            diagnostic=ShotRemappingDiagnostic(
+                message=(
+                    "outer return value did not refine to IListResult; "
+                    f"got {type(return_value).__name__}"
+                ),
+                offending_value=return_value,
+            ),
+        )
 
     remapping: list[int] = []
-    for logical in return_value.data:
+    for i, logical in enumerate(return_value.data):
         if not isinstance(logical, IListResult):
-            return None
-        for physical in logical.data:
+            return ShotMappingResult(
+                mapping=None,
+                diagnostic=ShotRemappingDiagnostic(
+                    message=(
+                        f"logical[{i}] did not refine to IListResult; "
+                        f"got {type(logical).__name__}"
+                    ),
+                    offending_value=logical,
+                ),
+            )
+        for j, physical in enumerate(logical.data):
             if not isinstance(physical, MeasureResult):
-                return None
+                return ShotMappingResult(
+                    mapping=None,
+                    diagnostic=ShotRemappingDiagnostic(
+                        message=(
+                            f"logical[{i}].physical[{j}] did not refine "
+                            f"to MeasureResult; got {type(physical).__name__}"
+                        ),
+                        offending_value=physical,
+                    ),
+                )
             # ``ArchSpec.get_zone_index`` is O(1) via the Rust backend
-            # and returns ``None`` for addresses outside Zone-0 — which
-            # propagates as the "give up" signal here.
+            # and returns ``None`` for addresses outside Zone-0.
             idx = arch_spec.get_zone_index(physical.location_address, zone0)
             if idx is None:
-                return None
+                return ShotMappingResult(
+                    mapping=None,
+                    diagnostic=ShotRemappingDiagnostic(
+                        message=(
+                            f"logical[{i}].physical[{j}]: "
+                            f"location_address {physical.location_address} "
+                            "is not in Zone-0 of the arch spec"
+                        ),
+                        offending_value=physical.location_address,
+                    ),
+                )
             remapping.append(idx)
-    return remapping
+    return ShotMappingResult(mapping=remapping)

--- a/python/bloqade/lanes/analysis/atom/_shot_remapping.py
+++ b/python/bloqade/lanes/analysis/atom/_shot_remapping.py
@@ -1,0 +1,88 @@
+"""Shot-remapping helper.
+
+A *shot* coming back from hardware is a full Zone-0 bitstring: one
+bit per ``LocationAddress`` in ``arch_spec.yield_zone_locations(
+ZoneAddress(0))``, including bits for sites that no atom is ever
+moved into. Downstream post-processing (detector / observable
+synthesis, user-level result reconstruction) operates on a *per-
+measurement* array — typically shape ``(n_shots, n_measurements)``
+— that's been projected out of the full bitstring at exactly the
+sites the program actually measures.
+
+This module provides the bridge: given the analysis output for a
+``terminal_measure`` (or equivalent) ``IListResult[IListResult[
+MeasureResult]]`` value, plus the architecture spec, build the
+``logical_mapping[i]`` index table the original #98 spec called for.
+
+See: issue #563.
+"""
+
+from __future__ import annotations
+
+from bloqade.lanes.analysis.atom.lattice import (
+    IListResult,
+    MeasureResult,
+    MoveExecution,
+)
+from bloqade.lanes.layout.arch import ArchSpec
+from bloqade.lanes.layout.encoding import ZoneAddress
+
+
+def get_shot_remapping(
+    return_value: MoveExecution,
+    arch_spec: ArchSpec,
+) -> list[list[int]] | None:
+    """Project an analysis ``IListResult[IListResult[MeasureResult]]``
+    value onto the corresponding Zone-0 bitstring indices.
+
+    Args:
+        return_value: lattice value for the SSA result of a
+            ``terminal_measure`` (or any value with the nested-IList
+            shape produced by lowering a logical-qubit measurement
+            through the atom-analysis chain). The outer ``IListResult``
+            indexes logical qubits; each inner ``IListResult`` indexes
+            the physical qubits making up that logical block.
+        arch_spec: architecture spec; ``arch_spec.yield_zone_locations(
+            ZoneAddress(0))`` defines the canonical Zone-0 bitstring
+            layout that hardware shots are reported against.
+
+    Returns:
+        ``list[list[int]]`` where ``result[i][j]`` is the position in
+        the Zone-0 bitstring corresponding to the ``j``-th physical
+        qubit of the ``i``-th logical qubit, **or** ``None`` if the
+        mapping cannot be derived. Reasons the mapping may fail:
+
+        - ``return_value`` (or any nested element) does not have the
+          expected ``IListResult[IListResult[MeasureResult]]`` shape
+          — most often a sign that the analysis didn't refine the
+          lattice value past ``Bottom`` / ``Unknown``.
+        - A ``MeasureResult.location_address`` resolves outside
+          ``arch_spec``'s Zone-0 iteration — i.e. the analysis and
+          arch spec disagree about hardware layout.
+
+        Callers are expected to surface a meaningful diagnostic when
+        ``None`` is returned; this function does not raise on either
+        condition.
+    """
+    zone0 = ZoneAddress(0)
+
+    if not isinstance(return_value, IListResult):
+        return None
+
+    remapping: list[list[int]] = []
+    for logical in return_value.data:
+        if not isinstance(logical, IListResult):
+            return None
+        per_qubit: list[int] = []
+        for physical in logical.data:
+            if not isinstance(physical, MeasureResult):
+                return None
+            # ``ArchSpec.get_zone_index`` is O(1) via the Rust backend
+            # and returns ``None`` for addresses outside Zone-0 — which
+            # propagates as the "give up" signal here.
+            idx = arch_spec.get_zone_index(physical.location_address, zone0)
+            if idx is None:
+                return None
+            per_qubit.append(idx)
+        remapping.append(per_qubit)
+    return remapping

--- a/python/bloqade/lanes/analysis/atom/analysis.py
+++ b/python/bloqade/lanes/analysis/atom/analysis.py
@@ -79,26 +79,29 @@ class AtomInterpreter(Forward[MoveExecution]):
     def eval_fallback(self, frame: ForwardFrame[MoveExecution], node: ir.Statement):
         return tuple(MoveExecution.bottom() for _ in node.results)
 
-    def get_shot_remapping(self, method: ir.Method) -> list[int] | None:
+    def get_shot_remapping(
+        self, method: ir.Method
+    ) -> _shot_remapping.ShotMappingResult:
         """Run the analysis on ``method`` and return the flat Zone-0
         bitstring index list (in row-major order over the nested
-        IListResult[IListResult[MeasureResult]] return shape), or
-        ``None`` if the analysis output couldn't be refined into that
-        shape.
+        ``IListResult[IListResult[MeasureResult]]`` return shape) wrapped
+        in a ``ShotMappingResult``. On failure, the result carries a
+        ``ShotRemappingDiagnostic`` instead of a mapping.
 
         Convenience wrapper around the standalone
         ``bloqade.lanes.analysis.atom._shot_remapping.get_shot_remapping``;
         see that function's docstring for the contract on the analysis
         output shape, the meaning of the returned indices, and the
-        conditions under which ``None`` is returned.
+        diagnostic emitted on failure.
 
         The method's return value is expected to refine to
         ``IListResult[IListResult[MeasureResult]]`` — the shape produced
         by lowering a logical ``terminal_measure`` (or any kernel that
         returns a nested ilist of measurement results) through the
         atom-analysis chain. Callers (typically the compiler service)
-        are responsible for surfacing a diagnostic when ``None`` is
-        returned.
+        are responsible for surfacing the diagnostic in the failure
+        case; a failure here is a compiler-pipeline regression, not a
+        user error.
         """
         _, output = self.run(method)
         return _shot_remapping.get_shot_remapping(output, self.arch_spec)

--- a/python/bloqade/lanes/analysis/atom/analysis.py
+++ b/python/bloqade/lanes/analysis/atom/analysis.py
@@ -80,13 +80,13 @@ class AtomInterpreter(Forward[MoveExecution]):
         return tuple(MoveExecution.bottom() for _ in node.results)
 
     def get_shot_remapping(
-        self, method: ir.Method
-    ) -> _shot_remapping.ShotMappingResult:
+        self, method: ir.Method, *, no_raise: bool = True
+    ) -> _shot_remapping.ShotRemappingOk | _shot_remapping.ShotRemappingErr:
         """Run the analysis on ``method`` and return the flat Zone-0
         bitstring index list (in row-major order over the nested
-        ``IListResult[IListResult[MeasureResult]]`` return shape) wrapped
-        in a ``ShotMappingResult``. On failure, the result carries a
-        ``ShotRemappingDiagnostic`` instead of a mapping.
+        ``IListResult[IListResult[MeasureResult]]`` return shape) as a
+        ``ShotRemappingOk``. On failure, returns ``ShotRemappingErr``
+        carrying a ``ShotRemappingDiagnostic``.
 
         Convenience wrapper around the standalone
         ``bloqade.lanes.analysis.atom._shot_remapping.get_shot_remapping``;
@@ -94,7 +94,7 @@ class AtomInterpreter(Forward[MoveExecution]):
         output shape, the meaning of the returned indices, and the
         diagnostic emitted on failure.
 
-        The method's return value is expected to refine to
+        ``method``'s return value is expected to refine to
         ``IListResult[IListResult[MeasureResult]]`` — the shape produced
         by lowering a logical ``terminal_measure`` (or any kernel that
         returns a nested ilist of measurement results) through the
@@ -102,8 +102,19 @@ class AtomInterpreter(Forward[MoveExecution]):
         are responsible for surfacing the diagnostic in the failure
         case; a failure here is a compiler-pipeline regression, not a
         user error.
+
+        Args:
+            method: kirin method to analyse.
+            no_raise: when ``True`` (default), an analysis crash is
+                caught by ``Forward.run_no_raise`` and falls through
+                into the standard ``ShotRemappingErr`` path with the
+                ``Bottom`` lattice as the offending value, so callers
+                see a single failure shape. Flip to ``False`` when
+                debugging an analysis-side bug to let the original
+                exception propagate.
         """
-        _, output = self.run(method)
+        run_method = self.run_no_raise if no_raise else self.run
+        _, output = run_method(method)
         return _shot_remapping.get_shot_remapping(output, self.arch_spec)
 
     def get_post_processing(

--- a/python/bloqade/lanes/analysis/atom/analysis.py
+++ b/python/bloqade/lanes/analysis/atom/analysis.py
@@ -10,6 +10,7 @@ from typing_extensions import Self
 from bloqade.lanes.layout.arch import ArchSpec
 from bloqade.lanes.utils import no_none_elements_tuple
 
+from . import _shot_remapping
 from ._post_processing import constructor_function
 from .lattice import AtomState, MoveExecution
 
@@ -98,10 +99,8 @@ class AtomInterpreter(Forward[MoveExecution]):
         are responsible for surfacing a diagnostic when ``None`` is
         returned.
         """
-        from ._shot_remapping import get_shot_remapping
-
         _, output = self.run(method)
-        return get_shot_remapping(output, self.arch_spec)
+        return _shot_remapping.get_shot_remapping(output, self.arch_spec)
 
     def get_post_processing(
         self, method: ir.Method[..., RetType]

--- a/python/bloqade/lanes/analysis/atom/analysis.py
+++ b/python/bloqade/lanes/analysis/atom/analysis.py
@@ -78,6 +78,31 @@ class AtomInterpreter(Forward[MoveExecution]):
     def eval_fallback(self, frame: ForwardFrame[MoveExecution], node: ir.Statement):
         return tuple(MoveExecution.bottom() for _ in node.results)
 
+    def get_shot_remapping(self, method: ir.Method) -> list[list[int]] | None:
+        """Run the analysis on ``method`` and return the per-logical-qubit
+        Zone-0 bitstring index table, or ``None`` if the analysis output
+        couldn't be refined into the expected nested-ilist-of-MeasureResult
+        shape.
+
+        Convenience wrapper around the standalone
+        ``bloqade.lanes.analysis.atom._shot_remapping.get_shot_remapping``;
+        see that function's docstring for the contract on the analysis
+        output shape, the meaning of the returned indices, and the
+        conditions under which ``None`` is returned.
+
+        The method's return value is expected to refine to
+        ``IListResult[IListResult[MeasureResult]]`` — the shape produced
+        by lowering a logical ``terminal_measure`` (or any kernel that
+        returns a nested ilist of measurement results) through the
+        atom-analysis chain. Callers (typically the compiler service)
+        are responsible for surfacing a diagnostic when ``None`` is
+        returned.
+        """
+        from ._shot_remapping import get_shot_remapping
+
+        _, output = self.run(method)
+        return get_shot_remapping(output, self.arch_spec)
+
     def get_post_processing(
         self, method: ir.Method[..., RetType]
     ) -> PostProcessing[RetType]:

--- a/python/bloqade/lanes/analysis/atom/analysis.py
+++ b/python/bloqade/lanes/analysis/atom/analysis.py
@@ -79,10 +79,11 @@ class AtomInterpreter(Forward[MoveExecution]):
     def eval_fallback(self, frame: ForwardFrame[MoveExecution], node: ir.Statement):
         return tuple(MoveExecution.bottom() for _ in node.results)
 
-    def get_shot_remapping(self, method: ir.Method) -> list[list[int]] | None:
-        """Run the analysis on ``method`` and return the per-logical-qubit
-        Zone-0 bitstring index table, or ``None`` if the analysis output
-        couldn't be refined into the expected nested-ilist-of-MeasureResult
+    def get_shot_remapping(self, method: ir.Method) -> list[int] | None:
+        """Run the analysis on ``method`` and return the flat Zone-0
+        bitstring index list (in row-major order over the nested
+        IListResult[IListResult[MeasureResult]] return shape), or
+        ``None`` if the analysis output couldn't be refined into that
         shape.
 
         Convenience wrapper around the standalone

--- a/python/bloqade/lanes/analysis/atom/impl.py
+++ b/python/bloqade/lanes/analysis/atom/impl.py
@@ -278,7 +278,7 @@ class Move(interp.MethodTable):
         if qubit_id is None:
             return (Bottom(),)
 
-        return (MeasureResult(qubit_id),)
+        return (MeasureResult(qubit_id, stmt.location_address),)
 
 
 @py.constant.dialect.register(key="atom")

--- a/python/bloqade/lanes/analysis/atom/lattice.py
+++ b/python/bloqade/lanes/analysis/atom/lattice.py
@@ -129,12 +129,16 @@ class MeasureFuture(MoveExecution):
 @dataclass
 class MeasureResult(MoveExecution):
     qubit_id: int
+    location_address: layout.LocationAddress
 
     def copy(self):
-        return MeasureResult(self.qubit_id)
+        return MeasureResult(self.qubit_id, self.location_address)
 
     def is_subseteq_MeasureResult(self, elem: "MeasureResult") -> bool:
-        return self.qubit_id == elem.qubit_id
+        return (
+            self.qubit_id == elem.qubit_id
+            and self.location_address == elem.location_address
+        )
 
 
 @final

--- a/python/tests/analysis/atom/test_atom_interpreter.py
+++ b/python/tests/analysis/atom/test_atom_interpreter.py
@@ -44,7 +44,9 @@ def test_atom_interpreter_simple():
 
     interp = atom.AtomInterpreter(kernel, arch_spec=get_arch_spec())
     frame, result = interp.run(main)
-    assert result == atom.MeasureResult(qubit_id=0)
+    assert result == atom.MeasureResult(
+        qubit_id=0, location_address=move.LocationAddress(1, 0)
+    )
 
 
 def test_get_post_processing():

--- a/python/tests/analysis/atom/test_lattice.py
+++ b/python/tests/analysis/atom/test_lattice.py
@@ -1,4 +1,5 @@
 from bloqade.lanes.analysis.atom import lattice
+from bloqade.lanes.layout.encoding import LocationAddress
 
 
 def test_unknown_and_bottom_singleton():
@@ -37,12 +38,16 @@ def test_measurefuture_copy_and_subset():
 
 
 def test_measureresult_copy_and_subset():
-    mr1 = lattice.MeasureResult(1)
-    mr2 = lattice.MeasureResult(1)
-    mr3 = lattice.MeasureResult(2)
+    addr = LocationAddress(0, 0, 0)
+    other = LocationAddress(1, 0, 0)
+    mr1 = lattice.MeasureResult(1, addr)
+    mr2 = lattice.MeasureResult(1, addr)
+    mr3 = lattice.MeasureResult(2, addr)
+    mr4 = lattice.MeasureResult(1, other)
     assert mr1.copy() == mr1
     assert mr1.is_subseteq_MeasureResult(mr2)
     assert not mr1.is_subseteq_MeasureResult(mr3)
+    assert not mr1.is_subseteq_MeasureResult(mr4)
 
 
 def test_detector_and_observable_result():

--- a/python/tests/analysis/atom/test_shot_remapping.py
+++ b/python/tests/analysis/atom/test_shot_remapping.py
@@ -15,6 +15,8 @@ from bloqade.lanes.analysis.atom import (
     IListResult,
     MeasureResult,
     ShotRemappingDiagnostic,
+    ShotRemappingErr,
+    ShotRemappingOk,
     Value,
 )
 from bloqade.lanes.analysis.atom._shot_remapping import get_shot_remapping
@@ -84,9 +86,8 @@ def test_single_logical_qubit():
     """One logical qubit at sites 0 and 1: remapping yields [0, 1]."""
     return_value = _ll(_ll(_mr(0, 0), _mr(0, 1)))
     result = get_shot_remapping(return_value, _ARCH)
-    assert result.ok
-    assert result.diagnostic is None
-    assert result.get() == [0, 1]
+    assert isinstance(result, ShotRemappingOk)
+    assert result.mapping == [0, 1]
 
 
 def test_two_logical_qubits_skipping_a_site():
@@ -99,19 +100,18 @@ def test_two_logical_qubits_skipping_a_site():
         _ll(_mr(1, 1), _mr(1, 3)),
     )
     result = get_shot_remapping(return_value, _ARCH)
-    assert result.ok
-    assert result.get() == [0, 2, 1, 3]
+    assert isinstance(result, ShotRemappingOk)
+    assert result.mapping == [0, 2, 1, 3]
 
 
 def test_outer_not_ilist_returns_diagnostic():
     """A non-IListResult outer (e.g. ``Bottom``) means the analysis
     didn't refine the SSA value past the bottom of the lattice; the
-    function gives up and returns a diagnostic identifying the bad
-    outer value."""
+    function gives up and returns ``ShotRemappingErr`` identifying
+    the bad outer value."""
     bottom = Bottom()
     result = get_shot_remapping(bottom, _ARCH)
-    assert not result.ok
-    assert result.mapping is None
+    assert isinstance(result, ShotRemappingErr)
     assert isinstance(result.diagnostic, ShotRemappingDiagnostic)
     assert "outer" in result.diagnostic.message
     assert result.diagnostic.offending_value is bottom
@@ -123,8 +123,7 @@ def test_inner_not_ilist_returns_diagnostic():
     bad_logical = _mr(0, 0)
     return_value = _ll(bad_logical)  # outer ilist of MeasureResult, no nesting
     result = get_shot_remapping(return_value, _ARCH)
-    assert not result.ok
-    assert isinstance(result.diagnostic, ShotRemappingDiagnostic)
+    assert isinstance(result, ShotRemappingErr)
     assert "logical[0]" in result.diagnostic.message
     assert result.diagnostic.offending_value is bad_logical
 
@@ -135,8 +134,7 @@ def test_innermost_not_measureresult_returns_diagnostic():
     bad_physical = Value(False)
     return_value = _ll(_ll(_mr(0, 0), bad_physical))
     result = get_shot_remapping(return_value, _ARCH)
-    assert not result.ok
-    assert isinstance(result.diagnostic, ShotRemappingDiagnostic)
+    assert isinstance(result, ShotRemappingErr)
     assert "logical[0].physical[1]" in result.diagnostic.message
     assert result.diagnostic.offending_value is bad_physical
 
@@ -148,8 +146,7 @@ def test_unknown_location_address_returns_diagnostic():
     out_of_arch = LocationAddress(99, 0, 0)
     return_value = _ll(_ll(MeasureResult(0, out_of_arch)))
     result = get_shot_remapping(return_value, _ARCH)
-    assert not result.ok
-    assert isinstance(result.diagnostic, ShotRemappingDiagnostic)
+    assert isinstance(result, ShotRemappingErr)
     assert "logical[0].physical[0]" in result.diagnostic.message
     assert "Zone-0" in result.diagnostic.message
     assert result.diagnostic.offending_value == out_of_arch
@@ -160,19 +157,11 @@ def test_empty_logical_blocks():
     outer list is also valid (no logical qubits). Both produce an
     empty mapping."""
     empty_inner = get_shot_remapping(_ll(_ll(), _ll()), _ARCH)
-    assert empty_inner.ok
-    assert empty_inner.get() == []
+    assert isinstance(empty_inner, ShotRemappingOk)
+    assert empty_inner.mapping == []
     empty_outer = get_shot_remapping(_ll(), _ARCH)
-    assert empty_outer.ok
-    assert empty_outer.get() == []
-
-
-def test_get_raises_on_failure():
-    """``ShotMappingResult.get()`` raises a ``RuntimeError`` carrying
-    the diagnostic when the mapping is unavailable."""
-    result = get_shot_remapping(Bottom(), _ARCH)
-    with pytest.raises(RuntimeError, match="ShotMappingResult"):
-        result.get()
+    assert isinstance(empty_outer, ShotRemappingOk)
+    assert empty_outer.mapping == []
 
 
 # ── Integration: end-to-end via compile_squin_to_move ──────────────────
@@ -182,8 +171,9 @@ def test_get_raises_on_failure():
 def test_get_shot_remapping_end_to_end_via_compile_squin_to_move():
     """End-to-end: compile a Steane logical kernel that returns its
     ``terminal_measure`` value, then run ``AtomInterpreter.get_shot_remapping``
-    on the lowered move kernel and assert the flat index list has the
-    expected Steane size and no overlapping indices."""
+    on the lowered move kernel and assert the flat index list matches
+    the analysis output's measurement-leaf count and has no overlapping
+    indices."""
     from bloqade import qubit, squin
     from bloqade.gemini import logical as gemini_logical
     from bloqade.lanes.analysis.atom import AtomInterpreter
@@ -206,16 +196,24 @@ def test_get_shot_remapping_end_to_end_via_compile_squin_to_move():
     result = interp.get_shot_remapping(physical_move)
 
     # The analysis must refine to a concrete remapping for this
-    # well-formed Steane kernel; a failure here would indicate an
-    # analysis or pipeline regression rather than legitimate
-    # soft-fail behaviour.
-    assert result.ok, f"unexpected diagnostic: {result.diagnostic}"
-    remapping = result.get()
+    # well-formed kernel; an Err here would indicate an analysis or
+    # pipeline regression rather than legitimate soft-fail behaviour.
+    assert isinstance(
+        result, ShotRemappingOk
+    ), f"unexpected diagnostic: {getattr(result, 'diagnostic', None)}"
+    remapping = result.mapping
 
-    # Steane [[7,1,3]] encodes one logical qubit into seven physical
-    # qubits; ``terminal_measure`` over ``num_logical`` logical qubits
-    # yields a flat list of length ``num_logical * 7``.
-    assert len(remapping) == num_logical * 7
+    # The remapping length should equal the number of MeasureResult
+    # leaves in the analysis output. Re-run the analysis here to
+    # derive the expected length from the output shape rather than
+    # hard-coding the code's block size, so the assertion stays
+    # honest if the encoder changes.
+    _, output = interp.run(physical_move)
+    assert isinstance(output, IListResult)
+    expected_len = sum(
+        len(logical.data) for logical in output.data if isinstance(logical, IListResult)
+    )
+    assert len(remapping) == expected_len
 
     # No two physical qubits map to the same Zone-0 index.
     assert len(set(remapping)) == len(

--- a/python/tests/analysis/atom/test_shot_remapping.py
+++ b/python/tests/analysis/atom/test_shot_remapping.py
@@ -14,8 +14,8 @@ from bloqade.lanes.analysis.atom import (
     IListResult,
     MeasureResult,
     Value,
-    get_shot_remapping,
 )
+from bloqade.lanes.analysis.atom._shot_remapping import get_shot_remapping
 from bloqade.lanes.bytecode._native import (
     Grid as RustGrid,
     LocationAddress as RustLocAddr,

--- a/python/tests/analysis/atom/test_shot_remapping.py
+++ b/python/tests/analysis/atom/test_shot_remapping.py
@@ -3,7 +3,7 @@
 Hand-builds a small ``ArchSpec`` with a known Zone-0 location order and
 checks that the standalone shot-remapping function projects nested
 ``IListResult[IListResult[MeasureResult]]`` values onto the expected
-indices into the architecture's Zone-0 bitstring.
+flat list of indices into the architecture's Zone-0 bitstring.
 """
 
 import pytest
@@ -79,20 +79,21 @@ def test_zone0_location_order_matches_arch_iteration():
 
 
 def test_single_logical_qubit():
-    """One logical qubit at sites 0 and 1: remapping yields [[0, 1]]."""
+    """One logical qubit at sites 0 and 1: remapping yields [0, 1]."""
     return_value = _ll(_ll(_mr(0, 0), _mr(0, 1)))
-    assert get_shot_remapping(return_value, _ARCH) == [[0, 1]]
+    assert get_shot_remapping(return_value, _ARCH) == [0, 1]
 
 
 def test_two_logical_qubits_skipping_a_site():
-    """Two logical qubits using sites 0/2 and 1/3: skipping one site
-    in between exercises that the table reports the *Zone-0* index, not
-    a packed enumeration."""
+    """Two logical qubits using sites 0/2 and 1/3: the result is the
+    flat row-major concatenation, and skipping a site in between
+    exercises that the table reports the *Zone-0* index, not a packed
+    enumeration."""
     return_value = _ll(
         _ll(_mr(0, 0), _mr(0, 2)),
         _ll(_mr(1, 1), _mr(1, 3)),
     )
-    assert get_shot_remapping(return_value, _ARCH) == [[0, 2], [1, 3]]
+    assert get_shot_remapping(return_value, _ARCH) == [0, 2, 1, 3]
 
 
 def test_outer_not_ilist_returns_none():
@@ -128,8 +129,9 @@ def test_unknown_location_address_returns_none():
 
 def test_empty_logical_blocks():
     """Empty inner lists (no physical qubits) are valid; an empty
-    outer list is also valid (no logical qubits)."""
-    assert get_shot_remapping(_ll(_ll(), _ll()), _ARCH) == [[], []]
+    outer list is also valid (no logical qubits). Both flatten to
+    an empty list."""
+    assert get_shot_remapping(_ll(_ll(), _ll()), _ARCH) == []
     assert get_shot_remapping(_ll(), _ARCH) == []
 
 
@@ -140,8 +142,8 @@ def test_empty_logical_blocks():
 def test_get_shot_remapping_end_to_end_via_compile_squin_to_move():
     """End-to-end: compile a Steane logical kernel that returns its
     ``terminal_measure`` value, then run ``AtomInterpreter.get_shot_remapping``
-    on the lowered move kernel and assert the table has the expected
-    Steane shape and no overlapping indices."""
+    on the lowered move kernel and assert the flat index list has the
+    expected Steane size and no overlapping indices."""
     from bloqade import qubit, squin
     from bloqade.gemini import logical as gemini_logical
     from bloqade.lanes.analysis.atom import AtomInterpreter
@@ -171,19 +173,16 @@ def test_get_shot_remapping_end_to_end_via_compile_squin_to_move():
 
     # Steane [[7,1,3]] encodes one logical qubit into seven physical
     # qubits; ``terminal_measure`` over ``num_logical`` logical qubits
-    # yields an outer list of length ``num_logical`` with seven
-    # ``MeasureResult``s each.
-    assert len(remapping) == num_logical
-    assert all(len(per_qubit) == 7 for per_qubit in remapping)
+    # yields a flat list of length ``num_logical * 7``.
+    assert len(remapping) == num_logical * 7
 
     # No two physical qubits map to the same Zone-0 index.
-    flat = [idx for per_qubit in remapping for idx in per_qubit]
-    assert len(set(flat)) == len(
-        flat
-    ), f"physical qubit indices overlap across logical blocks: {remapping}"
+    assert len(set(remapping)) == len(
+        remapping
+    ), f"physical qubit indices overlap: {remapping}"
 
     # All indices fall inside the Zone-0 bitstring.
     zone0_size = sum(1 for _ in arch_spec.yield_zone_locations(ZoneAddress(0)))
     assert all(
-        0 <= idx < zone0_size for idx in flat
-    ), f"index out of Zone-0 range [0, {zone0_size}): {flat}"
+        0 <= idx < zone0_size for idx in remapping
+    ), f"index out of Zone-0 range [0, {zone0_size}): {remapping}"

--- a/python/tests/analysis/atom/test_shot_remapping.py
+++ b/python/tests/analysis/atom/test_shot_remapping.py
@@ -1,0 +1,189 @@
+"""Unit tests for ``get_shot_remapping``.
+
+Hand-builds a small ``ArchSpec`` with a known Zone-0 location order and
+checks that the standalone shot-remapping function projects nested
+``IListResult[IListResult[MeasureResult]]`` values onto the expected
+indices into the architecture's Zone-0 bitstring.
+"""
+
+import pytest
+
+from bloqade.lanes import layout
+from bloqade.lanes.analysis.atom import (
+    Bottom,
+    IListResult,
+    MeasureResult,
+    Value,
+    get_shot_remapping,
+)
+from bloqade.lanes.bytecode._native import (
+    Grid as RustGrid,
+    LocationAddress as RustLocAddr,
+    Mode as RustMode,
+    Zone as RustZone,
+)
+from bloqade.lanes.layout import word
+from bloqade.lanes.layout.encoding import LocationAddress, ZoneAddress
+
+# Small toy architecture: one zone with one word containing four sites
+# at y-positions 0..3. ``yield_zone_locations(ZoneAddress(0))`` will
+# emit those four ``LocationAddress``es in order, giving a Zone-0
+# bitstring of length 4.
+_word = word.Word(sites=((0, 0), (0, 1), (0, 2), (0, 3)))
+_rust_grid = RustGrid.from_positions([0.0], [0.0, 1.0, 2.0, 3.0])
+_rust_zone = RustZone(
+    name="test",
+    grid=_rust_grid,
+    site_buses=[],
+    word_buses=[],
+    words_with_site_buses=[],
+    sites_with_word_buses=[],
+)
+_rust_mode = RustMode(
+    name="all",
+    zones=[0],
+    bitstring_order=[
+        RustLocAddr(0, 0, 0),
+        RustLocAddr(0, 0, 1),
+        RustLocAddr(0, 0, 2),
+        RustLocAddr(0, 0, 3),
+    ],
+)
+_ARCH = layout.ArchSpec.from_components(
+    words=(_word,),
+    zones=(_rust_zone,),
+    modes=[_rust_mode],
+)
+
+
+def _ll(*items):
+    """Helper to wrap a sequence of lattice values as an ``IListResult``."""
+    return IListResult(tuple(items))
+
+
+def _mr(qubit_id: int, site_id: int) -> MeasureResult:
+    """Helper to build a ``MeasureResult`` at a Zone-0 ``site_id``."""
+    return MeasureResult(qubit_id, LocationAddress(0, site_id, 0))
+
+
+def test_zone0_location_order_matches_arch_iteration():
+    """Sanity: confirm the test fixture's Zone-0 bitstring layout
+    matches arch_spec.yield_zone_locations iteration."""
+    locs = list(_ARCH.yield_zone_locations(ZoneAddress(0)))
+    assert locs == [
+        LocationAddress(0, 0, 0),
+        LocationAddress(0, 1, 0),
+        LocationAddress(0, 2, 0),
+        LocationAddress(0, 3, 0),
+    ]
+
+
+def test_single_logical_qubit():
+    """One logical qubit at sites 0 and 1: remapping yields [[0, 1]]."""
+    return_value = _ll(_ll(_mr(0, 0), _mr(0, 1)))
+    assert get_shot_remapping(return_value, _ARCH) == [[0, 1]]
+
+
+def test_two_logical_qubits_skipping_a_site():
+    """Two logical qubits using sites 0/2 and 1/3: skipping one site
+    in between exercises that the table reports the *Zone-0* index, not
+    a packed enumeration."""
+    return_value = _ll(
+        _ll(_mr(0, 0), _mr(0, 2)),
+        _ll(_mr(1, 1), _mr(1, 3)),
+    )
+    assert get_shot_remapping(return_value, _ARCH) == [[0, 2], [1, 3]]
+
+
+def test_outer_not_ilist_returns_none():
+    """A non-IListResult outer (e.g. ``Bottom``) means the analysis
+    didn't refine the SSA value past the bottom of the lattice; the
+    function gives up and returns ``None`` (callers handle the
+    diagnostic)."""
+    assert get_shot_remapping(Bottom(), _ARCH) is None
+
+
+def test_inner_not_ilist_returns_none():
+    """Each logical entry must itself be an IListResult; otherwise
+    return ``None``."""
+    return_value = _ll(_mr(0, 0))  # outer ilist of MeasureResult, no nesting
+    assert get_shot_remapping(return_value, _ARCH) is None
+
+
+def test_innermost_not_measureresult_returns_none():
+    """Innermost element must be a ``MeasureResult``; anything else
+    means the analysis didn't refine that operand. Return ``None``."""
+    return_value = _ll(_ll(_mr(0, 0), Value(False)))
+    assert get_shot_remapping(return_value, _ARCH) is None
+
+
+def test_unknown_location_address_returns_none():
+    """A ``MeasureResult`` whose ``location_address`` isn't in the
+    architecture's Zone-0 iteration is a sign of analysis/arch
+    disagreement; return ``None`` rather than raising."""
+    out_of_arch = LocationAddress(99, 0, 0)
+    return_value = _ll(_ll(MeasureResult(0, out_of_arch)))
+    assert get_shot_remapping(return_value, _ARCH) is None
+
+
+def test_empty_logical_blocks():
+    """Empty inner lists (no physical qubits) are valid; an empty
+    outer list is also valid (no logical qubits)."""
+    assert get_shot_remapping(_ll(_ll(), _ll()), _ARCH) == [[], []]
+    assert get_shot_remapping(_ll(), _ARCH) == []
+
+
+# ── Integration: end-to-end via compile_squin_to_move ──────────────────
+
+
+@pytest.mark.slow
+def test_get_shot_remapping_end_to_end_via_compile_squin_to_move():
+    """End-to-end: compile a Steane logical kernel that returns its
+    ``terminal_measure`` value, then run ``AtomInterpreter.get_shot_remapping``
+    on the lowered move kernel and assert the table has the expected
+    Steane shape and no overlapping indices."""
+    from bloqade import qubit, squin
+    from bloqade.gemini import logical as gemini_logical
+    from bloqade.lanes.analysis.atom import AtomInterpreter
+    from bloqade.lanes.arch.gemini import physical
+    from bloqade.lanes.logical_mvp import compile_squin_to_move
+
+    num_logical = 2
+
+    @gemini_logical.kernel(aggressive_unroll=True)
+    def main():
+        reg = qubit.qalloc(num_logical)
+        squin.h(reg[0])
+        squin.cx(reg[0], reg[1])
+        return gemini_logical.terminal_measure(reg)
+
+    arch_spec = physical.get_arch_spec()
+    physical_move = compile_squin_to_move(main, transversal_rewrite=True)
+
+    interp = AtomInterpreter(physical_move.dialects, arch_spec=arch_spec)
+    remapping = interp.get_shot_remapping(physical_move)
+
+    # The analysis must refine to a concrete remapping for this
+    # well-formed Steane kernel; ``None`` here would indicate an
+    # analysis or pipeline regression rather than legitimate
+    # soft-fail behaviour.
+    assert remapping is not None
+
+    # Steane [[7,1,3]] encodes one logical qubit into seven physical
+    # qubits; ``terminal_measure`` over ``num_logical`` logical qubits
+    # yields an outer list of length ``num_logical`` with seven
+    # ``MeasureResult``s each.
+    assert len(remapping) == num_logical
+    assert all(len(per_qubit) == 7 for per_qubit in remapping)
+
+    # No two physical qubits map to the same Zone-0 index.
+    flat = [idx for per_qubit in remapping for idx in per_qubit]
+    assert len(set(flat)) == len(
+        flat
+    ), f"physical qubit indices overlap across logical blocks: {remapping}"
+
+    # All indices fall inside the Zone-0 bitstring.
+    zone0_size = sum(1 for _ in arch_spec.yield_zone_locations(ZoneAddress(0)))
+    assert all(
+        0 <= idx < zone0_size for idx in flat
+    ), f"index out of Zone-0 range [0, {zone0_size}): {flat}"

--- a/python/tests/analysis/atom/test_shot_remapping.py
+++ b/python/tests/analysis/atom/test_shot_remapping.py
@@ -3,7 +3,8 @@
 Hand-builds a small ``ArchSpec`` with a known Zone-0 location order and
 checks that the standalone shot-remapping function projects nested
 ``IListResult[IListResult[MeasureResult]]`` values onto the expected
-flat list of indices into the architecture's Zone-0 bitstring.
+flat list of indices into the architecture's Zone-0 bitstring,
+emitting structured diagnostics on the soft-fail paths.
 """
 
 import pytest
@@ -13,6 +14,7 @@ from bloqade.lanes.analysis.atom import (
     Bottom,
     IListResult,
     MeasureResult,
+    ShotRemappingDiagnostic,
     Value,
 )
 from bloqade.lanes.analysis.atom._shot_remapping import get_shot_remapping
@@ -81,7 +83,10 @@ def test_zone0_location_order_matches_arch_iteration():
 def test_single_logical_qubit():
     """One logical qubit at sites 0 and 1: remapping yields [0, 1]."""
     return_value = _ll(_ll(_mr(0, 0), _mr(0, 1)))
-    assert get_shot_remapping(return_value, _ARCH) == [0, 1]
+    result = get_shot_remapping(return_value, _ARCH)
+    assert result.ok
+    assert result.diagnostic is None
+    assert result.get() == [0, 1]
 
 
 def test_two_logical_qubits_skipping_a_site():
@@ -93,46 +98,81 @@ def test_two_logical_qubits_skipping_a_site():
         _ll(_mr(0, 0), _mr(0, 2)),
         _ll(_mr(1, 1), _mr(1, 3)),
     )
-    assert get_shot_remapping(return_value, _ARCH) == [0, 2, 1, 3]
+    result = get_shot_remapping(return_value, _ARCH)
+    assert result.ok
+    assert result.get() == [0, 2, 1, 3]
 
 
-def test_outer_not_ilist_returns_none():
+def test_outer_not_ilist_returns_diagnostic():
     """A non-IListResult outer (e.g. ``Bottom``) means the analysis
     didn't refine the SSA value past the bottom of the lattice; the
-    function gives up and returns ``None`` (callers handle the
-    diagnostic)."""
-    assert get_shot_remapping(Bottom(), _ARCH) is None
+    function gives up and returns a diagnostic identifying the bad
+    outer value."""
+    bottom = Bottom()
+    result = get_shot_remapping(bottom, _ARCH)
+    assert not result.ok
+    assert result.mapping is None
+    assert isinstance(result.diagnostic, ShotRemappingDiagnostic)
+    assert "outer" in result.diagnostic.message
+    assert result.diagnostic.offending_value is bottom
 
 
-def test_inner_not_ilist_returns_none():
-    """Each logical entry must itself be an IListResult; otherwise
-    return ``None``."""
-    return_value = _ll(_mr(0, 0))  # outer ilist of MeasureResult, no nesting
-    assert get_shot_remapping(return_value, _ARCH) is None
+def test_inner_not_ilist_returns_diagnostic():
+    """Each logical entry must itself be an IListResult; otherwise the
+    diagnostic identifies which logical block went wrong."""
+    bad_logical = _mr(0, 0)
+    return_value = _ll(bad_logical)  # outer ilist of MeasureResult, no nesting
+    result = get_shot_remapping(return_value, _ARCH)
+    assert not result.ok
+    assert isinstance(result.diagnostic, ShotRemappingDiagnostic)
+    assert "logical[0]" in result.diagnostic.message
+    assert result.diagnostic.offending_value is bad_logical
 
 
-def test_innermost_not_measureresult_returns_none():
-    """Innermost element must be a ``MeasureResult``; anything else
-    means the analysis didn't refine that operand. Return ``None``."""
-    return_value = _ll(_ll(_mr(0, 0), Value(False)))
-    assert get_shot_remapping(return_value, _ARCH) is None
+def test_innermost_not_measureresult_returns_diagnostic():
+    """Innermost element must be a ``MeasureResult``; the diagnostic
+    points at the offending physical index."""
+    bad_physical = Value(False)
+    return_value = _ll(_ll(_mr(0, 0), bad_physical))
+    result = get_shot_remapping(return_value, _ARCH)
+    assert not result.ok
+    assert isinstance(result.diagnostic, ShotRemappingDiagnostic)
+    assert "logical[0].physical[1]" in result.diagnostic.message
+    assert result.diagnostic.offending_value is bad_physical
 
 
-def test_unknown_location_address_returns_none():
+def test_unknown_location_address_returns_diagnostic():
     """A ``MeasureResult`` whose ``location_address`` isn't in the
     architecture's Zone-0 iteration is a sign of analysis/arch
-    disagreement; return ``None`` rather than raising."""
+    disagreement; return a diagnostic carrying the offending address."""
     out_of_arch = LocationAddress(99, 0, 0)
     return_value = _ll(_ll(MeasureResult(0, out_of_arch)))
-    assert get_shot_remapping(return_value, _ARCH) is None
+    result = get_shot_remapping(return_value, _ARCH)
+    assert not result.ok
+    assert isinstance(result.diagnostic, ShotRemappingDiagnostic)
+    assert "logical[0].physical[0]" in result.diagnostic.message
+    assert "Zone-0" in result.diagnostic.message
+    assert result.diagnostic.offending_value == out_of_arch
 
 
 def test_empty_logical_blocks():
     """Empty inner lists (no physical qubits) are valid; an empty
-    outer list is also valid (no logical qubits). Both flatten to
-    an empty list."""
-    assert get_shot_remapping(_ll(_ll(), _ll()), _ARCH) == []
-    assert get_shot_remapping(_ll(), _ARCH) == []
+    outer list is also valid (no logical qubits). Both produce an
+    empty mapping."""
+    empty_inner = get_shot_remapping(_ll(_ll(), _ll()), _ARCH)
+    assert empty_inner.ok
+    assert empty_inner.get() == []
+    empty_outer = get_shot_remapping(_ll(), _ARCH)
+    assert empty_outer.ok
+    assert empty_outer.get() == []
+
+
+def test_get_raises_on_failure():
+    """``ShotMappingResult.get()`` raises a ``RuntimeError`` carrying
+    the diagnostic when the mapping is unavailable."""
+    result = get_shot_remapping(Bottom(), _ARCH)
+    with pytest.raises(RuntimeError, match="ShotMappingResult"):
+        result.get()
 
 
 # ── Integration: end-to-end via compile_squin_to_move ──────────────────
@@ -163,13 +203,14 @@ def test_get_shot_remapping_end_to_end_via_compile_squin_to_move():
     physical_move = compile_squin_to_move(main, transversal_rewrite=True)
 
     interp = AtomInterpreter(physical_move.dialects, arch_spec=arch_spec)
-    remapping = interp.get_shot_remapping(physical_move)
+    result = interp.get_shot_remapping(physical_move)
 
     # The analysis must refine to a concrete remapping for this
-    # well-formed Steane kernel; ``None`` here would indicate an
+    # well-formed Steane kernel; a failure here would indicate an
     # analysis or pipeline regression rather than legitimate
     # soft-fail behaviour.
-    assert remapping is not None
+    assert result.ok, f"unexpected diagnostic: {result.diagnostic}"
+    remapping = result.get()
 
     # Steane [[7,1,3]] encodes one logical qubit into seven physical
     # qubits; ``terminal_measure`` over ``num_logical`` logical qubits

--- a/python/tests/rewrite/move2squin/test_gate.py
+++ b/python/tests/rewrite/move2squin/test_gate.py
@@ -443,7 +443,8 @@ def test_insert_measurements():
     }
 
     frame: forward.ForwardFrame[atom.MoveExecution] = forward.ForwardFrame(
-        gate_node, entries={gate_node.result: atom.MeasureResult(0)}
+        gate_node,
+        entries={gate_node.result: atom.MeasureResult(0, layout.LocationAddress(0, 0))},
     )
 
     rule = gates.InsertMeasurements(


### PR DESCRIPTION
## Summary

Closes #563. Adds the bridge between a raw hardware shot (a full Zone-0 bitstring with one bit per `LocationAddress` in `arch_spec.yield_zone_locations(ZoneAddress(0))`, including empty sites) and the per-measurement `np.ndarray` shape `bloqade.gemini.post_processing.generate_post_processing` expects.

This is the durable piece of the original #98 that didn't get superseded by `m2dets` / `m2obs`: hardware shots come back as a full Zone-0 bitstring, and *something* has to project that onto the flat per-measurement array consumed by the post-processing callable produced by `generate_post_processing`. That mapping is what this PR provides.

## Design changes vs. the original spec

Three implementation shifts surfaced during review and are baked into the final PR:

1. **Flat `list[int]` mapping (was `list[list[int]]`).** The original #563 spec called for a list-of-lists indexed by logical qubit, but post-processing takes a flat per-measurement array of shape `(n_shots, n_measurements)`. The flat result indexes directly into the post-processing input array; logical-qubit grouping is recoverable from the kernel itself.
2. **Tagged-union return type (was `list[int] | None` then a single nullable `ShotMappingResult`).** A failure here is a compiler-pipeline regression, not a user error, and the compiler service needs structured debug context — not just `None` and not a string buried in a `RuntimeError`. The result type is now `ShotRemappingOk | ShotRemappingErr`, two independent frozen dataclasses; illegal states are unconstructible.
3. **Default `no_raise=True` on the interpreter wrapper.** `AtomInterpreter.get_shot_remapping(method, *, no_raise=True)` routes through `Forward.run_no_raise`, so an analysis crash falls through into the standard `ShotRemappingErr` path with the `Bottom` lattice as the offending value. Callers see one failure shape; flip `no_raise=False` when debugging an analysis-side bug.

Issue body updated to reflect these shifts.

## API

### Convenience method on `AtomInterpreter`

```python
interp = AtomInterpreter(method.dialects, arch_spec=arch_spec)
match interp.get_shot_remapping(method):
    case ShotRemappingOk(mapping):
        use(mapping)  # list[int] in row-major order
    case ShotRemappingErr(diagnostic):
        log.error("shot remapping failed: %s", diagnostic.message)
```

### Public types

```python
@dataclass(frozen=True)
class ShotRemappingDiagnostic:
    message: str
    offending_value: MoveExecution | LocationAddress

@dataclass(frozen=True)
class ShotRemappingOk:
    mapping: list[int]

@dataclass(frozen=True)
class ShotRemappingErr:
    diagnostic: ShotRemappingDiagnostic
```

All three are re-exported from `bloqade.lanes.analysis.atom` since the compiler service needs to reference them. The standalone `_shot_remapping.get_shot_remapping(return_value, arch_spec)` function stays private — the public surface is the `AtomInterpreter` method; the helper exists so unit tests can drive it with hand-built lattice values without spinning up a kirin method.

## Failure modes (compiler-developer-facing)

`get_shot_remapping` produces a `ShotRemappingErr` carrying a `ShotRemappingDiagnostic` on:

- **Outer / nested-shape mismatch** — `return_value` (or any nested element) is not the expected `IListResult[IListResult[MeasureResult]]` (any other lattice type — `Bottom`, `Unknown`, `Value`, `MeasureFuture`, `MeasureResult`, `DetectorResult`, `ObservableResult`, `TupleResult` — triggers the failure). The diagnostic identifies the failure site by row-major index path (`logical[i]` / `logical[i].physical[j]`).
- **Address outside Zone-0** — a `MeasureResult.location_address` resolves outside `arch_spec`'s Zone-0 iteration, signalling analysis/arch disagreement about hardware layout.

A failure here indicates a pipeline regression rather than a malformed kernel, so the diagnostic is aimed at compiler developers debugging the failed lowering — not surfaced verbatim to users.

## Implementation notes

- **`MeasureResult` lattice element** gains a `location_address: LocationAddress` field. `get_future_result_impl` already had `stmt.location_address` locally — it's now threaded onto the lattice value.
- **`ArchSpec.get_zone_index(loc, zone)`** (O(1) via Rust backend) is used for the Zone-0 index lookup, so we don't materialise a redundant Python dict per call. The helper asserts `len(arch_spec.zones) > 0` at the top so the "address is not in Zone-0" diagnostic stays truthful even if a future arch spec violates the implicit invariant.

## Tests

- **8 unit tests** with hand-built lattice values + a small ArchSpec — cover the happy path (flat output across one or more logical blocks), all four soft-fail conditions (each asserting the diagnostic message identifies the failure site and carries the right offending value), and the empty-list edge cases.
- **1 `@pytest.mark.slow` integration test** compiles a 2-logical-qubit Steane kernel via `compile_squin_to_move(transversal_rewrite=True)` and asserts the resulting flat remapping length matches the analysis output's leaf count (derived from the output, not from the Steane block size), has no overlapping indices, and stays inside the Zone-0 bitstring range.
- Existing `MeasureResult` constructor sites in `test_lattice.py`, `test_atom_interpreter.py`, and `test_gate.py` updated for the new `location_address` arg.

## Test plan

- [x] `uv run pytest python/tests/` — full suite passes.
- [x] `uv run pyright python/` — clean.
- [x] Lint / black / isort — clean.

## Out of scope (separate follow-ups)

- Replacing `m2dets` / `m2obs` static matrices with dynamically-derived equivalents.
- Porting / re-using `RemovePostProcessing` from `QuEraComputing/bloqade-internal#222` once that merges.
- Deprecating the callable-based `PostProcessing` at `analysis/atom/analysis.py:39`.
- ArchSpec congruence enforcement between hardware and software.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
