### PR TITLE
ci: skip coverage post job for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,9 @@ jobs:
   post:
     runs-on: ubuntu-latest
     needs: build
-    if: github.event.pull_request
+    if: github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - name: download coverage


### PR DESCRIPTION
## Summary

- The `post` job's `orgoro/coverage` step was failing for fork PRs with `HttpError: Resource not accessible by integration`
- GitHub restricts `GITHUB_TOKEN` to read-only for fork `pull_request` events, so the action can't post PR comments
- Add `github.event.pull_request.head.repo.full_name == github.repository` condition to skip the job for fork PRs (CI stays green for external contributors)
- Add `permissions: pull-requests: write` so the job has the right token scope for internal PRs

## Test plan

- [ ] Verify the `post` job is skipped on a fork PR (external contributor flow)
- [ ] Verify the `post` job still posts a coverage comment on an internal PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)