### PR TITLE
feat: added small helper for constructing physicalplacementstrategy

### DIFF
--- a/python/bloqade/lanes/heuristics/physical/__init__.py
+++ b/python/bloqade/lanes/heuristics/physical/__init__.py
@@ -4,6 +4,7 @@ from bloqade.lanes.heuristics.physical.layout import (
 from bloqade.lanes.heuristics.physical.movement import (
     PhysicalPlacementStrategy,
     RustPlacementTraversal,
+    make_physical_placement_strategy,
 )
 from bloqade.lanes.heuristics.physical.target_generator import (
     AODClusterTargetGenerator,
@@ -22,4 +23,5 @@ __all__ = [
     "RustPlacementTraversal",
     "TargetContext",
     "TargetGeneratorABC",
+    "make_physical_placement_strategy",
 ]

--- a/python/bloqade/lanes/heuristics/physical/movement.py
+++ b/python/bloqade/lanes/heuristics/physical/movement.py
@@ -8,6 +8,7 @@ from bloqade.lanes.analysis.placement import (
     ConcreteState,
     ExecuteCZ,
     ExecuteMeasure,
+    PalindromePlacementStrategy,
     PlacementStrategyABC,
 )
 from bloqade.lanes.analysis.placement.strategy import assert_single_cz_zone
@@ -44,6 +45,19 @@ _STRATEGY_MAP: dict[str, _native.SearchStrategy] = {
     "entropy": _native.SearchStrategy.ENTROPY,
 }
 
+SearchStrategyName = Literal[
+    "astar",
+    "dfs",
+    "bfs",
+    "greedy",
+    "ids",
+    "cascade",
+    "cascade-ids",
+    "cascade-dfs",
+    "cascade-entropy",
+    "entropy",
+]
+
 
 _DIR_MAP = {0: Direction.FORWARD, 1: Direction.BACKWARD}
 _MT_MAP = {0: MoveType.SITE, 1: MoveType.WORD, 2: MoveType.ZONE}
@@ -79,18 +93,7 @@ class RustPlacementTraversal:
     once the parameters are validated via Rust-only benchmarking.
     """
 
-    strategy: Literal[
-        "astar",
-        "dfs",
-        "bfs",
-        "greedy",
-        "ids",
-        "cascade",
-        "cascade-ids",
-        "cascade-dfs",
-        "cascade-entropy",
-        "entropy",
-    ] = "entropy"
+    strategy: SearchStrategyName = "entropy"
     max_movesets_per_group: int = 3
     max_goal_candidates: int = 3
     max_expansions: int | None = 300
@@ -351,3 +354,36 @@ class PhysicalPlacementStrategy(PlacementStrategyABC):
             move_count=state.move_count,
             zone_maps=tuple(ZoneAddress(loc.zone_id) for loc in state.layout),
         )
+
+
+def make_physical_placement_strategy(
+    *,
+    move_solutions_per_layer: int = 3,
+    search_budget: int | None = 300,
+    strategy: SearchStrategyName = "entropy",
+    arch_spec: ArchSpec | None = None,
+    return_moves: bool = True,
+    target_generator: TargetGeneratorABC | TargetGeneratorCallable | None = None,
+) -> PlacementStrategyABC:
+    """Build a physical placement strategy from user-facing search knobs.
+
+    ``move_solutions_per_layer`` maps to the Rust solver's
+    ``max_goal_candidates``. ``search_budget`` maps to the per-CZ-stage
+    ``max_expansions`` budget shared across target candidates.
+    """
+    if move_solutions_per_layer < 1:
+        raise ValueError("move_solutions_per_layer must be >= 1")
+    if search_budget is not None and search_budget < 1:
+        raise ValueError("search_budget must be None or >= 1")
+
+    inner = PhysicalPlacementStrategy(
+        arch_spec=get_physical_arch_spec() if arch_spec is None else arch_spec,
+        traversal=RustPlacementTraversal(
+            strategy=strategy,
+            max_goal_candidates=move_solutions_per_layer,
+            max_expansions=search_budget,
+        ),
+        target_generator=target_generator,
+    )
+
+    return PalindromePlacementStrategy(inner=inner) if return_moves else inner

--- a/python/bloqade/lanes/pipeline/physical.py
+++ b/python/bloqade/lanes/pipeline/physical.py
@@ -10,13 +10,12 @@ from bloqade.gemini.common.validation.terminal_measure import (
     PhysicalTerminalMeasurementValidation,
 )
 from bloqade.lanes.analysis import layout, placement
-from bloqade.lanes.analysis.placement import PalindromePlacementStrategy
 from bloqade.lanes.arch.gemini.physical import get_arch_spec as get_physical_arch_spec
 from bloqade.lanes.arch.spec import ArchSpec
 from bloqade.lanes.heuristics.physical.layout import (
     PhysicalLayoutHeuristicGraphPartitionCenterOut,
 )
-from bloqade.lanes.heuristics.physical.placement import PhysicalPlacementStrategy
+from bloqade.lanes.heuristics.physical.movement import make_physical_placement_strategy
 from bloqade.lanes.passes import SequentialPlacePass
 from bloqade.lanes.rewrite import circuit2place
 
@@ -49,7 +48,9 @@ class PhysicalPipeline:
 
     arch_spec: ArchSpec = field(default_factory=get_physical_arch_spec)
     layout_heuristic: layout.LayoutHeuristicABC | None = None
-    placement_strategy: placement.PlacementStrategyABC | None = None
+    placement_strategy: placement.PlacementStrategyABC | None = field(
+        default_factory=make_physical_placement_strategy
+    )
     place_opt_type: type[passes.Pass] = field(default=SequentialPlacePass)
 
     def emit(self, mt: Method, no_raise: bool = True) -> Method:
@@ -59,9 +60,7 @@ class PhysicalPipeline:
             else self.layout_heuristic
         )
         strategy = (
-            PalindromePlacementStrategy(
-                inner=PhysicalPlacementStrategy(arch_spec=self.arch_spec)
-            )
+            make_physical_placement_strategy(arch_spec=self.arch_spec)
             if self.placement_strategy is None
             else self.placement_strategy
         )

--- a/python/tests/heuristics/test_physical_placement_factory.py
+++ b/python/tests/heuristics/test_physical_placement_factory.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from bloqade.lanes.analysis.placement import PalindromePlacementStrategy
+from bloqade.lanes.heuristics.physical import make_physical_placement_strategy
+from bloqade.lanes.heuristics.physical.movement import PhysicalPlacementStrategy
+
+
+def test_make_physical_placement_strategy_defaults_match_physical_pipeline():
+    strategy = make_physical_placement_strategy()
+
+    assert isinstance(strategy, PalindromePlacementStrategy)
+    assert isinstance(strategy.inner, PhysicalPlacementStrategy)
+    assert strategy.inner.traversal.strategy == "entropy"
+    assert strategy.inner.traversal.max_movesets_per_group == 3
+    assert strategy.inner.traversal.max_goal_candidates == 3
+    assert strategy.inner.traversal.max_expansions == 300
+
+
+def test_make_physical_placement_strategy_threads_user_knobs():
+    strategy = make_physical_placement_strategy(
+        move_solutions_per_layer=8,
+        search_budget=10_000,
+        strategy="astar",
+    )
+
+    assert isinstance(strategy, PalindromePlacementStrategy)
+    inner = strategy.inner
+    assert isinstance(inner, PhysicalPlacementStrategy)
+    assert inner.traversal.strategy == "astar"
+    assert inner.traversal.max_goal_candidates == 8
+    assert inner.traversal.max_movesets_per_group == 3
+    assert inner.traversal.max_expansions == 10_000
+
+
+def test_make_physical_placement_strategy_can_disable_return_moves():
+    strategy = make_physical_placement_strategy(return_moves=False)
+
+    assert isinstance(strategy, PhysicalPlacementStrategy)
+
+
+def test_make_physical_placement_strategy_allows_unbounded_search_budget():
+    strategy = make_physical_placement_strategy(search_budget=None)
+
+    assert isinstance(strategy, PalindromePlacementStrategy)
+    inner = strategy.inner
+    assert isinstance(inner, PhysicalPlacementStrategy)
+    assert inner.traversal.max_expansions is None
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"move_solutions_per_layer": 0}, "move_solutions_per_layer"),
+        ({"search_budget": 0}, "search_budget"),
+    ],
+)
+def test_make_physical_placement_strategy_rejects_invalid_values(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        make_physical_placement_strategy(**kwargs)

--- a/python/tests/pipeline/test_physical_pipeline.py
+++ b/python/tests/pipeline/test_physical_pipeline.py
@@ -8,6 +8,7 @@ from kirin.ir.exception import ValidationErrorGroup
 from bloqade import qubit
 from bloqade.lanes.bytecode.encoding import LocationAddress
 from bloqade.lanes.dialects import move, place
+from bloqade.lanes.heuristics.physical.movement import PhysicalPlacementStrategy
 from bloqade.lanes.pipeline import PhysicalPipeline
 from bloqade.lanes.rewrite.circuit2place import RewriteQubitsToPinnedQubits
 
@@ -50,6 +51,20 @@ def test_physical_pipeline_smoke():
     assert out is not None
     fills = [s for s in out.callable_region.walk() if isinstance(s, move.Fill)]
     assert len(fills) == 1
+
+
+def test_physical_pipeline_placement_strategy_default_uses_factory():
+    """PhysicalPipeline should eagerly construct the shared default strategy."""
+    from bloqade.lanes.analysis.placement import PalindromePlacementStrategy
+
+    pipeline = PhysicalPipeline()
+
+    assert isinstance(pipeline.placement_strategy, PalindromePlacementStrategy)
+    assert isinstance(pipeline.placement_strategy.inner, PhysicalPlacementStrategy)
+    traversal = pipeline.placement_strategy.inner.traversal
+    assert traversal.strategy == "entropy"
+    assert traversal.max_goal_candidates == 3
+    assert traversal.max_expansions == 300
 
 
 def test_physical_pipeline_no_new_pinned_remaining():


### PR DESCRIPTION
# PR Description: Add user-facing physical move-search tuning helper

## Summary

Adds a small public helper for constructing the physical placement strategy from user-facing compiler search knobs:

```python
make_physical_placement_strategy(
    move_solutions_per_layer=8,
    search_budget=10_000,
)
```

This avoids requiring users to manually thread configuration through `RustPlacementTraversal`, `PhysicalPlacementStrategy`, and `PalindromePlacementStrategy`.

## Changes

- Added `make_physical_placement_strategy` to `bloqade.lanes.heuristics.physical`.
- Exported the helper from the physical heuristics package.
- Added a shared `SearchStrategyName` type alias for the supported Rust move-search strategy names.
- Mapped user-facing knobs to the underlying Rust traversal fields:
  - `move_solutions_per_layer` -> `RustPlacementTraversal.max_goal_candidates`
  - `search_budget` -> `RustPlacementTraversal.max_expansions`
- Preserved the existing physical pipeline default by returning `PalindromePlacementStrategy(inner=PhysicalPlacementStrategy(...))`.
- Added `return_moves=False` for callers that need the bare `PhysicalPlacementStrategy`.
- Added validation for invalid non-positive knob values.
- Added support for `search_budget=None` to allow unbounded search.
- Added focused tests for defaults, knob threading, return type selection, unbounded budget, and validation.

## Notes

The “number of valid move solutions per layer” knob maps to `max_goal_candidates`, not `max_movesets_per_group`.

`max_goal_candidates` controls how many complete goal states / valid move solutions entropy search tries to collect before stopping. `max_movesets_per_group` is a lower-level branching-width knob controlling how many candidate movesets are retained per bus group during entropy search.

## Testing

Ran:

```bash
uv run pytest python/tests/heuristics/test_physical_placement_factory.py python/tests/heuristics/test_physical_placement.py python/tests/heuristics/test_target_generator.py
uv run ruff check python/bloqade/lanes/heuristics/physical/movement.py python/bloqade/lanes/heuristics/physical/__init__.py python/tests/heuristics/test_physical_placement_factory.py
uv run pyright python/bloqade/lanes/heuristics/physical/movement.py python/tests/heuristics/test_physical_placement_factory.py
```

Results:

- `43 passed`
- Ruff clean
- Pyright: `0 errors`
