### PR TITLE
refactor(arch): rename bytecode/arch.py to bytecode/grid.py (stage 4 of #569, non-breaking shim)

### DIFF
--- a/python/bloqade/lanes/bytecode/arch.py
+++ b/python/bloqade/lanes/bytecode/arch.py
@@ -1,23 +1,13 @@
-from bloqade.geometry.dialects import grid as geometry_grid
+"""TRANSITIONAL SHIM — see ``.superpowers/plans/2026-04-27-archspec-package-merge.md``
+(Stage 4) for the rationale. The original ``bytecode/arch.py`` only held
+two ``Grid`` conversion utilities; the file was renamed to ``grid.py``
+(matching its responsibility) to free the ``arch`` slot for the higher-tier
+arch surface.
 
-from bloqade.lanes.bytecode._native import Grid
+Removed in the final cleanup stage.
+"""
 
-
-def grid_to_rust(g: geometry_grid.Grid) -> Grid:
-    """Convert a bloqade-geometry Grid to a Rust bytecode Grid."""
-    return Grid(
-        x_start=g.x_init,  # type: ignore[arg-type]
-        y_start=g.y_init,  # type: ignore[arg-type]
-        x_spacing=list(g.x_spacing),
-        y_spacing=list(g.y_spacing),
-    )
-
-
-def grid_from_rust(g: Grid) -> geometry_grid.Grid:
-    """Convert a Rust bytecode Grid to a bloqade-geometry Grid."""
-    return geometry_grid.Grid(
-        x_init=g.x_start,
-        y_init=g.y_start,
-        x_spacing=list(g.x_spacing),  # type: ignore[arg-type]
-        y_spacing=list(g.y_spacing),  # type: ignore[arg-type]
-    )
+from bloqade.lanes.bytecode.grid import (
+    grid_from_rust as grid_from_rust,
+    grid_to_rust as grid_to_rust,
+)

--- a/python/bloqade/lanes/bytecode/grid.py
+++ b/python/bloqade/lanes/bytecode/grid.py
@@ -1,0 +1,23 @@
+from bloqade.geometry.dialects import grid as geometry_grid
+
+from bloqade.lanes.bytecode._native import Grid
+
+
+def grid_to_rust(g: geometry_grid.Grid) -> Grid:
+    """Convert a bloqade-geometry Grid to a Rust bytecode Grid."""
+    return Grid(
+        x_start=g.x_init,  # type: ignore[arg-type]
+        y_start=g.y_init,  # type: ignore[arg-type]
+        x_spacing=list(g.x_spacing),
+        y_spacing=list(g.y_spacing),
+    )
+
+
+def grid_from_rust(g: Grid) -> geometry_grid.Grid:
+    """Convert a Rust bytecode Grid to a bloqade-geometry Grid."""
+    return geometry_grid.Grid(
+        x_init=g.x_start,
+        y_init=g.y_start,
+        x_spacing=list(g.x_spacing),  # type: ignore[arg-type]
+        y_spacing=list(g.y_spacing),  # type: ignore[arg-type]
+    )


### PR DESCRIPTION
## Summary

Stage 4 of the multi-stage package merge tracked in #569. Renames `bloqade.lanes.bytecode.arch` (which held only two `Grid` conversion utilities, `grid_to_rust` / `grid_from_rust`) to `bloqade.lanes.bytecode.grid`. The filename now matches its responsibility, and the `arch` slot is freed for the higher-tier arch surface in later stages.

**Non-breaking**: the old path stays alive as a re-export shim.

See PR #571 (Stage 1) for the broader strategy.

## Test plan

- [x] `uv run pyright python python/tests` — clean.
- [x] `uv run ruff check python` — clean.
- Full pytest suite runs in CI.

Refs #569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
