### PR TITLE
feat(pipeline): split LogicalPipeline / PhysicalPipeline

### DIFF
--- a/python/bloqade/gemini/common/impl/__init__.py
+++ b/python/bloqade/gemini/common/impl/__init__.py
@@ -1,1 +1,5 @@
-from . import duplicate_address as duplicate_address, qubit_address as qubit_address
+from . import (
+    duplicate_address as duplicate_address,
+    qubit_address as qubit_address,
+    terminal_measure as terminal_measure,
+)

--- a/python/bloqade/gemini/common/impl/terminal_measure.py
+++ b/python/bloqade/gemini/common/impl/terminal_measure.py
@@ -1,0 +1,47 @@
+from typing import TYPE_CHECKING
+
+import bloqade.qubit as qubit
+from kirin import interp as _interp, ir
+from kirin.analysis import ForwardFrame
+
+from bloqade.gemini.common.validation.terminal_measure import _collect_qubit_ids
+
+if TYPE_CHECKING:
+    from bloqade.gemini.common.validation.terminal_measure import (
+        _PhysicalTerminalMeasurementAnalysis,
+    )
+
+
+@qubit.dialect.register(key="gemini.validate.physical.terminal_measure")
+class _PhysicalMeasureValidation(_interp.MethodTable):
+    @_interp.impl(qubit.stmts.Measure)
+    def measure(
+        self,
+        interp: "_PhysicalTerminalMeasurementAnalysis",
+        frame: ForwardFrame,
+        stmt: qubit.stmts.Measure,
+    ):
+        if interp.measure_count > 0:
+            interp.add_validation_error(
+                stmt,
+                ir.ValidationError(
+                    stmt,
+                    "Multiple terminal measurements are not allowed in physical circuits; "
+                    "only one qubit.stmts.Measure is permitted.",
+                ),
+            )
+        else:
+            measured_ids = _collect_qubit_ids(interp.address_frame.get(stmt.qubits))
+            expected_ids = set(range(interp.total_qubits))
+            if measured_ids != expected_ids:
+                interp.add_validation_error(
+                    stmt,
+                    ir.ValidationError(
+                        stmt,
+                        f"Terminal measure covers {len(measured_ids)} qubit(s) but "
+                        f"{interp.total_qubits} were allocated; all qubits must be measured.",
+                    ),
+                )
+
+        interp.measure_count += 1
+        return (interp.lattice.bottom(),)

--- a/python/bloqade/gemini/common/validation/__init__.py
+++ b/python/bloqade/gemini/common/validation/__init__.py
@@ -1,1 +1,5 @@
-from . import duplicate_address as duplicate_address, new_at as new_at
+from . import (
+    duplicate_address as duplicate_address,
+    new_at as new_at,
+    terminal_measure as terminal_measure,
+)

--- a/python/bloqade/gemini/common/validation/terminal_measure.py
+++ b/python/bloqade/gemini/common/validation/terminal_measure.py
@@ -1,10 +1,17 @@
-"""Pre-compilation validation for physical circuits (post-unroll).
+"""Terminal-measurement validation for physical Gemini programs (post-unroll).
 
-Checks that the unrolled squin kernel has exactly one qubit.stmts.Measure statement
-and that it consumes every qubit allocated in the circuit.
+``PhysicalTerminalMeasurementValidation`` checks that the unrolled squin kernel
+has exactly one ``qubit.stmts.Measure`` statement and that it consumes every
+qubit allocated in the circuit.
 
-Run this after SquinToNative + AggressiveUnroll so that qubit.stmts.New and
-qubit.stmts.Measure are present as direct IR statements rather than Invokes.
+Run this after ``SquinToNative`` + ``AggressiveUnroll`` so that
+``qubit.stmts.New`` and ``qubit.stmts.Measure`` are present as direct IR
+statements rather than Invokes.
+
+The ``_PhysicalTerminalMeasurementAnalysis`` Forward pass accumulates a
+``measure_count`` on the interpreter; the per-statement impl is registered in
+``bloqade.gemini.common.impl.terminal_measure`` under the key
+``"gemini.validate.physical.terminal_measure"``.
 """
 
 from __future__ import annotations
@@ -12,10 +19,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-import bloqade.qubit as qubit_dialect
 from bloqade.analysis import address
 from bloqade.analysis.address.lattice import AddressQubit, AddressReg, PartialIList
 from kirin import ir
+from kirin.analysis import Forward, ForwardFrame
+from kirin.lattice import EmptyLattice
 from kirin.validation import ValidationPass
 
 
@@ -34,16 +42,31 @@ def _collect_qubit_ids(addr: address.Address) -> set[int]:
 
 
 @dataclass
+class _PhysicalTerminalMeasurementAnalysis(Forward[EmptyLattice]):
+    """Forward dataflow pass that validates the physical terminal measurement.
+
+    ``measure_count`` accumulates across the walk via the impl registered in
+    ``bloqade.gemini.common.impl.terminal_measure``.
+    """
+
+    keys = ("gemini.validate.physical.terminal_measure",)
+    lattice = EmptyLattice
+
+    address_frame: ForwardFrame
+    total_qubits: int
+    measure_count: int = field(init=False, default=0)
+
+    def eval_fallback(self, frame: ForwardFrame, node: ir.Statement):
+        return tuple(self.lattice.bottom() for _ in node.results)
+
+    def method_self(self, method: ir.Method) -> EmptyLattice:
+        return self.lattice.bottom()
+
+
+@dataclass
 class PhysicalTerminalMeasurementValidation(ValidationPass):
-    """Validate that a physical circuit has exactly one terminal measure
-    covering all allocated qubits.
-
-    Pre-condition: IR has been through SquinToNative + AggressiveUnroll so that
-    qubit.stmts.New and qubit.stmts.Measure are direct IR statements.
-
-    Checks:
-    1. Exactly one qubit.stmts.Measure statement exists.
-    2. Its qubits argument covers all qubits allocated in the circuit.
+    """Validate that a physical (post-unroll) circuit contains exactly one
+    ``qubit.stmts.Measure`` consuming all allocated qubits.
     """
 
     analysis_cache: dict = field(default_factory=dict)
@@ -58,23 +81,22 @@ class PhysicalTerminalMeasurementValidation(ValidationPass):
         self.analysis_cache.update(cache)
 
     def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
-        measure_stmts = [
-            s
-            for s in method.callable_region.walk()
-            if isinstance(s, qubit_dialect.stmts.Measure)
-        ]
-
         addr_analysis = address.AddressAnalysis(dialects=method.dialects)
-        frame, _ = addr_analysis.run(method)
+        address_frame, _ = addr_analysis.run(method)
         total_qubits = addr_analysis.qubit_count
 
-        errors: list[ir.ValidationError] = []
+        analysis = _PhysicalTerminalMeasurementAnalysis(
+            method.dialects,
+            address_frame=address_frame,
+            total_qubits=total_qubits,
+        )
+        frame, _ = analysis.run(method)
 
-        # Anchor method-level errors to the return statement.
-        return_stmt = method.callable_region.blocks[0].last_stmt
-        assert return_stmt is not None
+        errors = list(analysis.get_validation_errors())
 
-        if len(measure_stmts) == 0:
+        if analysis.measure_count == 0:
+            return_stmt = method.callable_region.blocks[0].last_stmt
+            assert return_stmt is not None
             errors.append(
                 ir.ValidationError(
                     return_stmt,
@@ -82,28 +104,5 @@ class PhysicalTerminalMeasurementValidation(ValidationPass):
                     "consuming all allocated qubits; none found.",
                 )
             )
-            return None, errors
 
-        if len(measure_stmts) > 1:
-            for extra in measure_stmts[1:]:
-                errors.append(
-                    ir.ValidationError(
-                        extra,
-                        "Multiple qubit.stmts.Measure statements found; only one "
-                        "terminal measure is allowed in a physical circuit.",
-                    )
-                )
-
-        measure = measure_stmts[0]
-        measured_ids = _collect_qubit_ids(frame.get(measure.qubits))
-        expected_ids = set(range(total_qubits))
-        if measured_ids != expected_ids:
-            errors.append(
-                ir.ValidationError(
-                    measure,
-                    f"Terminal measure covers {len(measured_ids)} qubit(s) but "
-                    f"{total_qubits} were allocated; all qubits must be measured.",
-                )
-            )
-
-        return None, errors
+        return frame, errors

--- a/python/bloqade/gemini/common/validation/terminal_measure.py
+++ b/python/bloqade/gemini/common/validation/terminal_measure.py
@@ -38,7 +38,7 @@ def _collect_qubit_ids(addr: address.Address) -> set[int]:
         for elem in addr.data:
             result |= _collect_qubit_ids(elem)
         return result
-    raise TypeError(f"Unhandled Address type: {type(addr)}")
+    raise ValueError(f"Unhandled Address type: {type(addr)}")
 
 
 @dataclass

--- a/python/bloqade/gemini/common/validation/terminal_measure.py
+++ b/python/bloqade/gemini/common/validation/terminal_measure.py
@@ -1,0 +1,109 @@
+"""Pre-compilation validation for physical circuits (post-unroll).
+
+Checks that the unrolled squin kernel has exactly one qubit.stmts.Measure statement
+and that it consumes every qubit allocated in the circuit.
+
+Run this after SquinToNative + AggressiveUnroll so that qubit.stmts.New and
+qubit.stmts.Measure are present as direct IR statements rather than Invokes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import bloqade.qubit as qubit_dialect
+from bloqade.analysis import address
+from bloqade.analysis.address.lattice import AddressQubit, AddressReg, PartialIList
+from kirin import ir
+from kirin.validation import ValidationPass
+
+
+def _collect_qubit_ids(addr: address.Address) -> set[int]:
+    """Recursively collect all qubit IDs from an Address lattice value."""
+    if isinstance(addr, AddressQubit):
+        return {addr.data}
+    if isinstance(addr, AddressReg):
+        return set(addr.data)
+    if isinstance(addr, PartialIList):
+        result: set[int] = set()
+        for elem in addr.data:
+            result |= _collect_qubit_ids(elem)
+        return result
+    return set()
+
+
+@dataclass
+class PhysicalTerminalMeasurementValidation(ValidationPass):
+    """Validate that a physical circuit has exactly one terminal measure
+    covering all allocated qubits.
+
+    Pre-condition: IR has been through SquinToNative + AggressiveUnroll so that
+    qubit.stmts.New and qubit.stmts.Measure are direct IR statements.
+
+    Checks:
+    1. Exactly one qubit.stmts.Measure statement exists.
+    2. Its qubits argument covers all qubits allocated in the circuit.
+    """
+
+    analysis_cache: dict = field(default_factory=dict)
+
+    def name(self) -> str:
+        return "Physical Terminal Measurement Validation"
+
+    def get_required_analyses(self) -> list[type]:
+        return []
+
+    def set_analysis_cache(self, cache: dict[type, Any]) -> None:
+        self.analysis_cache.update(cache)
+
+    def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
+        measure_stmts = [
+            s
+            for s in method.callable_region.walk()
+            if isinstance(s, qubit_dialect.stmts.Measure)
+        ]
+
+        addr_analysis = address.AddressAnalysis(dialects=method.dialects)
+        frame, _ = addr_analysis.run(method)
+        total_qubits = addr_analysis.qubit_count
+
+        errors: list[ir.ValidationError] = []
+
+        # Anchor method-level errors to the return statement.
+        return_stmt = method.callable_region.blocks[0].last_stmt
+        assert return_stmt is not None
+
+        if len(measure_stmts) == 0:
+            errors.append(
+                ir.ValidationError(
+                    return_stmt,
+                    "Physical circuit must end with exactly one terminal measure "
+                    "consuming all allocated qubits; none found.",
+                )
+            )
+            return None, errors
+
+        if len(measure_stmts) > 1:
+            for extra in measure_stmts[1:]:
+                errors.append(
+                    ir.ValidationError(
+                        extra,
+                        "Multiple qubit.stmts.Measure statements found; only one "
+                        "terminal measure is allowed in a physical circuit.",
+                    )
+                )
+
+        measure = measure_stmts[0]
+        measured_ids = _collect_qubit_ids(frame.get(measure.qubits))
+        expected_ids = set(range(total_qubits))
+        if measured_ids != expected_ids:
+            errors.append(
+                ir.ValidationError(
+                    measure,
+                    f"Terminal measure covers {len(measured_ids)} qubit(s) but "
+                    f"{total_qubits} were allocated; all qubits must be measured.",
+                )
+            )
+
+        return None, errors

--- a/python/bloqade/gemini/common/validation/terminal_measure.py
+++ b/python/bloqade/gemini/common/validation/terminal_measure.py
@@ -69,16 +69,8 @@ class PhysicalTerminalMeasurementValidation(ValidationPass):
     ``qubit.stmts.Measure`` consuming all allocated qubits.
     """
 
-    analysis_cache: dict = field(default_factory=dict)
-
     def name(self) -> str:
         return "Physical Terminal Measurement Validation"
-
-    def get_required_analyses(self) -> list[type]:
-        return []
-
-    def set_analysis_cache(self, cache: dict[type, Any]) -> None:
-        self.analysis_cache.update(cache)
 
     def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
         addr_analysis = address.AddressAnalysis(dialects=method.dialects)

--- a/python/bloqade/gemini/common/validation/terminal_measure.py
+++ b/python/bloqade/gemini/common/validation/terminal_measure.py
@@ -38,7 +38,7 @@ def _collect_qubit_ids(addr: address.Address) -> set[int]:
         for elem in addr.data:
             result |= _collect_qubit_ids(elem)
         return result
-    return set()
+    raise TypeError(f"Unhandled Address type: {type(addr)}")
 
 
 @dataclass
@@ -96,7 +96,11 @@ class PhysicalTerminalMeasurementValidation(ValidationPass):
 
         if analysis.measure_count == 0:
             return_stmt = method.callable_region.blocks[0].last_stmt
-            assert return_stmt is not None
+            if return_stmt is None:
+                raise RuntimeError(
+                    "PhysicalTerminalMeasurementValidation: method has no statements; "
+                    "cannot attach missing-measure error."
+                )
             errors.append(
                 ir.ValidationError(
                     return_stmt,

--- a/python/bloqade/lanes/compile.py
+++ b/python/bloqade/lanes/compile.py
@@ -10,15 +10,11 @@ from bloqade.lanes.analysis.layout import LayoutHeuristicABC
 from bloqade.lanes.analysis.placement import PlacementStrategyABC
 from bloqade.lanes.arch.gemini.physical import get_arch_spec as get_physical_arch_spec
 from bloqade.lanes.dialects import move
-from bloqade.lanes.heuristics.physical.layout import (
-    PhysicalLayoutHeuristicGraphPartitionCenterOut,
-)
-from bloqade.lanes.heuristics.physical.placement import PhysicalPlacementStrategy
 from bloqade.lanes.noise_model import generate_simple_noise_model
+from bloqade.lanes.pipeline import PhysicalPipeline
 from bloqade.lanes.rewrite.move2squin.noise import NoiseModelABC
 from bloqade.lanes.rewrite.squin2stim import RemoveReturn
 from bloqade.lanes.transform import MoveToSquinPhysical
-from bloqade.lanes.upstream import squin_to_move
 
 __all__ = [
     "compile_squin_to_move",
@@ -37,21 +33,12 @@ def compile_squin_to_move(
     insert_return_moves: bool = True,
 ) -> ir.Method:
     """Compile a physical squin kernel to the move dialect."""
-    arch_spec = get_physical_arch_spec()
-    if layout_heuristic is None:
-        layout_heuristic = PhysicalLayoutHeuristicGraphPartitionCenterOut(
-            arch_spec=arch_spec
-        )
-    if placement_strategy is None:
-        placement_strategy = PhysicalPlacementStrategy(arch_spec=arch_spec)
-
-    return squin_to_move(
-        mt,
+    return PhysicalPipeline(
+        arch_spec=get_physical_arch_spec(),
         layout_heuristic=layout_heuristic,
         placement_strategy=placement_strategy,
         insert_return_moves=insert_return_moves,
-        no_raise=no_raise,
-    )
+    ).emit(mt, no_raise=no_raise)
 
 
 def _count_move_events(mt: ir.Method) -> int:

--- a/python/bloqade/lanes/dialects/place.py
+++ b/python/bloqade/lanes/dialects/place.py
@@ -56,6 +56,21 @@ class NewLogicalQubit(ir.Statement):
     result: ir.ResultValue = info.result(bloqade_types.QubitType)
 
 
+@statement(dialect=dialect)
+class NewPinnedQubit(ir.Statement):
+    """Allocate a physical qubit at an optional pinned location.
+
+    Unlike NewLogicalQubit there are no initialization angles — physical qubits
+    have a location but no associated initialization sequence.  location_address=None
+    means the layout heuristic will assign a site; after ResolvePinnedAddresses runs
+    this is never None in well-formed IR.
+    """
+
+    traits = frozenset()
+    location_address: LocationAddress | None = info.attribute(default=None)
+    result: ir.ResultValue = info.result(bloqade_types.QubitType)
+
+
 @statement(init=False)
 class QuantumStmt(ir.Statement):
     """This is a base class for all low level statements."""
@@ -314,6 +329,27 @@ class InitialLayoutMethods(interp.MethodTable):
         _interp.location_addresses[qubit_id] = stmt.location_address
         return (EmptyLattice.bottom(),)
 
+    @interp.impl(NewPinnedQubit)
+    def new_pinned_qubit_layout(
+        self,
+        _interp: LayoutAnalysis,
+        frame: ForwardFrame[EmptyLattice],
+        stmt: NewPinnedQubit,
+    ):
+        if stmt.location_address is None:
+            return (EmptyLattice.bottom(),)
+        addr_entry = _interp.address_entries.get(stmt.result)
+        if not isinstance(addr_entry, address.AddressQubit):
+            return (EmptyLattice.bottom(),)
+        qubit_id = addr_entry.data
+        pinned_values = _interp.location_addresses.values()
+        if stmt.location_address in pinned_values:
+            raise interp.InterpreterError(
+                f"Duplicate pinned location address: {stmt.location_address}"
+            )
+        _interp.location_addresses[qubit_id] = stmt.location_address
+        return (EmptyLattice.bottom(),)
+
     @interp.impl(CZ)
     def cz(
         self,
@@ -358,6 +394,17 @@ class QubitAddressAnalysis(interp.MethodTable):
         _interp: address.AddressAnalysis,
         frame: ForwardFrame[address.Address],
         stmt: NewLogicalQubit,
+    ):
+        addr = address.AddressQubit(_interp.next_address)
+        _interp.next_address += 1
+        return (addr,)
+
+    @interp.impl(NewPinnedQubit)
+    def new_pinned_qubit(
+        self,
+        _interp: address.AddressAnalysis,
+        frame: ForwardFrame[address.Address],
+        stmt: NewPinnedQubit,
     ):
         addr = address.AddressQubit(_interp.next_address)
         _interp.next_address += 1

--- a/python/bloqade/lanes/dialects/place.py
+++ b/python/bloqade/lanes/dialects/place.py
@@ -34,13 +34,15 @@ class LogicalInitialize(ir.Statement):
     qubits: tuple[ir.SSAValue, ...] = info.argument(bloqade_types.QubitType)
 
 
-@statement(dialect=dialect)
-class NewPinnedQubit(ir.Statement):
-    """Allocate a physical qubit at an optional pinned location.
+@statement(init=False)
+class _NewQubitBase(ir.Statement):
+    """Shared abstract base for qubit-allocation statements.
 
-    No initialization angles — physical qubits have a location but no associated
-    initialization sequence.  location_address=None means the layout heuristic will
-    assign a site; after ResolvePinnedAddresses runs this is never None in well-formed IR.
+    Holds the two fields common to both ``NewPinnedQubit`` (physical) and
+    ``NewLogicalQubit`` (logical) so that isinstance guards throughout the
+    codebase can match "any qubit allocation" without one type being a subtype
+    of the other.  Neither class should be used where only one flavour is
+    intended; use the concrete subclass directly in those cases.
     """
 
     traits = frozenset()
@@ -49,11 +51,20 @@ class NewPinnedQubit(ir.Statement):
 
 
 @statement(dialect=dialect)
-class NewLogicalQubit(NewPinnedQubit):
+class NewPinnedQubit(_NewQubitBase):
+    """Allocate a physical qubit at an optional pinned location.
+
+    No initialization angles — physical qubits have a location but no associated
+    initialization sequence.  location_address=None means the layout heuristic will
+    assign a site; after ResolvePinnedAddresses runs this is never None in well-formed IR.
+    """
+
+
+@statement(dialect=dialect)
+class NewLogicalQubit(_NewQubitBase):
     """Allocate a logical qubit with initial state u3(theta, phi, lam)|0>.
 
-    Extends NewPinnedQubit with initialization angles.  location_address and result
-    are inherited from NewPinnedQubit.
+    location_address and result are inherited from _NewQubitBase.
 
     Args:
         theta (float): Angle for rotation around the Y axis
@@ -313,7 +324,7 @@ class InitialLayoutMethods(interp.MethodTable):
         self,
         _interp: LayoutAnalysis,
         frame: ForwardFrame[EmptyLattice],
-        stmt: NewPinnedQubit,
+        stmt: _NewQubitBase,
     ):
         if stmt.location_address is None:
             return (EmptyLattice.bottom(),)
@@ -373,7 +384,7 @@ class QubitAddressAnalysis(interp.MethodTable):
         self,
         _interp: address.AddressAnalysis,
         frame: ForwardFrame[address.Address],
-        stmt: NewPinnedQubit,
+        stmt: _NewQubitBase,
     ):
         addr = address.AddressQubit(_interp.next_address)
         _interp.next_address += 1

--- a/python/bloqade/lanes/dialects/place.py
+++ b/python/bloqade/lanes/dialects/place.py
@@ -35,8 +35,25 @@ class LogicalInitialize(ir.Statement):
 
 
 @statement(dialect=dialect)
-class NewLogicalQubit(ir.Statement):
-    """Allocate new logical qubits with initial state u3(theta, phi, lam)|0>.
+class NewPinnedQubit(ir.Statement):
+    """Allocate a physical qubit at an optional pinned location.
+
+    No initialization angles — physical qubits have a location but no associated
+    initialization sequence.  location_address=None means the layout heuristic will
+    assign a site; after ResolvePinnedAddresses runs this is never None in well-formed IR.
+    """
+
+    traits = frozenset()
+    location_address: LocationAddress | None = info.attribute(default=None)
+    result: ir.ResultValue = info.result(bloqade_types.QubitType)
+
+
+@statement(dialect=dialect)
+class NewLogicalQubit(NewPinnedQubit):
+    """Allocate a logical qubit with initial state u3(theta, phi, lam)|0>.
+
+    Extends NewPinnedQubit with initialization angles.  location_address and result
+    are inherited from NewPinnedQubit.
 
     Args:
         theta (float): Angle for rotation around the Y axis
@@ -48,27 +65,9 @@ class NewLogicalQubit(ir.Statement):
 
     """
 
-    traits = frozenset()
     theta: ir.SSAValue = info.argument(types.Float)
     phi: ir.SSAValue = info.argument(types.Float)
     lam: ir.SSAValue = info.argument(types.Float)
-    location_address: LocationAddress | None = info.attribute(default=None)
-    result: ir.ResultValue = info.result(bloqade_types.QubitType)
-
-
-@statement(dialect=dialect)
-class NewPinnedQubit(ir.Statement):
-    """Allocate a physical qubit at an optional pinned location.
-
-    Unlike NewLogicalQubit there are no initialization angles — physical qubits
-    have a location but no associated initialization sequence.  location_address=None
-    means the layout heuristic will assign a site; after ResolvePinnedAddresses runs
-    this is never None in well-formed IR.
-    """
-
-    traits = frozenset()
-    location_address: LocationAddress | None = info.attribute(default=None)
-    result: ir.ResultValue = info.result(bloqade_types.QubitType)
 
 
 @statement(init=False)
@@ -309,28 +308,8 @@ class PlacementMethods(interp.MethodTable):
 class InitialLayoutMethods(interp.MethodTable):
 
     @interp.impl(NewLogicalQubit)
-    def new_logical_qubit(
-        self,
-        _interp: LayoutAnalysis,
-        frame: ForwardFrame[EmptyLattice],
-        stmt: NewLogicalQubit,
-    ):
-        if stmt.location_address is None:
-            return (EmptyLattice.bottom(),)
-        addr_entry = _interp.address_entries.get(stmt.result)
-        if not isinstance(addr_entry, address.AddressQubit):
-            return (EmptyLattice.bottom(),)
-        qubit_id = addr_entry.data
-        pinned_values = _interp.location_addresses.values()
-        if stmt.location_address in pinned_values:
-            raise interp.InterpreterError(
-                f"Duplicate pinned location address: {stmt.location_address}"
-            )
-        _interp.location_addresses[qubit_id] = stmt.location_address
-        return (EmptyLattice.bottom(),)
-
     @interp.impl(NewPinnedQubit)
-    def new_pinned_qubit_layout(
+    def new_qubit_layout(
         self,
         _interp: LayoutAnalysis,
         frame: ForwardFrame[EmptyLattice],
@@ -389,18 +368,8 @@ class InitialLayoutMethods(interp.MethodTable):
 class QubitAddressAnalysis(interp.MethodTable):
 
     @interp.impl(NewLogicalQubit)
-    def new_logical_qubit(
-        self,
-        _interp: address.AddressAnalysis,
-        frame: ForwardFrame[address.Address],
-        stmt: NewLogicalQubit,
-    ):
-        addr = address.AddressQubit(_interp.next_address)
-        _interp.next_address += 1
-        return (addr,)
-
     @interp.impl(NewPinnedQubit)
-    def new_pinned_qubit(
+    def new_qubit_address(
         self,
         _interp: address.AddressAnalysis,
         frame: ForwardFrame[address.Address],

--- a/python/bloqade/lanes/logical_mvp.py
+++ b/python/bloqade/lanes/logical_mvp.py
@@ -26,12 +26,12 @@ from bloqade.lanes.cudaq_integration import cudaq_to_squin, is_cudaq_kernel
 from bloqade.lanes.heuristics.logical import layout as logical_layout
 from bloqade.lanes.heuristics.logical.placement import LogicalPlacementStrategyNoHome
 from bloqade.lanes.noise_model import generate_logical_noise_model
+from bloqade.lanes.pipeline import LogicalPipeline
 from bloqade.lanes.rewrite import transversal
 from bloqade.lanes.rewrite.move2squin.noise import LogicalNoiseModelABC
 from bloqade.lanes.rewrite.squin2stim import RemoveReturn
 from bloqade.lanes.steane_defaults import steane7_m2dets, steane7_m2obs
 from bloqade.lanes.transform import MoveToSquinLogical
-from bloqade.lanes.upstream import squin_to_move
 
 __all__ = [
     "run_squin_kernel_validation",
@@ -122,14 +122,11 @@ def compile_squin_to_move(
     if layout_heuristic is None:
         layout_heuristic = logical_layout.LogicalLayoutHeuristic()
 
-    mt = squin_to_move(
-        mt,
+    mt = LogicalPipeline(
         layout_heuristic=layout_heuristic,
         placement_strategy=LogicalPlacementStrategyNoHome(),
         insert_return_moves=insert_return_moves,
-        no_raise=no_raise,
-        logical_initialize=True,
-    )
+    ).emit(mt, no_raise=no_raise)
     if transversal_rewrite:
         mt = transversal_rewrites(mt)
 

--- a/python/bloqade/lanes/pipeline/__init__.py
+++ b/python/bloqade/lanes/pipeline/__init__.py
@@ -1,0 +1,2 @@
+from .logical import LogicalPipeline as LogicalPipeline
+from .physical import PhysicalPipeline as PhysicalPipeline

--- a/python/bloqade/lanes/pipeline/__init__.py
+++ b/python/bloqade/lanes/pipeline/__init__.py
@@ -1,2 +1,4 @@
+__all__ = ["LogicalPipeline", "PhysicalPipeline"]
+
 from .logical import LogicalPipeline as LogicalPipeline
 from .physical import PhysicalPipeline as PhysicalPipeline

--- a/python/bloqade/lanes/pipeline/base.py
+++ b/python/bloqade/lanes/pipeline/base.py
@@ -54,6 +54,13 @@ class _NativeToPlaceBase:
       Physical subclass runs ``RewriteQubitsToPinnedQubits`` +
       ``RewritePhysicalMeasure``; logical subclass runs the four initialize
       rewrites.
+
+    The ``arch_spec`` field controls whether post-unroll address and duplicate
+    validation runs (the ``if self.arch_spec is not None`` block).
+    ``PhysicalPipeline`` always supplies an ``arch_spec`` (defaults to
+    ``get_physical_arch_spec()``), so this validation is unconditional for the
+    physical pipeline.  ``LogicalPipeline`` defaults ``arch_spec=None``, so the
+    block is skipped unless the caller passes an explicit spec.
     """
 
     merge_heuristic: Callable[[ir.Region, ir.Region], bool] = field(
@@ -64,7 +71,7 @@ class _NativeToPlaceBase:
     def _pre_native_rewrites(self, mt: Method, out: Method, no_raise: bool) -> Method:
         return out
 
-    def _post_unroll_validation(self, out: Method) -> None:
+    def _post_unroll_validation(self, out: Method, no_raise: bool) -> None:
         pass
 
     def _lower_qubits(self, out: Method) -> None:
@@ -76,7 +83,7 @@ class _NativeToPlaceBase:
 
         out = SquinToNative().emit(out, no_raise=no_raise)
         AggressiveUnroll(out.dialects, no_raise=no_raise).fixpoint(out)
-        self._post_unroll_validation(out)
+        self._post_unroll_validation(out, no_raise)
 
         rewrite.Walk(scf2cf.ScfToCfRule()).rewrite(out.code)
         rewrite.Walk(circuit2place.HoistConstants()).rewrite(out.code)
@@ -221,7 +228,8 @@ class _PlaceToMove:
         ).rewrite(out.code)
 
         passes.TypeInfer(out.dialects)(out)
-        out.verify()
-        out.verify_type()
+        if not no_raise:
+            out.verify()
+            out.verify_type()
 
         return out

--- a/python/bloqade/lanes/pipeline/base.py
+++ b/python/bloqade/lanes/pipeline/base.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import chain
+from typing import Callable
+
+import bloqade.qubit as squin_qubit
+from bloqade.analysis import address
+from bloqade.native.dialects import gate as native_gate
+from bloqade.native.upstream.squin2native import SquinToNative
+from bloqade.rewrite.passes import AggressiveUnroll
+from kirin import ir, passes, rewrite
+from kirin.dialects.scf import scf2cf
+from kirin.ir.exception import ValidationErrorGroup
+from kirin.ir.method import Method
+from kirin.rewrite.abc import RewriteRule
+
+from bloqade.gemini.common.dialects import qubit as gemini_qubit
+from bloqade.gemini.common.validation.duplicate_address import (
+    DuplicateAddressValidation,
+)
+from bloqade.lanes.analysis import layout, placement
+from bloqade.lanes.arch.spec import ArchSpec
+from bloqade.lanes.bytecode.encoding import LaneAddress
+from bloqade.lanes.dialects import move, place
+from bloqade.lanes.rewrite import circuit2place, place2move, resolve_pinned, state
+from bloqade.lanes.validation.address import Validation as AddressValidation
+
+
+def _default_merge_heuristic(region_a: ir.Region, region_b: ir.Region) -> bool:
+    return all(
+        isinstance(stmt, (place.R, place.Rz, place.Yield))
+        for stmt in chain(region_a.walk(), region_b.walk())
+    )
+
+
+@dataclass
+class _NativeToPlaceBase:
+    """Template-method base for the squin-native → place compilation stage.
+
+    Subclasses override up to three hooks; all other steps are shared:
+
+    * ``_pre_native_rewrites(mt, out, no_raise)`` — called after ``out`` is
+      created (dialect-extended copy of ``mt``) but before ``SquinToNative``.
+      Default is a no-op.  Logical subclass runs ``ValidationSuite`` on ``mt``
+      and applies callgraph rewrites to ``out``.
+
+    * ``_post_unroll_validation(out)`` — called after ``AggressiveUnroll``,
+      before ``ScfToCfRule``.  Default is a no-op.  Physical subclass runs
+      ``PhysicalTerminalMeasurementValidation``.
+
+    * ``_lower_qubits(out)`` — called after the optional address/duplicate
+      validation block.  Must be overridden: raises ``NotImplementedError``.
+      Physical subclass runs ``RewriteQubitsToPinnedQubits`` +
+      ``RewritePhysicalMeasure``; logical subclass runs the four initialize
+      rewrites.
+    """
+
+    merge_heuristic: Callable[[ir.Region, ir.Region], bool] = field(
+        default=_default_merge_heuristic
+    )
+    arch_spec: ArchSpec | None = field(default=None)
+
+    def _pre_native_rewrites(self, mt: Method, out: Method, no_raise: bool) -> Method:
+        return out
+
+    def _post_unroll_validation(self, out: Method) -> None:
+        pass
+
+    def _lower_qubits(self, out: Method) -> None:
+        raise NotImplementedError
+
+    def emit(self, mt: Method, no_raise: bool = True) -> Method:
+        out = mt.similar(mt.dialects.add(place))
+        out = self._pre_native_rewrites(mt, out, no_raise)
+
+        out = SquinToNative().emit(out, no_raise=no_raise)
+        AggressiveUnroll(out.dialects, no_raise=no_raise).fixpoint(out)
+        self._post_unroll_validation(out)
+
+        rewrite.Walk(scf2cf.ScfToCfRule()).rewrite(out.code)
+        rewrite.Walk(circuit2place.HoistConstants()).rewrite(out.code)
+
+        if self.arch_spec is not None:
+            validation_errors: list[ir.ValidationError] = []
+            _, per_stmt_errors = AddressValidation(arch_spec=self.arch_spec).run(out)
+            validation_errors.extend(per_stmt_errors)
+            _, dup_errors = DuplicateAddressValidation().run(out)
+            validation_errors.extend(dup_errors)
+            if validation_errors:
+                raise ValidationErrorGroup(
+                    f"Gemini IR validation failed with {len(validation_errors)} error(s)",
+                    errors=validation_errors,
+                )
+
+        self._lower_qubits(out)
+
+        rewrite.Walk(circuit2place.RewritePlaceOperations()).rewrite(out.code)
+        rewrite.Walk(
+            rewrite.Chain(
+                rewrite.DeadCodeElimination(),
+                rewrite.CommonSubexpressionElimination(),
+            )
+        ).rewrite(out.code)
+        rewrite.Walk(circuit2place.HoistConstants()).rewrite(out.code)
+        rewrite.Fixpoint(
+            rewrite.Walk(circuit2place.MergePlacementRegions(self.merge_heuristic))
+        ).rewrite(out.code)
+        rewrite.Walk(circuit2place.HoistNewQubitsUp()).rewrite(out.code)
+        rewrite.Fixpoint(
+            rewrite.Walk(circuit2place.MergePlacementRegions(self.merge_heuristic))
+        ).rewrite(out.code)
+
+        out = out.similar(
+            out.dialects.discard(native_gate).discard(gemini_qubit).discard(squin_qubit)
+        )
+        passes.TypeInfer(out.dialects, no_raise=True)(out)
+
+        if not no_raise:
+            out.verify()
+            out.verify_type()
+
+        return out
+
+
+@dataclass
+class _PlaceToMove:
+    """Shared place → move compilation stage for both pipelines.
+
+    The only difference between the physical and logical pipelines at this
+    stage is whether ``InsertInitialize`` is included in the rewrite rules.
+    Pass ``insert_initialize=True`` for the logical pipeline.
+    """
+
+    layout_heuristic: layout.LayoutHeuristicABC
+    placement_strategy: placement.PlacementStrategyABC
+    insert_initialize: bool = False
+    insert_return_moves: bool = True
+    revert_initial_position: Callable[
+        [dict[ir.SSAValue, placement.AtomState], place.StaticPlacement],
+        tuple[tuple[LaneAddress, ...], ...] | None,
+    ] = place2move.palindrome_move_layers
+
+    def emit(self, mt: Method, no_raise: bool = True) -> Method:
+        out = mt.similar(mt.dialects.add(move))
+
+        address_analysis = address.AddressAnalysis(out.dialects)
+        if no_raise:
+            address_frame, _ = address_analysis.run_no_raise(out)
+            all_qubits = tuple(range(address_analysis.next_address))
+            initial_layout = layout.LayoutAnalysis(
+                out.dialects,
+                self.layout_heuristic,
+                address_frame.entries,
+                all_qubits,
+            ).get_layout_no_raise(out)
+        else:
+            address_frame, _ = address_analysis.run(out)
+            all_qubits = tuple(range(address_analysis.next_address))
+            initial_layout = layout.LayoutAnalysis(
+                out.dialects,
+                self.layout_heuristic,
+                address_frame.entries,
+                all_qubits,
+            ).get_layout(out)
+
+        rewrite.Walk(
+            resolve_pinned.ResolvePinnedAddresses(
+                address_entries=address_frame.entries,
+                initial_layout=initial_layout,
+            )
+        ).rewrite(out.code)
+
+        placement_analysis = placement.PlacementAnalysis(
+            out.dialects,
+            initial_layout,
+            address_frame.entries,
+            self.placement_strategy,
+        )
+        if no_raise:
+            placement_frame, _ = placement_analysis.run_no_raise(out)
+        else:
+            placement_frame, _ = placement_analysis.run(out)
+
+        rules: list[RewriteRule] = [place2move.InsertFill()]
+        if self.insert_initialize:
+            rules.append(place2move.InsertInitialize())
+        rules += [
+            place2move.InsertMoves(placement_frame.entries),
+            place2move.RewriteGates(placement_frame.entries),
+            place2move.InsertMeasure(placement_frame.entries),
+        ]
+        rewrite.Walk(rewrite.Chain(*rules)).rewrite(out.code)
+
+        if self.insert_return_moves:
+            rewrite.Walk(
+                place2move.InsertReturnMoves(
+                    placement_analysis=placement_frame.entries,
+                    revert_initial_position=self.revert_initial_position,
+                )
+            ).rewrite(out.code)
+
+        rewrite.Walk(
+            rewrite.Chain(
+                place2move.LiftMoveStatements(), place2move.DeleteInitialize()
+            )
+        ).rewrite(out.code)
+        rewrite.Walk(place2move.RemoveNoOpStaticPlacements()).rewrite(out.code)
+        rewrite.Fixpoint(rewrite.Walk(rewrite.CFGCompactify())).rewrite(out.code)
+
+        state.InsertBlockArgs().rewrite(out.code)
+        rewrite.Walk(state.RewriteBranches()).rewrite(out.code)
+        rewrite.Walk(state.RewriteLoadStore()).rewrite(out.code)
+
+        rewrite.Fixpoint(
+            rewrite.Walk(
+                rewrite.Chain(
+                    place2move.DeleteQubitNew(), rewrite.DeadCodeElimination()
+                )
+            )
+        ).rewrite(out.code)
+
+        passes.TypeInfer(out.dialects)(out)
+        out.verify()
+        out.verify_type()
+
+        return out

--- a/python/bloqade/lanes/pipeline/base.py
+++ b/python/bloqade/lanes/pipeline/base.py
@@ -56,11 +56,12 @@ class _NativeToPlaceBase:
       rewrites.
 
     The ``arch_spec`` field controls whether post-unroll address and duplicate
-    validation runs (the ``if self.arch_spec is not None`` block).
-    ``PhysicalPipeline`` always supplies an ``arch_spec`` (defaults to
-    ``get_physical_arch_spec()``), so this validation is unconditional for the
-    physical pipeline.  ``LogicalPipeline`` defaults ``arch_spec=None``, so the
-    block is skipped unless the caller passes an explicit spec.
+    validation runs (the ``if self.arch_spec is not None`` block).  Both
+    ``PhysicalPipeline`` and ``LogicalPipeline`` always supply an
+    ``arch_spec`` (defaulting to their respective Gemini arch specs), so this
+    validation is unconditional for both pipelines.  Set ``arch_spec=None``
+    only when constructing a ``_NativeToPlaceBase`` subclass directly and
+    you explicitly want to skip address validation.
     """
 
     merge_heuristic: Callable[[ir.Region, ir.Region], bool] = field(

--- a/python/bloqade/lanes/pipeline/logical.py
+++ b/python/bloqade/lanes/pipeline/logical.py
@@ -1,27 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from itertools import chain
 from typing import Callable
 
-import bloqade.qubit as squin_qubit
-from bloqade.analysis import address
 from bloqade.analysis.validation.simple_nocloning import FlatKernelNoCloningValidation
-from bloqade.native.dialects import gate as native_gate
-from bloqade.native.upstream.squin2native import SquinToNative
-from bloqade.rewrite.passes import AggressiveUnroll
 from bloqade.rewrite.passes.callgraph import CallGraphPass
 from bloqade.squin.rewrite.non_clifford_to_U3 import RewriteNonCliffordToU3
-from kirin import ir, passes, rewrite
-from kirin.dialects.scf import scf2cf
-from kirin.ir.exception import ValidationErrorGroup
+from kirin import ir, rewrite
 from kirin.ir.method import Method
 from kirin.validation import ValidationSuite
 
-from bloqade.gemini.common.dialects import qubit as gemini_qubit
-from bloqade.gemini.common.validation.duplicate_address import (
-    DuplicateAddressValidation,
-)
 from bloqade.gemini.logical.rewrite.initialize import _RewriteU3ToInitialize
 from bloqade.gemini.logical.validation.clifford.analysis import GeminiLogicalValidation
 from bloqade.gemini.logical.validation.measurement.analysis import (
@@ -29,29 +17,16 @@ from bloqade.gemini.logical.validation.measurement.analysis import (
 )
 from bloqade.lanes.analysis import layout, placement
 from bloqade.lanes.arch.spec import ArchSpec
-from bloqade.lanes.bytecode.encoding import LaneAddress
-from bloqade.lanes.dialects import move, place
 from bloqade.lanes.heuristics.logical.layout import LogicalLayoutHeuristic
 from bloqade.lanes.heuristics.logical.placement import LogicalPlacementStrategyNoHome
-from bloqade.lanes.rewrite import circuit2place, place2move, resolve_pinned, state
-from bloqade.lanes.validation.address import Validation as AddressValidation
+from bloqade.lanes.rewrite import circuit2place
 
-
-def _default_merge_heuristic(region_a: ir.Region, region_b: ir.Region) -> bool:
-    return all(
-        isinstance(stmt, (place.R, place.Rz, place.Yield))
-        for stmt in chain(region_a.walk(), region_b.walk())
-    )
+from .base import _default_merge_heuristic, _NativeToPlaceBase, _PlaceToMove
 
 
 @dataclass
-class _LogicalNativeToPlace:
-    merge_heuristic: Callable[[ir.Region, ir.Region], bool] = field(
-        default=_default_merge_heuristic
-    )
-    arch_spec: ArchSpec | None = field(default=None)
-
-    def emit(self, mt: Method, no_raise: bool = True) -> Method:
+class _LogicalNativeToPlace(_NativeToPlaceBase):
+    def _pre_native_rewrites(self, mt: Method, out: Method, no_raise: bool) -> Method:
         validator = ValidationSuite(
             [
                 GeminiLogicalValidation,
@@ -63,31 +38,14 @@ class _LogicalNativeToPlace:
         if not result.is_valid:
             result.raise_if_invalid()
 
-        out = mt.similar(mt.dialects.add(place))
-
         rule = rewrite.Chain(
             rewrite.Walk(RewriteNonCliffordToU3()),
             rewrite.Walk(_RewriteU3ToInitialize()),
         )
         CallGraphPass(mt.dialects, rule)(out)
+        return out
 
-        out = SquinToNative().emit(out, no_raise=no_raise)
-        AggressiveUnroll(out.dialects, no_raise=no_raise).fixpoint(out)
-        rewrite.Walk(scf2cf.ScfToCfRule()).rewrite(out.code)
-        rewrite.Walk(circuit2place.HoistConstants()).rewrite(out.code)
-
-        if self.arch_spec is not None:
-            validation_errors: list[ir.ValidationError] = []
-            _, per_stmt_errors = AddressValidation(arch_spec=self.arch_spec).run(out)
-            validation_errors.extend(per_stmt_errors)
-            _, dup_errors = DuplicateAddressValidation().run(out)
-            validation_errors.extend(dup_errors)
-            if validation_errors:
-                raise ValidationErrorGroup(
-                    f"Gemini IR validation failed with {len(validation_errors)} error(s)",
-                    errors=validation_errors,
-                )
-
+    def _lower_qubits(self, out: Method) -> None:
         rewrite.Walk(circuit2place.RewriteInitializeToLogicalInitialize()).rewrite(
             out.code
         )
@@ -96,128 +54,6 @@ class _LogicalNativeToPlace:
         )
         rewrite.Walk(circuit2place.CleanUpLogicalInitialize()).rewrite(out.code)
         rewrite.Walk(circuit2place.InitializeNewQubits()).rewrite(out.code)
-
-        rewrite.Walk(circuit2place.RewritePlaceOperations()).rewrite(out.code)
-        rewrite.Walk(
-            rewrite.Chain(
-                rewrite.DeadCodeElimination(),
-                rewrite.CommonSubexpressionElimination(),
-            )
-        ).rewrite(out.code)
-        rewrite.Walk(circuit2place.HoistConstants()).rewrite(out.code)
-        rewrite.Fixpoint(
-            rewrite.Walk(circuit2place.MergePlacementRegions(self.merge_heuristic))
-        ).rewrite(out.code)
-        rewrite.Walk(circuit2place.HoistNewQubitsUp()).rewrite(out.code)
-        rewrite.Fixpoint(
-            rewrite.Walk(circuit2place.MergePlacementRegions(self.merge_heuristic))
-        ).rewrite(out.code)
-
-        out = out.similar(
-            out.dialects.discard(native_gate).discard(gemini_qubit).discard(squin_qubit)
-        )
-        passes.TypeInfer(out.dialects, no_raise=True)(out)
-
-        if not no_raise:
-            out.verify()
-            out.verify_type()
-
-        return out
-
-
-@dataclass
-class _LogicalPlaceToMove:
-    layout_heuristic: layout.LayoutHeuristicABC
-    placement_strategy: placement.PlacementStrategyABC
-    insert_return_moves: bool = True
-    revert_initial_position: Callable[
-        [dict[ir.SSAValue, placement.AtomState], place.StaticPlacement],
-        tuple[tuple[LaneAddress, ...], ...] | None,
-    ] = place2move.palindrome_move_layers
-
-    def emit(self, mt: Method, no_raise: bool = True) -> Method:
-        out = mt.similar(mt.dialects.add(move))
-
-        address_analysis = address.AddressAnalysis(out.dialects)
-        if no_raise:
-            address_frame, _ = address_analysis.run_no_raise(out)
-            all_qubits = tuple(range(address_analysis.next_address))
-            initial_layout = layout.LayoutAnalysis(
-                out.dialects,
-                self.layout_heuristic,
-                address_frame.entries,
-                all_qubits,
-            ).get_layout_no_raise(out)
-        else:
-            address_frame, _ = address_analysis.run(out)
-            all_qubits = tuple(range(address_analysis.next_address))
-            initial_layout = layout.LayoutAnalysis(
-                out.dialects,
-                self.layout_heuristic,
-                address_frame.entries,
-                all_qubits,
-            ).get_layout(out)
-
-        rewrite.Walk(
-            resolve_pinned.ResolvePinnedAddresses(
-                address_entries=address_frame.entries,
-                initial_layout=initial_layout,
-            )
-        ).rewrite(out.code)
-
-        placement_analysis = placement.PlacementAnalysis(
-            out.dialects,
-            initial_layout,
-            address_frame.entries,
-            self.placement_strategy,
-        )
-        if no_raise:
-            placement_frame, _ = placement_analysis.run_no_raise(out)
-        else:
-            placement_frame, _ = placement_analysis.run(out)
-
-        rules = [
-            place2move.InsertFill(),
-            place2move.InsertInitialize(),
-            place2move.InsertMoves(placement_frame.entries),
-            place2move.RewriteGates(placement_frame.entries),
-            place2move.InsertMeasure(placement_frame.entries),
-        ]
-        rewrite.Walk(rewrite.Chain(*rules)).rewrite(out.code)
-
-        if self.insert_return_moves:
-            rewrite.Walk(
-                place2move.InsertReturnMoves(
-                    placement_analysis=placement_frame.entries,
-                    revert_initial_position=self.revert_initial_position,
-                )
-            ).rewrite(out.code)
-
-        rewrite.Walk(
-            rewrite.Chain(
-                place2move.LiftMoveStatements(), place2move.DeleteInitialize()
-            )
-        ).rewrite(out.code)
-        rewrite.Walk(place2move.RemoveNoOpStaticPlacements()).rewrite(out.code)
-        rewrite.Fixpoint(rewrite.Walk(rewrite.CFGCompactify())).rewrite(out.code)
-
-        state.InsertBlockArgs().rewrite(out.code)
-        rewrite.Walk(state.RewriteBranches()).rewrite(out.code)
-        rewrite.Walk(state.RewriteLoadStore()).rewrite(out.code)
-
-        rewrite.Fixpoint(
-            rewrite.Walk(
-                rewrite.Chain(
-                    place2move.DeleteQubitNew(), rewrite.DeadCodeElimination()
-                )
-            )
-        ).rewrite(out.code)
-
-        passes.TypeInfer(out.dialects)(out)
-        out.verify()
-        out.verify_type()
-
-        return out
 
 
 @dataclass
@@ -246,9 +82,10 @@ class LogicalPipeline:
             arch_spec=self.arch_spec,
         ).emit(mt, no_raise=no_raise)
 
-        out = _LogicalPlaceToMove(
+        out = _PlaceToMove(
             layout_heuristic=self.layout_heuristic,
             placement_strategy=self.placement_strategy,
+            insert_initialize=True,
             insert_return_moves=self.insert_return_moves,
         ).emit(out, no_raise=no_raise)
 

--- a/python/bloqade/lanes/pipeline/logical.py
+++ b/python/bloqade/lanes/pipeline/logical.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import chain
+from typing import Callable
+
+import bloqade.qubit as squin_qubit
+from bloqade.analysis import address
+from bloqade.analysis.validation.simple_nocloning import FlatKernelNoCloningValidation
+from bloqade.native.dialects import gate as native_gate
+from bloqade.native.upstream.squin2native import SquinToNative
+from bloqade.rewrite.passes import AggressiveUnroll
+from bloqade.rewrite.passes.callgraph import CallGraphPass
+from bloqade.squin.rewrite.non_clifford_to_U3 import RewriteNonCliffordToU3
+from kirin import ir, passes, rewrite
+from kirin.dialects.scf import scf2cf
+from kirin.ir.exception import ValidationErrorGroup
+from kirin.ir.method import Method
+from kirin.validation import ValidationSuite
+
+from bloqade.gemini.common.dialects import qubit as gemini_qubit
+from bloqade.gemini.common.validation.duplicate_address import (
+    DuplicateAddressValidation,
+)
+from bloqade.gemini.logical.rewrite.initialize import _RewriteU3ToInitialize
+from bloqade.gemini.logical.validation.clifford.analysis import GeminiLogicalValidation
+from bloqade.gemini.logical.validation.measurement.analysis import (
+    GeminiTerminalMeasurementValidation,
+)
+from bloqade.lanes.analysis import layout, placement
+from bloqade.lanes.arch.spec import ArchSpec
+from bloqade.lanes.bytecode.encoding import LaneAddress
+from bloqade.lanes.dialects import move, place
+from bloqade.lanes.heuristics.logical.layout import LogicalLayoutHeuristic
+from bloqade.lanes.heuristics.logical.placement import LogicalPlacementStrategyNoHome
+from bloqade.lanes.rewrite import circuit2place, place2move, resolve_pinned, state
+from bloqade.lanes.validation.address import Validation as AddressValidation
+
+
+def _default_merge_heuristic(region_a: ir.Region, region_b: ir.Region) -> bool:
+    return all(
+        isinstance(stmt, (place.R, place.Rz, place.Yield))
+        for stmt in chain(region_a.walk(), region_b.walk())
+    )
+
+
+@dataclass
+class _LogicalNativeToPlace:
+    merge_heuristic: Callable[[ir.Region, ir.Region], bool] = field(
+        default=_default_merge_heuristic
+    )
+    arch_spec: ArchSpec | None = field(default=None)
+
+    def emit(self, mt: Method, no_raise: bool = True) -> Method:
+        validator = ValidationSuite(
+            [
+                GeminiLogicalValidation,
+                GeminiTerminalMeasurementValidation,
+                FlatKernelNoCloningValidation,
+            ]
+        )
+        result = validator.validate(mt)
+        if not result.is_valid:
+            result.raise_if_invalid()
+
+        out = mt.similar(mt.dialects.add(place))
+
+        rule = rewrite.Chain(
+            rewrite.Walk(RewriteNonCliffordToU3()),
+            rewrite.Walk(_RewriteU3ToInitialize()),
+        )
+        CallGraphPass(mt.dialects, rule)(out)
+
+        out = SquinToNative().emit(out, no_raise=no_raise)
+        AggressiveUnroll(out.dialects, no_raise=no_raise).fixpoint(out)
+        rewrite.Walk(scf2cf.ScfToCfRule()).rewrite(out.code)
+        rewrite.Walk(circuit2place.HoistConstants()).rewrite(out.code)
+
+        if self.arch_spec is not None:
+            validation_errors: list[ir.ValidationError] = []
+            _, per_stmt_errors = AddressValidation(arch_spec=self.arch_spec).run(out)
+            validation_errors.extend(per_stmt_errors)
+            _, dup_errors = DuplicateAddressValidation().run(out)
+            validation_errors.extend(dup_errors)
+            if validation_errors:
+                raise ValidationErrorGroup(
+                    f"Gemini IR validation failed with {len(validation_errors)} error(s)",
+                    errors=validation_errors,
+                )
+
+        rewrite.Walk(circuit2place.RewriteInitializeToLogicalInitialize()).rewrite(
+            out.code
+        )
+        rewrite.Walk(circuit2place.RewriteLogicalInitializeToNewLogical()).rewrite(
+            out.code
+        )
+        rewrite.Walk(circuit2place.CleanUpLogicalInitialize()).rewrite(out.code)
+        rewrite.Walk(circuit2place.InitializeNewQubits()).rewrite(out.code)
+
+        rewrite.Walk(circuit2place.RewritePlaceOperations()).rewrite(out.code)
+        rewrite.Walk(
+            rewrite.Chain(
+                rewrite.DeadCodeElimination(),
+                rewrite.CommonSubexpressionElimination(),
+            )
+        ).rewrite(out.code)
+        rewrite.Walk(circuit2place.HoistConstants()).rewrite(out.code)
+        rewrite.Fixpoint(
+            rewrite.Walk(circuit2place.MergePlacementRegions(self.merge_heuristic))
+        ).rewrite(out.code)
+        rewrite.Walk(circuit2place.HoistNewQubitsUp()).rewrite(out.code)
+        rewrite.Fixpoint(
+            rewrite.Walk(circuit2place.MergePlacementRegions(self.merge_heuristic))
+        ).rewrite(out.code)
+
+        out = out.similar(
+            out.dialects.discard(native_gate).discard(gemini_qubit).discard(squin_qubit)
+        )
+        passes.TypeInfer(out.dialects, no_raise=True)(out)
+
+        if not no_raise:
+            out.verify()
+            out.verify_type()
+
+        return out
+
+
+@dataclass
+class _LogicalPlaceToMove:
+    layout_heuristic: layout.LayoutHeuristicABC
+    placement_strategy: placement.PlacementStrategyABC
+    insert_return_moves: bool = True
+    revert_initial_position: Callable[
+        [dict[ir.SSAValue, placement.AtomState], place.StaticPlacement],
+        tuple[tuple[LaneAddress, ...], ...] | None,
+    ] = place2move.palindrome_move_layers
+
+    def emit(self, mt: Method, no_raise: bool = True) -> Method:
+        out = mt.similar(mt.dialects.add(move))
+
+        address_analysis = address.AddressAnalysis(out.dialects)
+        if no_raise:
+            address_frame, _ = address_analysis.run_no_raise(out)
+            all_qubits = tuple(range(address_analysis.next_address))
+            initial_layout = layout.LayoutAnalysis(
+                out.dialects,
+                self.layout_heuristic,
+                address_frame.entries,
+                all_qubits,
+            ).get_layout_no_raise(out)
+        else:
+            address_frame, _ = address_analysis.run(out)
+            all_qubits = tuple(range(address_analysis.next_address))
+            initial_layout = layout.LayoutAnalysis(
+                out.dialects,
+                self.layout_heuristic,
+                address_frame.entries,
+                all_qubits,
+            ).get_layout(out)
+
+        rewrite.Walk(
+            resolve_pinned.ResolvePinnedAddresses(
+                address_entries=address_frame.entries,
+                initial_layout=initial_layout,
+            )
+        ).rewrite(out.code)
+
+        placement_analysis = placement.PlacementAnalysis(
+            out.dialects,
+            initial_layout,
+            address_frame.entries,
+            self.placement_strategy,
+        )
+        if no_raise:
+            placement_frame, _ = placement_analysis.run_no_raise(out)
+        else:
+            placement_frame, _ = placement_analysis.run(out)
+
+        rules = [
+            place2move.InsertFill(),
+            place2move.InsertInitialize(),
+            place2move.InsertMoves(placement_frame.entries),
+            place2move.RewriteGates(placement_frame.entries),
+            place2move.InsertMeasure(placement_frame.entries),
+        ]
+        rewrite.Walk(rewrite.Chain(*rules)).rewrite(out.code)
+
+        if self.insert_return_moves:
+            rewrite.Walk(
+                place2move.InsertReturnMoves(
+                    placement_analysis=placement_frame.entries,
+                    revert_initial_position=self.revert_initial_position,
+                )
+            ).rewrite(out.code)
+
+        rewrite.Walk(
+            rewrite.Chain(
+                place2move.LiftMoveStatements(), place2move.DeleteInitialize()
+            )
+        ).rewrite(out.code)
+        rewrite.Walk(place2move.RemoveNoOpStaticPlacements()).rewrite(out.code)
+        rewrite.Fixpoint(rewrite.Walk(rewrite.CFGCompactify())).rewrite(out.code)
+
+        state.InsertBlockArgs().rewrite(out.code)
+        rewrite.Walk(state.RewriteBranches()).rewrite(out.code)
+        rewrite.Walk(state.RewriteLoadStore()).rewrite(out.code)
+
+        rewrite.Fixpoint(
+            rewrite.Walk(
+                rewrite.Chain(
+                    place2move.DeleteQubitNew(), rewrite.DeadCodeElimination()
+                )
+            )
+        ).rewrite(out.code)
+
+        passes.TypeInfer(out.dialects)(out)
+        out.verify()
+        out.verify_type()
+
+        return out
+
+
+@dataclass
+class LogicalPipeline:
+    """Compile a logical squin kernel to the move dialect.
+
+    Includes Clifford/measurement/no-cloning validation and the full logical
+    initialization sequence (InsertInitialize for LogicalQubits).
+    """
+
+    layout_heuristic: layout.LayoutHeuristicABC = field(
+        default_factory=LogicalLayoutHeuristic
+    )
+    placement_strategy: placement.PlacementStrategyABC = field(
+        default_factory=LogicalPlacementStrategyNoHome
+    )
+    insert_return_moves: bool = True
+    merge_heuristic: Callable[[ir.Region, ir.Region], bool] = field(
+        default=_default_merge_heuristic
+    )
+    arch_spec: ArchSpec | None = None
+
+    def emit(self, mt: Method, no_raise: bool = True) -> Method:
+        out = _LogicalNativeToPlace(
+            merge_heuristic=self.merge_heuristic,
+            arch_spec=self.arch_spec,
+        ).emit(mt, no_raise=no_raise)
+
+        out = _LogicalPlaceToMove(
+            layout_heuristic=self.layout_heuristic,
+            placement_strategy=self.placement_strategy,
+            insert_return_moves=self.insert_return_moves,
+        ).emit(out, no_raise=no_raise)
+
+        return out

--- a/python/bloqade/lanes/pipeline/logical.py
+++ b/python/bloqade/lanes/pipeline/logical.py
@@ -16,6 +16,7 @@ from bloqade.gemini.logical.validation.measurement.analysis import (
     GeminiTerminalMeasurementValidation,
 )
 from bloqade.lanes.analysis import layout, placement
+from bloqade.lanes.arch.gemini.logical import get_arch_spec as get_logical_arch_spec
 from bloqade.lanes.arch.spec import ArchSpec
 from bloqade.lanes.heuristics.logical.layout import LogicalLayoutHeuristic
 from bloqade.lanes.heuristics.logical.placement import LogicalPlacementStrategyNoHome
@@ -35,7 +36,7 @@ class _LogicalNativeToPlace(_NativeToPlaceBase):
             ]
         )
         result = validator.validate(mt)
-        if not result.is_valid:
+        if not result.is_valid and not no_raise:
             result.raise_if_invalid()
 
         rule = rewrite.Chain(
@@ -74,7 +75,7 @@ class LogicalPipeline:
     merge_heuristic: Callable[[ir.Region, ir.Region], bool] = field(
         default=_default_merge_heuristic
     )
-    arch_spec: ArchSpec | None = None
+    arch_spec: ArchSpec = field(default_factory=get_logical_arch_spec)
 
     def emit(self, mt: Method, no_raise: bool = True) -> Method:
         out = _LogicalNativeToPlace(

--- a/python/bloqade/lanes/pipeline/physical.py
+++ b/python/bloqade/lanes/pipeline/physical.py
@@ -24,9 +24,9 @@ from .base import _default_merge_heuristic, _NativeToPlaceBase, _PlaceToMove
 
 @dataclass
 class _PhysicalNativeToPlace(_NativeToPlaceBase):
-    def _post_unroll_validation(self, out: Method) -> None:
+    def _post_unroll_validation(self, out: Method, no_raise: bool) -> None:
         _, errors = PhysicalTerminalMeasurementValidation().run(out)
-        if errors:
+        if errors and not no_raise:
             raise ValidationErrorGroup(
                 f"Physical circuit validation failed with {len(errors)} error(s)",
                 errors=errors,

--- a/python/bloqade/lanes/pipeline/physical.py
+++ b/python/bloqade/lanes/pipeline/physical.py
@@ -1,60 +1,30 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from itertools import chain
 from typing import Callable
 
-import bloqade.qubit as squin_qubit
-from bloqade.analysis import address
-from bloqade.native.dialects import gate as native_gate
-from bloqade.native.upstream.squin2native import SquinToNative
-from bloqade.rewrite.passes import AggressiveUnroll
-from kirin import ir, passes, rewrite
-from kirin.dialects.scf import scf2cf
+from kirin import ir, rewrite
 from kirin.ir.exception import ValidationErrorGroup
 from kirin.ir.method import Method
 
-from bloqade.gemini.common.dialects import qubit as gemini_qubit
-from bloqade.gemini.common.validation.duplicate_address import (
-    DuplicateAddressValidation,
-)
 from bloqade.gemini.common.validation.terminal_measure import (
     PhysicalTerminalMeasurementValidation,
 )
 from bloqade.lanes.analysis import layout, placement
 from bloqade.lanes.arch.gemini.physical import get_arch_spec as get_physical_arch_spec
 from bloqade.lanes.arch.spec import ArchSpec
-from bloqade.lanes.bytecode.encoding import LaneAddress
-from bloqade.lanes.dialects import move, place
 from bloqade.lanes.heuristics.physical.layout import (
     PhysicalLayoutHeuristicGraphPartitionCenterOut,
 )
 from bloqade.lanes.heuristics.physical.placement import PhysicalPlacementStrategy
-from bloqade.lanes.rewrite import circuit2place, place2move, resolve_pinned, state
-from bloqade.lanes.validation.address import Validation as AddressValidation
+from bloqade.lanes.rewrite import circuit2place
 
-
-def _default_merge_heuristic(region_a: ir.Region, region_b: ir.Region) -> bool:
-    return all(
-        isinstance(stmt, (place.R, place.Rz, place.Yield))
-        for stmt in chain(region_a.walk(), region_b.walk())
-    )
+from .base import _default_merge_heuristic, _NativeToPlaceBase, _PlaceToMove
 
 
 @dataclass
-class _PhysicalNativeToPlace:
-    merge_heuristic: Callable[[ir.Region, ir.Region], bool] = field(
-        default=_default_merge_heuristic
-    )
-    arch_spec: ArchSpec | None = field(default=None)
-
-    def emit(self, mt: Method, no_raise: bool = True) -> Method:
-        out = mt.similar(mt.dialects.add(place))
-
-        out = SquinToNative().emit(out, no_raise=no_raise)
-        AggressiveUnroll(out.dialects, no_raise=no_raise).fixpoint(out)
-
-        # Validate terminal measure post-unroll (Measure/New are direct stmts here).
+class _PhysicalNativeToPlace(_NativeToPlaceBase):
+    def _post_unroll_validation(self, out: Method) -> None:
         _, errors = PhysicalTerminalMeasurementValidation().run(out)
         if errors:
             raise ValidationErrorGroup(
@@ -62,146 +32,9 @@ class _PhysicalNativeToPlace:
                 errors=errors,
             )
 
-        rewrite.Walk(scf2cf.ScfToCfRule()).rewrite(out.code)
-        rewrite.Walk(circuit2place.HoistConstants()).rewrite(out.code)
-
-        if self.arch_spec is not None:
-            validation_errors: list[ir.ValidationError] = []
-            _, per_stmt_errors = AddressValidation(arch_spec=self.arch_spec).run(out)
-            validation_errors.extend(per_stmt_errors)
-            _, dup_errors = DuplicateAddressValidation().run(out)
-            validation_errors.extend(dup_errors)
-            if validation_errors:
-                raise ValidationErrorGroup(
-                    f"Gemini IR validation failed with {len(validation_errors)} error(s)",
-                    errors=validation_errors,
-                )
-
-        # Lower all qubit allocations to NewPinnedQubit (no logical-init sequence).
+    def _lower_qubits(self, out: Method) -> None:
         rewrite.Walk(circuit2place.RewriteQubitsToPinnedQubits()).rewrite(out.code)
-
         rewrite.Walk(circuit2place.RewritePhysicalMeasure()).rewrite(out.code)
-        rewrite.Walk(circuit2place.RewritePlaceOperations()).rewrite(out.code)
-        rewrite.Walk(
-            rewrite.Chain(
-                rewrite.DeadCodeElimination(),
-                rewrite.CommonSubexpressionElimination(),
-            )
-        ).rewrite(out.code)
-        rewrite.Walk(circuit2place.HoistConstants()).rewrite(out.code)
-        rewrite.Fixpoint(
-            rewrite.Walk(circuit2place.MergePlacementRegions(self.merge_heuristic))
-        ).rewrite(out.code)
-        rewrite.Walk(circuit2place.HoistNewQubitsUp()).rewrite(out.code)
-        rewrite.Fixpoint(
-            rewrite.Walk(circuit2place.MergePlacementRegions(self.merge_heuristic))
-        ).rewrite(out.code)
-
-        out = out.similar(
-            out.dialects.discard(native_gate).discard(gemini_qubit).discard(squin_qubit)
-        )
-        passes.TypeInfer(out.dialects, no_raise=True)(out)
-
-        if not no_raise:
-            out.verify()
-            out.verify_type()
-
-        return out
-
-
-@dataclass
-class _PhysicalPlaceToMove:
-    layout_heuristic: layout.LayoutHeuristicABC
-    placement_strategy: placement.PlacementStrategyABC
-    insert_return_moves: bool = True
-    revert_initial_position: Callable[
-        [dict[ir.SSAValue, placement.AtomState], place.StaticPlacement],
-        tuple[tuple[LaneAddress, ...], ...] | None,
-    ] = place2move.palindrome_move_layers
-
-    def emit(self, mt: Method, no_raise: bool = True) -> Method:
-        out = mt.similar(mt.dialects.add(move))
-
-        address_analysis = address.AddressAnalysis(out.dialects)
-        if no_raise:
-            address_frame, _ = address_analysis.run_no_raise(out)
-            all_qubits = tuple(range(address_analysis.next_address))
-            initial_layout = layout.LayoutAnalysis(
-                out.dialects,
-                self.layout_heuristic,
-                address_frame.entries,
-                all_qubits,
-            ).get_layout_no_raise(out)
-        else:
-            address_frame, _ = address_analysis.run(out)
-            all_qubits = tuple(range(address_analysis.next_address))
-            initial_layout = layout.LayoutAnalysis(
-                out.dialects,
-                self.layout_heuristic,
-                address_frame.entries,
-                all_qubits,
-            ).get_layout(out)
-
-        rewrite.Walk(
-            resolve_pinned.ResolvePinnedAddresses(
-                address_entries=address_frame.entries,
-                initial_layout=initial_layout,
-            )
-        ).rewrite(out.code)
-
-        placement_analysis = placement.PlacementAnalysis(
-            out.dialects,
-            initial_layout,
-            address_frame.entries,
-            self.placement_strategy,
-        )
-        if no_raise:
-            placement_frame, _ = placement_analysis.run_no_raise(out)
-        else:
-            placement_frame, _ = placement_analysis.run(out)
-
-        # Physical pipeline: no InsertInitialize (no logical init sequence).
-        rules = [
-            place2move.InsertFill(),
-            place2move.InsertMoves(placement_frame.entries),
-            place2move.RewriteGates(placement_frame.entries),
-            place2move.InsertMeasure(placement_frame.entries),
-        ]
-        rewrite.Walk(rewrite.Chain(*rules)).rewrite(out.code)
-
-        if self.insert_return_moves:
-            rewrite.Walk(
-                place2move.InsertReturnMoves(
-                    placement_analysis=placement_frame.entries,
-                    revert_initial_position=self.revert_initial_position,
-                )
-            ).rewrite(out.code)
-
-        rewrite.Walk(
-            rewrite.Chain(
-                place2move.LiftMoveStatements(), place2move.DeleteInitialize()
-            )
-        ).rewrite(out.code)
-        rewrite.Walk(place2move.RemoveNoOpStaticPlacements()).rewrite(out.code)
-        rewrite.Fixpoint(rewrite.Walk(rewrite.CFGCompactify())).rewrite(out.code)
-
-        state.InsertBlockArgs().rewrite(out.code)
-        rewrite.Walk(state.RewriteBranches()).rewrite(out.code)
-        rewrite.Walk(state.RewriteLoadStore()).rewrite(out.code)
-
-        rewrite.Fixpoint(
-            rewrite.Walk(
-                rewrite.Chain(
-                    place2move.DeleteQubitNew(), rewrite.DeadCodeElimination()
-                )
-            )
-        ).rewrite(out.code)
-
-        passes.TypeInfer(out.dialects)(out)
-        out.verify()
-        out.verify_type()
-
-        return out
 
 
 @dataclass
@@ -235,9 +68,10 @@ class PhysicalPipeline:
             arch_spec=self.arch_spec,
         ).emit(mt, no_raise=no_raise)
 
-        out = _PhysicalPlaceToMove(
+        out = _PlaceToMove(
             layout_heuristic=heuristic,
             placement_strategy=strategy,
+            insert_initialize=False,
             insert_return_moves=self.insert_return_moves,
         ).emit(out, no_raise=no_raise)
 

--- a/python/bloqade/lanes/pipeline/physical.py
+++ b/python/bloqade/lanes/pipeline/physical.py
@@ -56,11 +56,14 @@ class PhysicalPipeline:
 
     def emit(self, mt: Method, no_raise: bool = True) -> Method:
         heuristic = (
-            self.layout_heuristic
-            or PhysicalLayoutHeuristicGraphPartitionCenterOut(arch_spec=self.arch_spec)
+            PhysicalLayoutHeuristicGraphPartitionCenterOut(arch_spec=self.arch_spec)
+            if self.layout_heuristic is None
+            else self.layout_heuristic
         )
-        strategy = self.placement_strategy or PhysicalPlacementStrategy(
-            arch_spec=self.arch_spec
+        strategy = (
+            PhysicalPlacementStrategy(arch_spec=self.arch_spec)
+            if self.placement_strategy is None
+            else self.placement_strategy
         )
 
         out = _PhysicalNativeToPlace(

--- a/python/bloqade/lanes/pipeline/physical.py
+++ b/python/bloqade/lanes/pipeline/physical.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import chain
+from typing import Callable
+
+import bloqade.qubit as squin_qubit
+from bloqade.analysis import address
+from bloqade.native.dialects import gate as native_gate
+from bloqade.native.upstream.squin2native import SquinToNative
+from bloqade.rewrite.passes import AggressiveUnroll
+from kirin import ir, passes, rewrite
+from kirin.dialects.scf import scf2cf
+from kirin.ir.exception import ValidationErrorGroup
+from kirin.ir.method import Method
+
+from bloqade.gemini.common.dialects import qubit as gemini_qubit
+from bloqade.gemini.common.validation.duplicate_address import (
+    DuplicateAddressValidation,
+)
+from bloqade.gemini.common.validation.terminal_measure import (
+    PhysicalTerminalMeasurementValidation,
+)
+from bloqade.lanes.analysis import layout, placement
+from bloqade.lanes.arch.gemini.physical import get_arch_spec as get_physical_arch_spec
+from bloqade.lanes.arch.spec import ArchSpec
+from bloqade.lanes.bytecode.encoding import LaneAddress
+from bloqade.lanes.dialects import move, place
+from bloqade.lanes.heuristics.physical.layout import (
+    PhysicalLayoutHeuristicGraphPartitionCenterOut,
+)
+from bloqade.lanes.heuristics.physical.placement import PhysicalPlacementStrategy
+from bloqade.lanes.rewrite import circuit2place, place2move, resolve_pinned, state
+from bloqade.lanes.validation.address import Validation as AddressValidation
+
+
+def _default_merge_heuristic(region_a: ir.Region, region_b: ir.Region) -> bool:
+    return all(
+        isinstance(stmt, (place.R, place.Rz, place.Yield))
+        for stmt in chain(region_a.walk(), region_b.walk())
+    )
+
+
+@dataclass
+class _PhysicalNativeToPlace:
+    merge_heuristic: Callable[[ir.Region, ir.Region], bool] = field(
+        default=_default_merge_heuristic
+    )
+    arch_spec: ArchSpec | None = field(default=None)
+
+    def emit(self, mt: Method, no_raise: bool = True) -> Method:
+        out = mt.similar(mt.dialects.add(place))
+
+        out = SquinToNative().emit(out, no_raise=no_raise)
+        AggressiveUnroll(out.dialects, no_raise=no_raise).fixpoint(out)
+
+        # Validate terminal measure post-unroll (Measure/New are direct stmts here).
+        _, errors = PhysicalTerminalMeasurementValidation().run(out)
+        if errors:
+            raise ValidationErrorGroup(
+                f"Physical circuit validation failed with {len(errors)} error(s)",
+                errors=errors,
+            )
+
+        rewrite.Walk(scf2cf.ScfToCfRule()).rewrite(out.code)
+        rewrite.Walk(circuit2place.HoistConstants()).rewrite(out.code)
+
+        if self.arch_spec is not None:
+            validation_errors: list[ir.ValidationError] = []
+            _, per_stmt_errors = AddressValidation(arch_spec=self.arch_spec).run(out)
+            validation_errors.extend(per_stmt_errors)
+            _, dup_errors = DuplicateAddressValidation().run(out)
+            validation_errors.extend(dup_errors)
+            if validation_errors:
+                raise ValidationErrorGroup(
+                    f"Gemini IR validation failed with {len(validation_errors)} error(s)",
+                    errors=validation_errors,
+                )
+
+        # Lower all qubit allocations to NewPinnedQubit (no logical-init sequence).
+        rewrite.Walk(circuit2place.RewriteQubitsToPinnedQubits()).rewrite(out.code)
+
+        rewrite.Walk(circuit2place.RewritePhysicalMeasure()).rewrite(out.code)
+        rewrite.Walk(circuit2place.RewritePlaceOperations()).rewrite(out.code)
+        rewrite.Walk(
+            rewrite.Chain(
+                rewrite.DeadCodeElimination(),
+                rewrite.CommonSubexpressionElimination(),
+            )
+        ).rewrite(out.code)
+        rewrite.Walk(circuit2place.HoistConstants()).rewrite(out.code)
+        rewrite.Fixpoint(
+            rewrite.Walk(circuit2place.MergePlacementRegions(self.merge_heuristic))
+        ).rewrite(out.code)
+        rewrite.Walk(circuit2place.HoistNewQubitsUp()).rewrite(out.code)
+        rewrite.Fixpoint(
+            rewrite.Walk(circuit2place.MergePlacementRegions(self.merge_heuristic))
+        ).rewrite(out.code)
+
+        out = out.similar(
+            out.dialects.discard(native_gate).discard(gemini_qubit).discard(squin_qubit)
+        )
+        passes.TypeInfer(out.dialects, no_raise=True)(out)
+
+        if not no_raise:
+            out.verify()
+            out.verify_type()
+
+        return out
+
+
+@dataclass
+class _PhysicalPlaceToMove:
+    layout_heuristic: layout.LayoutHeuristicABC
+    placement_strategy: placement.PlacementStrategyABC
+    insert_return_moves: bool = True
+    revert_initial_position: Callable[
+        [dict[ir.SSAValue, placement.AtomState], place.StaticPlacement],
+        tuple[tuple[LaneAddress, ...], ...] | None,
+    ] = place2move.palindrome_move_layers
+
+    def emit(self, mt: Method, no_raise: bool = True) -> Method:
+        out = mt.similar(mt.dialects.add(move))
+
+        address_analysis = address.AddressAnalysis(out.dialects)
+        if no_raise:
+            address_frame, _ = address_analysis.run_no_raise(out)
+            all_qubits = tuple(range(address_analysis.next_address))
+            initial_layout = layout.LayoutAnalysis(
+                out.dialects,
+                self.layout_heuristic,
+                address_frame.entries,
+                all_qubits,
+            ).get_layout_no_raise(out)
+        else:
+            address_frame, _ = address_analysis.run(out)
+            all_qubits = tuple(range(address_analysis.next_address))
+            initial_layout = layout.LayoutAnalysis(
+                out.dialects,
+                self.layout_heuristic,
+                address_frame.entries,
+                all_qubits,
+            ).get_layout(out)
+
+        rewrite.Walk(
+            resolve_pinned.ResolvePinnedAddresses(
+                address_entries=address_frame.entries,
+                initial_layout=initial_layout,
+            )
+        ).rewrite(out.code)
+
+        placement_analysis = placement.PlacementAnalysis(
+            out.dialects,
+            initial_layout,
+            address_frame.entries,
+            self.placement_strategy,
+        )
+        if no_raise:
+            placement_frame, _ = placement_analysis.run_no_raise(out)
+        else:
+            placement_frame, _ = placement_analysis.run(out)
+
+        # Physical pipeline: no InsertInitialize (no logical init sequence).
+        rules = [
+            place2move.InsertFill(),
+            place2move.InsertMoves(placement_frame.entries),
+            place2move.RewriteGates(placement_frame.entries),
+            place2move.InsertMeasure(placement_frame.entries),
+        ]
+        rewrite.Walk(rewrite.Chain(*rules)).rewrite(out.code)
+
+        if self.insert_return_moves:
+            rewrite.Walk(
+                place2move.InsertReturnMoves(
+                    placement_analysis=placement_frame.entries,
+                    revert_initial_position=self.revert_initial_position,
+                )
+            ).rewrite(out.code)
+
+        rewrite.Walk(
+            rewrite.Chain(
+                place2move.LiftMoveStatements(), place2move.DeleteInitialize()
+            )
+        ).rewrite(out.code)
+        rewrite.Walk(place2move.RemoveNoOpStaticPlacements()).rewrite(out.code)
+        rewrite.Fixpoint(rewrite.Walk(rewrite.CFGCompactify())).rewrite(out.code)
+
+        state.InsertBlockArgs().rewrite(out.code)
+        rewrite.Walk(state.RewriteBranches()).rewrite(out.code)
+        rewrite.Walk(state.RewriteLoadStore()).rewrite(out.code)
+
+        rewrite.Fixpoint(
+            rewrite.Walk(
+                rewrite.Chain(
+                    place2move.DeleteQubitNew(), rewrite.DeadCodeElimination()
+                )
+            )
+        ).rewrite(out.code)
+
+        passes.TypeInfer(out.dialects)(out)
+        out.verify()
+        out.verify_type()
+
+        return out
+
+
+@dataclass
+class PhysicalPipeline:
+    """Compile a physical squin kernel to the move dialect.
+
+    Qubits are lowered to place.NewPinnedQubit; no logical initialization
+    sequence is inserted.  Validates that the kernel has exactly one terminal
+    measure covering all allocated qubits (post-unroll).
+    """
+
+    arch_spec: ArchSpec = field(default_factory=get_physical_arch_spec)
+    layout_heuristic: layout.LayoutHeuristicABC | None = None
+    placement_strategy: placement.PlacementStrategyABC | None = None
+    insert_return_moves: bool = True
+    merge_heuristic: Callable[[ir.Region, ir.Region], bool] = field(
+        default=_default_merge_heuristic
+    )
+
+    def emit(self, mt: Method, no_raise: bool = True) -> Method:
+        heuristic = (
+            self.layout_heuristic
+            or PhysicalLayoutHeuristicGraphPartitionCenterOut(arch_spec=self.arch_spec)
+        )
+        strategy = self.placement_strategy or PhysicalPlacementStrategy(
+            arch_spec=self.arch_spec
+        )
+
+        out = _PhysicalNativeToPlace(
+            merge_heuristic=self.merge_heuristic,
+            arch_spec=self.arch_spec,
+        ).emit(mt, no_raise=no_raise)
+
+        out = _PhysicalPlaceToMove(
+            layout_heuristic=heuristic,
+            placement_strategy=strategy,
+            insert_return_moves=self.insert_return_moves,
+        ).emit(out, no_raise=no_raise)
+
+        return out

--- a/python/bloqade/lanes/rewrite/circuit2place.py
+++ b/python/bloqade/lanes/rewrite/circuit2place.py
@@ -340,10 +340,14 @@ class RewritePhysicalMeasure(abc.RewriteRule):
     We unwrap one level of nesting to collect individual Qubit SSA values.
     """
 
-    def _collect_inputs(self, node: qubit.stmts.Measure) -> list[ir.SSAValue] | None:
+    def _collect_inputs(self, node: qubit.stmts.Measure) -> list[ir.SSAValue]:
         owner = node.qubits.owner
         if not isinstance(owner, ilist.New):
-            return None
+            raise ValueError(
+                f"RewritePhysicalMeasure: expected qubits owner to be ilist.New, "
+                f"got {type(owner).__name__}. Ensure AggressiveUnroll ran before "
+                f"this rewrite pass."
+            )
         inputs: list[ir.SSAValue] = []
         for val in owner.values:
             inner = val.owner
@@ -351,15 +355,18 @@ class RewritePhysicalMeasure(abc.RewriteRule):
                 inputs.extend(inner.values)
             else:
                 inputs.append(val)
-        return inputs or None
+        if not inputs:
+            raise ValueError(
+                f"RewritePhysicalMeasure: collected no qubit inputs from {node}; "
+                f"the qubits list appears to be empty."
+            )
+        return inputs
 
     def rewrite_Statement(self, node: ir.Statement) -> abc.RewriteResult:
         if not isinstance(node, qubit.stmts.Measure):
             return abc.RewriteResult()
 
         inputs = self._collect_inputs(node)
-        if inputs is None:
-            return abc.RewriteResult()
 
         body = ir.Region(block := ir.Block())
         entry_state = block.args.append_from(StateType, name="entry_state")
@@ -410,7 +417,7 @@ class HoistNewQubitsUp(abc.RewriteRule):
 
     def rewrite_Statement(self, node: ir.Statement) -> abc.RewriteResult:
         if not (
-            isinstance(node, place.NewPinnedQubit)
+            isinstance(node, place._NewQubitBase)
             and (parent_block := node.parent_block) is not None
             and (first_stmt := parent_block.first_stmt) is not None
             and node is not first_stmt
@@ -423,7 +430,7 @@ class HoistNewQubitsUp(abc.RewriteRule):
         def loop_cond(stmt: ir.Statement | None) -> TypeGuard[ir.Statement]:
             return (
                 stmt is not None
-                and not isinstance(stmt, place.NewPinnedQubit)
+                and not isinstance(stmt, place._NewQubitBase)
                 and set(stmt.results).isdisjoint(node.args)
             )
 

--- a/python/bloqade/lanes/rewrite/circuit2place.py
+++ b/python/bloqade/lanes/rewrite/circuit2place.py
@@ -334,7 +334,7 @@ class HoistNewQubitsUp(abc.RewriteRule):
 
     def rewrite_Statement(self, node: ir.Statement) -> abc.RewriteResult:
         if not (
-            isinstance(node, place.NewLogicalQubit)
+            isinstance(node, (place.NewLogicalQubit, place.NewPinnedQubit))
             and (parent_block := node.parent_block) is not None
             and (first_stmt := parent_block.first_stmt) is not None
             and node is not first_stmt
@@ -347,7 +347,7 @@ class HoistNewQubitsUp(abc.RewriteRule):
         def loop_cond(stmt: ir.Statement | None) -> TypeGuard[ir.Statement]:
             return (
                 stmt is not None
-                and not isinstance(stmt, place.NewLogicalQubit)
+                and not isinstance(stmt, (place.NewLogicalQubit, place.NewPinnedQubit))
                 and set(stmt.results).isdisjoint(node.args)
             )
 

--- a/python/bloqade/lanes/rewrite/circuit2place.py
+++ b/python/bloqade/lanes/rewrite/circuit2place.py
@@ -150,6 +150,31 @@ class InitializeNewQubits(abc.RewriteRule):
         return abc.RewriteResult()
 
 
+class RewriteQubitsToPinnedQubits(abc.RewriteRule):
+    """Lower all bare qubit allocations to place.NewPinnedQubit.
+
+    - qubit.stmts.New       → NewPinnedQubit(location_address=None)
+    - gemini.common.NewAt   → NewPinnedQubit(location_address=<const>)
+
+    Used exclusively by the physical pipeline; the logical pipeline uses
+    InitializeNewQubits instead.
+    """
+
+    def rewrite_Statement(self, node: ir.Statement) -> abc.RewriteResult:
+        if isinstance(node, qubit.stmts.New):
+            node.replace_by(place.NewPinnedQubit())
+            return abc.RewriteResult(has_done_something=True)
+
+        if isinstance(node, gemini_common_stmts.NewAt):
+            addr = _resolve_location_from_new_at(node)
+            if addr is None:
+                return abc.RewriteResult()
+            node.replace_by(place.NewPinnedQubit(location_address=addr))
+            return abc.RewriteResult(has_done_something=True)
+
+        return abc.RewriteResult()
+
+
 @dataclass
 class RewritePlaceOperations(abc.RewriteRule):
     """

--- a/python/bloqade/lanes/rewrite/circuit2place.py
+++ b/python/bloqade/lanes/rewrite/circuit2place.py
@@ -329,6 +329,57 @@ class RewritePlaceOperations(abc.RewriteRule):
         return abc.RewriteResult(has_done_something=True)
 
 
+class RewritePhysicalMeasure(abc.RewriteRule):
+    """Lower qubit.stmts.Measure to place.StaticPlacement(EndMeasure).
+
+    For the physical pipeline.  After AggressiveUnroll, qalloc produces:
+      ilist.New([q0, q1])   — the register
+    and measure receives:
+      ilist.New([reg])      — outer wrapper with one IList[Qubit, N] element
+
+    We unwrap one level of nesting to collect individual Qubit SSA values.
+    """
+
+    def _collect_inputs(self, node: qubit.stmts.Measure) -> list[ir.SSAValue] | None:
+        owner = node.qubits.owner
+        if not isinstance(owner, ilist.New):
+            return None
+        inputs: list[ir.SSAValue] = []
+        for val in owner.values:
+            inner = val.owner
+            if isinstance(inner, ilist.New):
+                inputs.extend(inner.values)
+            else:
+                inputs.append(val)
+        return inputs or None
+
+    def rewrite_Statement(self, node: ir.Statement) -> abc.RewriteResult:
+        if not isinstance(node, qubit.stmts.Measure):
+            return abc.RewriteResult()
+
+        inputs = self._collect_inputs(node)
+        if inputs is None:
+            return abc.RewriteResult()
+
+        body = ir.Region(block := ir.Block())
+        entry_state = block.args.append_from(StateType, name="entry_state")
+        gate_stmt = place.EndMeasure(entry_state, qubits=tuple(range(len(inputs))))
+        block.stmts.append(gate_stmt)
+        block.stmts.append(place.Yield(gate_stmt.state_after, *gate_stmt.results[1:]))
+
+        static_placement = place.StaticPlacement(qubits=tuple(inputs), body=body)
+        static_placement.insert_before(node)
+
+        # Assemble the flat IList[MeasurementResult, N] that replaces Measure.result.
+        meas_results = list(static_placement.results[1:])
+        result_list = ilist.New(tuple(meas_results))
+        result_list.insert_before(node)
+        node.result.replace_by(result_list.result)
+        node.delete()
+
+        return abc.RewriteResult(has_done_something=True)
+
+
 class HoistConstants(abc.RewriteRule):
     """This rewrite rule hoists all constant values to the top of the kernel."""
 

--- a/python/bloqade/lanes/rewrite/circuit2place.py
+++ b/python/bloqade/lanes/rewrite/circuit2place.py
@@ -359,7 +359,7 @@ class HoistNewQubitsUp(abc.RewriteRule):
 
     def rewrite_Statement(self, node: ir.Statement) -> abc.RewriteResult:
         if not (
-            isinstance(node, (place.NewLogicalQubit, place.NewPinnedQubit))
+            isinstance(node, place.NewPinnedQubit)
             and (parent_block := node.parent_block) is not None
             and (first_stmt := parent_block.first_stmt) is not None
             and node is not first_stmt
@@ -372,7 +372,7 @@ class HoistNewQubitsUp(abc.RewriteRule):
         def loop_cond(stmt: ir.Statement | None) -> TypeGuard[ir.Statement]:
             return (
                 stmt is not None
-                and not isinstance(stmt, (place.NewLogicalQubit, place.NewPinnedQubit))
+                and not isinstance(stmt, place.NewPinnedQubit)
                 and set(stmt.results).isdisjoint(node.args)
             )
 

--- a/python/bloqade/lanes/rewrite/circuit2place.py
+++ b/python/bloqade/lanes/rewrite/circuit2place.py
@@ -378,7 +378,7 @@ class RewritePhysicalMeasure(abc.RewriteRule):
         static_placement.insert_before(node)
 
         # Assemble the flat IList[MeasurementResult, N] that replaces Measure.result.
-        meas_results = list(static_placement.results[1:])
+        meas_results = list(static_placement.results)
         result_list = ilist.New(tuple(meas_results))
         result_list.insert_before(node)
         node.result.replace_by(result_list.result)

--- a/python/bloqade/lanes/rewrite/place2move.py
+++ b/python/bloqade/lanes/rewrite/place2move.py
@@ -374,7 +374,7 @@ class InsertFill(RewriteRule):
 
         location_addresses: list[LocationAddress | None] = []
         for stmt in node.body.walk():
-            if not isinstance(stmt, place.NewPinnedQubit):
+            if not isinstance(stmt, place._NewQubitBase):
                 continue
             location_addresses.append(stmt.location_address)
 
@@ -397,7 +397,7 @@ class InsertFill(RewriteRule):
 
 class DeleteQubitNew(RewriteRule):
     def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
-        if not (isinstance(node, place.NewPinnedQubit) and len(node.result.uses) == 0):
+        if not (isinstance(node, place._NewQubitBase) and len(node.result.uses) == 0):
             return RewriteResult()
 
         node.delete()

--- a/python/bloqade/lanes/rewrite/place2move.py
+++ b/python/bloqade/lanes/rewrite/place2move.py
@@ -374,7 +374,7 @@ class InsertFill(RewriteRule):
 
         location_addresses: list[LocationAddress | None] = []
         for stmt in node.body.walk():
-            if not isinstance(stmt, (place.NewLogicalQubit, place.NewPinnedQubit)):
+            if not isinstance(stmt, place.NewPinnedQubit):
                 continue
             location_addresses.append(stmt.location_address)
 
@@ -397,10 +397,7 @@ class InsertFill(RewriteRule):
 
 class DeleteQubitNew(RewriteRule):
     def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
-        if not (
-            isinstance(node, (place.NewLogicalQubit, place.NewPinnedQubit))
-            and len(node.result.uses) == 0
-        ):
+        if not (isinstance(node, place.NewPinnedQubit) and len(node.result.uses) == 0):
             return RewriteResult()
 
         node.delete()

--- a/python/bloqade/lanes/rewrite/place2move.py
+++ b/python/bloqade/lanes/rewrite/place2move.py
@@ -374,7 +374,7 @@ class InsertFill(RewriteRule):
 
         location_addresses: list[LocationAddress | None] = []
         for stmt in node.body.walk():
-            if not isinstance(stmt, place.NewLogicalQubit):
+            if not isinstance(stmt, (place.NewLogicalQubit, place.NewPinnedQubit)):
                 continue
             location_addresses.append(stmt.location_address)
 
@@ -397,7 +397,10 @@ class InsertFill(RewriteRule):
 
 class DeleteQubitNew(RewriteRule):
     def rewrite_Statement(self, node: ir.Statement) -> RewriteResult:
-        if not (isinstance(node, place.NewLogicalQubit) and len(node.result.uses) == 0):
+        if not (
+            isinstance(node, (place.NewLogicalQubit, place.NewPinnedQubit))
+            and len(node.result.uses) == 0
+        ):
             return RewriteResult()
 
         node.delete()

--- a/python/bloqade/lanes/rewrite/resolve_pinned.py
+++ b/python/bloqade/lanes/rewrite/resolve_pinned.py
@@ -27,7 +27,7 @@ class ResolvePinnedAddresses(abc.RewriteRule):
     initial_layout: tuple[LocationAddress, ...]
 
     def rewrite_Statement(self, node: ir.Statement) -> abc.RewriteResult:
-        if not isinstance(node, (place.NewLogicalQubit, place.NewPinnedQubit)):
+        if not isinstance(node, place.NewPinnedQubit):
             return abc.RewriteResult()
         if node.location_address is not None:
             return abc.RewriteResult()

--- a/python/bloqade/lanes/rewrite/resolve_pinned.py
+++ b/python/bloqade/lanes/rewrite/resolve_pinned.py
@@ -27,7 +27,7 @@ class ResolvePinnedAddresses(abc.RewriteRule):
     initial_layout: tuple[LocationAddress, ...]
 
     def rewrite_Statement(self, node: ir.Statement) -> abc.RewriteResult:
-        if not isinstance(node, place.NewPinnedQubit):
+        if not isinstance(node, place._NewQubitBase):
             return abc.RewriteResult()
         if node.location_address is not None:
             return abc.RewriteResult()

--- a/python/bloqade/lanes/rewrite/resolve_pinned.py
+++ b/python/bloqade/lanes/rewrite/resolve_pinned.py
@@ -10,17 +10,20 @@ from bloqade.lanes.dialects import place
 
 @dataclass
 class ResolvePinnedAddresses(abc.RewriteRule):
-    """Stamp each NewLogicalQubit's location_address from the analysis output.
+    """Stamp each _NewQubitBase node's location_address from the analysis output.
 
-    For NewLogicalQubits that already have a non-None location_address (i.e.
-    user-pinned), the attribute is left alone — the heuristic respected it
-    and the layout entry should match.
+    Operates on both NewPinnedQubit (physical pipeline) and NewLogicalQubit
+    (logical pipeline) — anything that is a _NewQubitBase subclass.
 
-    For NewLogicalQubits with location_address=None, the heuristic's choice is
-    looked up via address_entries[stmt.result] -> AddressQubit.data, which
-    indexes into initial_layout.
+    For nodes that already have a non-None location_address (i.e. user-pinned),
+    the attribute is left alone — the heuristic respected it and the layout
+    entry should match.
 
-    Post-condition: every NewLogicalQubit has a non-None location_address.
+    For nodes with location_address=None, the heuristic's choice is looked up
+    via address_entries[stmt.result] -> AddressQubit.data, which indexes into
+    initial_layout.
+
+    Post-condition: every _NewQubitBase node has a non-None location_address.
     """
 
     address_entries: dict[ir.SSAValue, address.Address]

--- a/python/bloqade/lanes/rewrite/resolve_pinned.py
+++ b/python/bloqade/lanes/rewrite/resolve_pinned.py
@@ -27,7 +27,7 @@ class ResolvePinnedAddresses(abc.RewriteRule):
     initial_layout: tuple[LocationAddress, ...]
 
     def rewrite_Statement(self, node: ir.Statement) -> abc.RewriteResult:
-        if not isinstance(node, place.NewLogicalQubit):
+        if not isinstance(node, (place.NewLogicalQubit, place.NewPinnedQubit)):
             return abc.RewriteResult()
         if node.location_address is not None:
             return abc.RewriteResult()

--- a/python/tests/gemini/validation/test_physical_terminal_measure.py
+++ b/python/tests/gemini/validation/test_physical_terminal_measure.py
@@ -1,0 +1,73 @@
+"""Tests for PhysicalTerminalMeasurementValidation."""
+
+import bloqade.squin as squin
+from bloqade.native.upstream.squin2native import SquinToNative
+from bloqade.rewrite.passes import AggressiveUnroll
+from kirin.dialects import ilist
+
+from bloqade.gemini.common.validation.terminal_measure import (
+    PhysicalTerminalMeasurementValidation,
+)
+
+
+def _validate(kernel):
+    """Run SquinToNative + AggressiveUnroll then validate — mirrors the pipeline."""
+    out = SquinToNative().emit(kernel)
+    AggressiveUnroll(out.dialects, no_raise=True).fixpoint(out)
+    _, errors = PhysicalTerminalMeasurementValidation().run(out)
+    return errors
+
+
+def test_valid_kernel_passes():
+    """Single measure consuming all qubits — no errors."""
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(2)
+        squin.qubit.measure(ilist.IList([reg[0], reg[1]]))  # type: ignore[arg-type]
+
+    assert _validate(kernel) == []
+
+
+def test_missing_measure_raises():
+    """No measure statement — validation error about missing terminal measure."""
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(2)  # noqa: F841
+
+    errors = _validate(kernel)
+    assert len(errors) >= 1
+    assert any(
+        "terminal" in str(e).lower() or "measure" in str(e).lower() for e in errors
+    )
+
+
+def test_partial_measure_raises():
+    """Measure covers only 1 of 2 allocated qubits — validation error."""
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(2)
+        squin.qubit.measure(ilist.IList([reg[0]]))  # type: ignore[arg-type]
+
+    errors = _validate(kernel)
+    assert len(errors) >= 1
+    assert any("2" in str(e) or "allocated" in str(e).lower() for e in errors)
+
+
+def test_multiple_measures_raises():
+    """Two measure statements — validation error."""
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(2)
+        squin.qubit.measure(ilist.IList([reg[0]]))  # type: ignore[arg-type]
+        squin.qubit.measure(ilist.IList([reg[1]]))  # type: ignore[arg-type]
+
+    errors = _validate(kernel)
+    assert len(errors) >= 1
+    assert any(
+        "multiple" in str(e).lower() or "more than one" in str(e).lower()
+        for e in errors
+    )

--- a/python/tests/pipeline/test_logical_pipeline.py
+++ b/python/tests/pipeline/test_logical_pipeline.py
@@ -1,0 +1,53 @@
+"""Tests for LogicalPipeline."""
+
+import bloqade.squin as squin
+
+import bloqade.gemini as gemini
+from bloqade.lanes.dialects import move
+from bloqade.lanes.pipeline import LogicalPipeline
+
+
+def test_logical_pipeline_smoke():
+    """2-qubit Bell kernel compiles end-to-end via LogicalPipeline."""
+
+    @gemini.logical.kernel(aggressive_unroll=True)
+    def kernel():
+        reg = squin.qalloc(2)
+        squin.h(reg[0])
+        squin.cx(reg[0], reg[1])
+        gemini.logical.terminal_measure(reg)
+
+    out = LogicalPipeline().emit(kernel)
+    assert out is not None
+    fills = [s for s in out.callable_region.walk() if isinstance(s, move.Fill)]
+    assert len(fills) == 1
+
+
+def test_logical_pipeline_produces_logical_initialize():
+    """Logical pipeline inserts LogicalInitialize (not just Fill)."""
+
+    @gemini.logical.kernel(aggressive_unroll=True)
+    def kernel():
+        reg = squin.qalloc(1)
+        squin.h(reg[0])
+        gemini.logical.terminal_measure(reg)
+
+    out = LogicalPipeline().emit(kernel)
+    inits = [
+        s for s in out.callable_region.walk() if isinstance(s, move.LogicalInitialize)
+    ]
+    assert len(inits) >= 1
+
+
+def test_logical_pipeline_no_return_moves():
+    """insert_return_moves=False still produces a valid compiled kernel."""
+
+    @gemini.logical.kernel(aggressive_unroll=True)
+    def kernel():
+        reg = squin.qalloc(2)
+        squin.h(reg[0])
+        squin.cx(reg[0], reg[1])
+        gemini.logical.terminal_measure(reg)
+
+    out = LogicalPipeline(insert_return_moves=False).emit(kernel)
+    assert out is not None

--- a/python/tests/pipeline/test_logical_pipeline.py
+++ b/python/tests/pipeline/test_logical_pipeline.py
@@ -51,3 +51,17 @@ def test_logical_pipeline_no_return_moves():
 
     out = LogicalPipeline(insert_return_moves=False).emit(kernel)
     assert out is not None
+
+
+def test_logical_pipeline_no_raise_suppresses_validation():
+    """no_raise=True does not raise even when pre-native validation fails."""
+
+    @gemini.logical.kernel(aggressive_unroll=True)
+    def invalid_kernel():
+        reg = squin.qalloc(2)
+        squin.h(reg[0])
+        squin.cx(reg[0], reg[1])
+        # missing terminal_measure — violates GeminiTerminalMeasurementValidation
+
+    out = LogicalPipeline().emit(invalid_kernel, no_raise=True)
+    assert out is not None

--- a/python/tests/pipeline/test_physical_pipeline.py
+++ b/python/tests/pipeline/test_physical_pipeline.py
@@ -78,3 +78,50 @@ def test_physical_pipeline_missing_measure_raises():
 
     with pytest.raises(ValidationErrorGroup):
         PhysicalPipeline().emit(kernel, no_raise=False)
+
+
+def test_physical_pipeline_no_raise_succeeds_without_terminal_measure():
+    """With no_raise=True, PhysicalPipeline.emit must not raise even when there
+    is no terminal measurement (validation errors are suppressed in lenient mode)."""
+
+    @squin.kernel
+    def kernel():
+        squin.qalloc(1)  # no measurement
+
+    # Should not raise in lenient mode.
+    result = PhysicalPipeline().emit(kernel, no_raise=True)
+    assert result is not None
+
+
+def test_physical_pipeline_resolves_none_to_physical_defaults(monkeypatch):
+    """When layout_heuristic and placement_strategy are None, PhysicalPipeline
+    resolves them to PhysicalLayoutHeuristicGraphPartitionCenterOut and
+    PhysicalPlacementStrategy before passing them to the place→move stage."""
+    from bloqade.lanes.heuristics.physical.layout import (
+        PhysicalLayoutHeuristicGraphPartitionCenterOut,
+    )
+    from bloqade.lanes.heuristics.physical.placement import PhysicalPlacementStrategy
+    from bloqade.lanes.pipeline.base import _PlaceToMove
+
+    captured: dict = {}
+    _orig_emit = _PlaceToMove.emit
+
+    def spy_emit(self_inner, mt, no_raise=True):
+        captured["layout_heuristic_type"] = type(self_inner.layout_heuristic)
+        captured["placement_strategy_type"] = type(self_inner.placement_strategy)
+        return _orig_emit(self_inner, mt, no_raise=no_raise)
+
+    monkeypatch.setattr(_PlaceToMove, "emit", spy_emit)
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(1)
+        squin.qubit.measure(ilist.IList([reg[0]]))  # type: ignore[arg-type]
+
+    PhysicalPipeline().emit(kernel)
+
+    assert (
+        captured["layout_heuristic_type"]
+        is PhysicalLayoutHeuristicGraphPartitionCenterOut
+    )
+    assert captured["placement_strategy_type"] is PhysicalPlacementStrategy

--- a/python/tests/pipeline/test_physical_pipeline.py
+++ b/python/tests/pipeline/test_physical_pipeline.py
@@ -1,7 +1,11 @@
 """Tests for the physical pipeline and NewPinnedQubit."""
 
+from kirin import ir, rewrite
+
+from bloqade import qubit
 from bloqade.lanes.bytecode.encoding import LocationAddress
 from bloqade.lanes.dialects import place
+from bloqade.lanes.rewrite.circuit2place import RewriteQubitsToPinnedQubits
 
 
 def test_new_pinned_qubit_unpinned():
@@ -15,3 +19,16 @@ def test_new_pinned_qubit_pinned():
     addr = LocationAddress(word_id=4, site_id=2, zone_id=0)
     stmt = place.NewPinnedQubit(location_address=addr)
     assert stmt.location_address == addr
+
+
+def test_rewrite_new_to_pinned():
+    """qubit.stmts.New is lowered to NewPinnedQubit(location_address=None)."""
+    block = ir.Block()
+    plain_new = qubit.stmts.New()
+    block.stmts.append(plain_new)
+
+    rewrite.Walk(RewriteQubitsToPinnedQubits()).rewrite(block)
+
+    pinned = [s for s in block.stmts if isinstance(s, place.NewPinnedQubit)]
+    assert len(pinned) == 1
+    assert pinned[0].location_address is None

--- a/python/tests/pipeline/test_physical_pipeline.py
+++ b/python/tests/pipeline/test_physical_pipeline.py
@@ -1,0 +1,17 @@
+"""Tests for the physical pipeline and NewPinnedQubit."""
+
+from bloqade.lanes.bytecode.encoding import LocationAddress
+from bloqade.lanes.dialects import place
+
+
+def test_new_pinned_qubit_unpinned():
+    """NewPinnedQubit with no address has location_address=None."""
+    stmt = place.NewPinnedQubit()
+    assert stmt.location_address is None
+
+
+def test_new_pinned_qubit_pinned():
+    """NewPinnedQubit with a LocationAddress stores it correctly."""
+    addr = LocationAddress(word_id=4, site_id=2, zone_id=0)
+    stmt = place.NewPinnedQubit(location_address=addr)
+    assert stmt.location_address == addr

--- a/python/tests/pipeline/test_physical_pipeline.py
+++ b/python/tests/pipeline/test_physical_pipeline.py
@@ -1,10 +1,14 @@
 """Tests for the physical pipeline and NewPinnedQubit."""
 
+import bloqade.squin as squin
 from kirin import ir, rewrite
+from kirin.dialects import ilist
+from kirin.ir.exception import ValidationErrorGroup
 
 from bloqade import qubit
 from bloqade.lanes.bytecode.encoding import LocationAddress
-from bloqade.lanes.dialects import place
+from bloqade.lanes.dialects import move, place
+from bloqade.lanes.pipeline import PhysicalPipeline
 from bloqade.lanes.rewrite.circuit2place import RewriteQubitsToPinnedQubits
 
 
@@ -32,3 +36,45 @@ def test_rewrite_new_to_pinned():
     pinned = [s for s in block.stmts if isinstance(s, place.NewPinnedQubit)]
     assert len(pinned) == 1
     assert pinned[0].location_address is None
+
+
+def test_physical_pipeline_smoke():
+    """Single-qubit kernel with terminal measure compiles end-to-end."""
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(1)
+        squin.qubit.measure(ilist.IList([reg[0]]))  # type: ignore[arg-type]
+
+    out = PhysicalPipeline().emit(kernel)
+    assert out is not None
+    fills = [s for s in out.callable_region.walk() if isinstance(s, move.Fill)]
+    assert len(fills) == 1
+
+
+def test_physical_pipeline_no_new_pinned_remaining():
+    """After compilation, no place.NewPinnedQubit statements remain."""
+
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(2)
+        squin.qubit.measure(ilist.IList([reg[0], reg[1]]))  # type: ignore[arg-type]
+
+    out = PhysicalPipeline().emit(kernel)
+    pinned_stmts = [
+        s for s in out.callable_region.walk() if isinstance(s, place.NewPinnedQubit)
+    ]
+    assert pinned_stmts == []
+
+
+def test_physical_pipeline_missing_measure_raises():
+    """Kernel with no terminal measure raises at validation."""
+
+    @squin.kernel
+    def kernel():
+        _reg = squin.qalloc(1)  # noqa: F841
+
+    import pytest
+
+    with pytest.raises(ValidationErrorGroup):
+        PhysicalPipeline().emit(kernel, no_raise=False)

--- a/python/tests/test_compile_api_split.py
+++ b/python/tests/test_compile_api_split.py
@@ -9,32 +9,28 @@ from bloqade.lanes.analysis.layout import LayoutHeuristicABC
 from bloqade.lanes.analysis.placement import PlacementStrategyABC
 from bloqade.lanes.heuristics.logical import layout as logical_layout
 from bloqade.lanes.heuristics.logical.placement import LogicalPlacementStrategyNoHome
-from bloqade.lanes.heuristics.physical.layout import (
-    PhysicalLayoutHeuristicGraphPartitionCenterOut,
-)
-from bloqade.lanes.heuristics.physical.placement import PhysicalPlacementStrategy
 
 
 def test_logical_mvp_compile_to_move_uses_logical_defaults(monkeypatch):
     captured = {}
 
-    def fake_squin_to_move(
-        mt,
-        layout_heuristic=None,
-        placement_strategy=None,
-        insert_return_moves=True,
-        no_raise=True,
-        logical_initialize=True,
-    ):
-        captured["mt"] = mt
-        captured["layout_heuristic"] = layout_heuristic
-        captured["placement_strategy"] = placement_strategy
-        captured["insert_return_moves"] = insert_return_moves
-        captured["no_raise"] = no_raise
-        captured["logical_initialize"] = logical_initialize
-        return "move_ir"
+    class FakeLogicalPipeline:
+        def __init__(
+            self,
+            layout_heuristic=None,
+            placement_strategy=None,
+            insert_return_moves=True,
+            **kwargs,
+        ):
+            captured["layout_heuristic"] = layout_heuristic
+            captured["placement_strategy"] = placement_strategy
+            captured["insert_return_moves"] = insert_return_moves
 
-    monkeypatch.setattr(logical_mvp, "squin_to_move", fake_squin_to_move)
+        def emit(self, mt, no_raise=True):
+            captured["mt"] = mt
+            return "move_ir"
+
+    monkeypatch.setattr(logical_mvp, "LogicalPipeline", FakeLogicalPipeline)
 
     marker = cast(ir.Method, object())
     out = logical_mvp.compile_squin_to_move(marker)
@@ -46,27 +42,28 @@ def test_logical_mvp_compile_to_move_uses_logical_defaults(monkeypatch):
     )
     assert isinstance(captured["placement_strategy"], LogicalPlacementStrategyNoHome)
     assert captured["insert_return_moves"] is True
-    assert captured["logical_initialize"] is True
 
 
 def test_modular_compile_to_move_allows_strategy_swapping(monkeypatch):
     captured = {}
 
-    def fake_squin_to_move(
-        mt,
-        layout_heuristic=None,
-        placement_strategy=None,
-        insert_return_moves=True,
-        no_raise=True,
-    ):
-        captured["mt"] = mt
-        captured["layout_heuristic"] = layout_heuristic
-        captured["placement_strategy"] = placement_strategy
-        captured["insert_return_moves"] = insert_return_moves
-        captured["no_raise"] = no_raise
-        return "move_ir"
+    class FakePhysicalPipeline:
+        def __init__(
+            self,
+            layout_heuristic=None,
+            placement_strategy=None,
+            insert_return_moves=True,
+            **kwargs,
+        ):
+            captured["layout_heuristic"] = layout_heuristic
+            captured["placement_strategy"] = placement_strategy
+            captured["insert_return_moves"] = insert_return_moves
 
-    monkeypatch.setattr(compile_api, "squin_to_move", fake_squin_to_move)
+        def emit(self, mt, no_raise=True):
+            captured["mt"] = mt
+            return "move_ir"
+
+    monkeypatch.setattr(compile_api, "PhysicalPipeline", FakePhysicalPipeline)
 
     marker = cast(ir.Method, object())
     custom_layout = cast(LayoutHeuristicABC, object())
@@ -88,26 +85,22 @@ def test_modular_compile_to_move_allows_strategy_swapping(monkeypatch):
 def test_physical_compile_to_move_defaults_are_physical(monkeypatch):
     captured = {}
 
-    def fake_squin_to_move(
-        mt,
-        layout_heuristic=None,
-        placement_strategy=None,
-        insert_return_moves=True,
-        no_raise=True,
-    ):
-        captured["layout_heuristic"] = layout_heuristic
-        captured["placement_strategy"] = placement_strategy
-        return "move_ir"
+    class FakePhysicalPipeline:
+        def __init__(self, layout_heuristic=None, placement_strategy=None, **kwargs):
+            captured["layout_heuristic"] = layout_heuristic
+            captured["placement_strategy"] = placement_strategy
 
-    monkeypatch.setattr(compile_api, "squin_to_move", fake_squin_to_move)
+        def emit(self, mt, no_raise=True):
+            return "move_ir"
+
+    monkeypatch.setattr(compile_api, "PhysicalPipeline", FakePhysicalPipeline)
 
     marker = cast(ir.Method, object())
     out = compile_api.compile_squin_to_move(marker)
     assert out == "move_ir"
-    assert isinstance(
-        captured["layout_heuristic"], PhysicalLayoutHeuristicGraphPartitionCenterOut
-    )
-    assert isinstance(captured["placement_strategy"], PhysicalPlacementStrategy)
+    # None means PhysicalPipeline.emit will use the physical defaults internally.
+    assert captured["layout_heuristic"] is None
+    assert captured["placement_strategy"] is None
 
 
 def test_physical_compile_has_no_transversal_or_placement_mode():

--- a/python/tests/test_integration.py
+++ b/python/tests/test_integration.py
@@ -11,7 +11,6 @@ from kirin.dialects import ilist
 
 from bloqade import qubit, squin, types
 from bloqade.gemini import logical as gemini_logical
-from bloqade.lanes import compile
 from bloqade.lanes.arch.gemini import physical
 from bloqade.lanes.arch.gemini.logical import get_arch_spec
 from bloqade.lanes.arch.gemini.physical import get_arch_spec as get_physical_arch_spec
@@ -19,6 +18,10 @@ from bloqade.lanes.heuristics.logical import layout as logical_layout
 from bloqade.lanes.heuristics.logical.placement import (
     LogicalPlacementStrategyNoHome,
 )
+from bloqade.lanes.heuristics.physical.layout import (
+    PhysicalLayoutHeuristicGraphPartitionCenterOut,
+)
+from bloqade.lanes.heuristics.physical.placement import PhysicalPlacementStrategy
 from bloqade.lanes.logical_mvp import (
     compile_squin_to_move,
     transversal_rewrites,
@@ -162,7 +165,15 @@ def test_ghz_move_to_squin_roundtrip_state_vector():
         for i in range(1, len(reg)):
             squin.cx(reg[0], reg[i])
 
-    physical_move = compile.compile_squin_to_move(ghz, no_raise=False)
+    # GHZ is a state-prep circuit with no terminal measurement; use the
+    # lower-level squin_to_move API which does not enforce that requirement.
+    physical_move = squin_to_move(
+        ghz,
+        PhysicalLayoutHeuristicGraphPartitionCenterOut(),
+        PhysicalPlacementStrategy(),
+        logical_initialize=False,
+        no_raise=False,
+    )
     roundtrip_squin = MoveToSquinPhysical(get_physical_arch_spec()).emit(
         physical_move, no_raise=False
     )

--- a/python/tests/test_upstream.py
+++ b/python/tests/test_upstream.py
@@ -3,12 +3,12 @@ import math
 from kirin.dialects import ilist
 
 from bloqade import squin
-from bloqade.lanes.compile import squin_to_move
 from bloqade.lanes.dialects import move
 from bloqade.lanes.heuristics.physical.layout import (
     PhysicalLayoutHeuristicGraphPartitionCenterOut,
 )
 from bloqade.lanes.heuristics.physical.placement import PhysicalPlacementStrategy
+from bloqade.lanes.upstream import squin_to_move
 
 
 def test_physical_compile():

--- a/python/tests/test_validation_squin_kernels.py
+++ b/python/tests/test_validation_squin_kernels.py
@@ -6,12 +6,12 @@ from tests._validation_squin_kernels import (
 
 from bloqade.lanes.analysis import atom
 from bloqade.lanes.arch.gemini.physical import get_arch_spec as get_physical_arch_spec
-from bloqade.lanes.compile import squin_to_move
 from bloqade.lanes.dialects import move
 from bloqade.lanes.heuristics.physical.layout import (
     PhysicalLayoutHeuristicGraphPartitionCenterOut,
 )
 from bloqade.lanes.heuristics.physical.placement import PhysicalPlacementStrategy
+from bloqade.lanes.upstream import squin_to_move
 from bloqade.lanes.validation.address import Validation
 
 


### PR DESCRIPTION
## Summary

- Adds `place.NewPinnedQubit` — the physical-pipeline counterpart of `NewLogicalQubit` (no init angles, optional `LocationAddress`)
- Adds `place._NewQubitBase` — shared abstract base so all rewrite rules accept both qubit types uniformly
- Adds `RewriteQubitsToPinnedQubits` — lowers `qubit.stmts.New` / `gemini.common.NewAt` to `NewPinnedQubit`
- Adds `PhysicalTerminalMeasurementValidation` — Forward dataflow pass (in `gemini.common.validation`) ensuring exactly one terminal measurement covering all allocated qubits
- Extracts shared `_NativeToPlaceBase` + `_PlaceToMove` in `pipeline/base.py`; `LogicalPipeline` and `PhysicalPipeline` become thin overrides
- Adds `pipeline/__init__.py` with `__all__ = ["LogicalPipeline", "PhysicalPipeline"]`
- Shims `compile.py` / `logical_mvp.py` to delegate to the new pipeline classes

## Test plan

- [x] `python/tests/pipeline/test_physical_pipeline.py` — `NewPinnedQubit` construction, `RewriteQubitsToPinnedQubits`, `no_raise` semantics, concrete default heuristic types
- [x] `python/tests/gemini/validation/test_physical_terminal_measure.py` — valid/missing/partial/multiple measure cases
- [x] Full non-slow test suite passes (`pytest -m "not slow"` — 1049 passed, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)