### PR TITLE
fix(benchmarks): avoid Initialize validation failure

### DIFF
--- a/python/bloqade/lanes/upstream.py
+++ b/python/bloqade/lanes/upstream.py
@@ -42,6 +42,21 @@ class NativeToPlace:
 
     def emit(self, mt: Method, no_raise: bool = True):
         out = mt.similar(mt.dialects.add(place))
+        if self.arch_spec is not None:
+            from bloqade.gemini.analysis.duplicate_address_validation import (
+                DuplicateAddressValidation,
+            )
+            from bloqade.lanes.validation.address import Validation
+
+            errors: list[ir.ValidationError] = []
+            _, per_stmt_errors = Validation(arch_spec=self.arch_spec).run(out)
+            errors.extend(per_stmt_errors)
+            _, dup_errors = DuplicateAddressValidation().run(out)
+            errors.extend(dup_errors)
+            if errors:
+                message = f"Gemini IR validation failed with {len(errors)} error(s)"
+                raise ValidationErrorGroup(message, errors=errors)
+
         if self.logical_initialize:
             rule = rewrite.Chain(
                 rewrite.Walk(
@@ -58,21 +73,6 @@ class NativeToPlace:
         rewrite.Walk(scf2cf.ScfToCfRule()).rewrite(out.code)
 
         rewrite.Walk(circuit2place.HoistConstants()).rewrite(out.code)
-
-        if self.arch_spec is not None:
-            from bloqade.gemini.analysis.duplicate_address_validation import (
-                DuplicateAddressValidation,
-            )
-            from bloqade.lanes.validation.address import Validation
-
-            errors: list[ir.ValidationError] = []
-            _, per_stmt_errors = Validation(arch_spec=self.arch_spec).run(out)
-            errors.extend(per_stmt_errors)
-            _, dup_errors = DuplicateAddressValidation().run(out)
-            errors.extend(dup_errors)
-            if errors:
-                message = f"Gemini IR validation failed with {len(errors)} error(s)"
-                raise ValidationErrorGroup(message, errors=errors)
 
         if self.logical_initialize:
             rewrite.Walk(circuit2place.RewriteInitializeToLogicalInitialize()).rewrite(

--- a/python/tests/gemini/validation/test_e3_pipeline_validation.py
+++ b/python/tests/gemini/validation/test_e3_pipeline_validation.py
@@ -11,8 +11,13 @@ from kirin.ir.exception import ValidationErrorGroup
 
 import bloqade.gemini as gemini
 from bloqade.gemini.common import new_at
+from bloqade.lanes.compile import compile_to_physical_squin_noise_model
 from bloqade.lanes.heuristics.logical.layout import LogicalLayoutHeuristic
 from bloqade.lanes.heuristics.logical.placement import LogicalPlacementStrategyNoHome
+from bloqade.lanes.heuristics.physical.layout import (
+    PhysicalLayoutHeuristicGraphPartitionCenterOut,
+)
+from bloqade.lanes.heuristics.physical.placement import PhysicalPlacementStrategy
 from bloqade.lanes.upstream import squin_to_move
 
 # ---------------------------------------------------------------------------
@@ -95,6 +100,22 @@ def test_pipeline_catches_duplicate_addresses():
     errors = exc_info.value.errors
     assert len(errors) >= 1
     assert any("pinned by two" in str(e) for e in errors)
+
+
+def test_pipeline_physical_noise_u3_kernel_compiles_without_initialize_validation_error():
+    """Physical U3 noise compilation should not expose Initialize to validation."""
+
+    @squin.kernel(typeinfer=True, fold=True)
+    def kernel():
+        q = squin.qalloc(2)
+        squin.u3(1.57079632679, 0.0, 3.14159265359, q[0])
+        squin.cz(q[0], q[1])
+
+    compile_to_physical_squin_noise_model(
+        kernel,
+        layout_heuristic=PhysicalLayoutHeuristicGraphPartitionCenterOut(),
+        placement_strategy=PhysicalPlacementStrategy(),
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Run eager explicit-allocation validation before logical initialization rewrites introduce Gemini `Initialize` statements.
- Add a regression test covering the physical noise/fidelity compile path for `squin.u3` kernels.

## Test plan
- `uv run --python /Users/jasonludmir/.local/bin/python3.12 --locked pytest python/tests/gemini/validation/test_e3_pipeline_validation.py -v`
- `uv run --python /Users/jasonludmir/.local/bin/python3.12 --locked pytest python/tests/test_compile_api_split.py python/tests/gemini/validation/test_e3_pipeline_validation.py -v`
- `uv run --python /Users/jasonludmir/.local/bin/python3.12 --locked python -m benchmarks.cli --architecture physical --cases adder_4,qpe_9,trotter_rand_35 --strategies rust_astar --output /tmp/benchmark-init-fix.csv`

Fixes #589

Made with [Cursor](https://cursor.com)