### PR TITLE
Fix: Adding test to check for ordering of final statements

### DIFF
--- a/python/bloqade/gemini/logical/rewrite/remove_postprocessing.py
+++ b/python/bloqade/gemini/logical/rewrite/remove_postprocessing.py
@@ -61,7 +61,7 @@ class _DeleteTerminalMeasure(RewriteRule):
             # In this case the _DeleteBelowTerminalMeasure
             # Has deleted the return and left only the Terminal measurement
             # we delete this and add back a return value
-            (none_stmt := func.ConstantNone()).insert_after(last_stmt)
+            (none_stmt := func.ConstantNone()).insert_before(last_stmt)
             func.Return(none_stmt).insert_before(last_stmt)
             last_stmt.delete()
             node.signature = func.Signature(node.signature.inputs, types.NoneType)

--- a/python/tests/gemini/test_rewrite.py
+++ b/python/tests/gemini/test_rewrite.py
@@ -3,7 +3,7 @@ from bloqade.squin.gate.stmts import U3
 from bloqade.test_utils import assert_nodes
 from bloqade.types import MeasurementResultType
 from kirin import ir, rewrite, types
-from kirin.dialects import ilist, py
+from kirin.dialects import func, ilist, py
 
 from bloqade import squin
 from bloqade.gemini import logical
@@ -110,6 +110,9 @@ def test_remove_postprocessing_and_terminal_measure():
     # check that calling twice doesn't do anything
     result = RemovePostProcessing(main.dialects, delete_terminal_measure=True)(main)
     assert not result.has_done_something
+    assert (last_stmt := main.callable_region.blocks[-1].last_stmt) is not None
+    assert isinstance(last_stmt, func.Return)
+    assert isinstance(last_stmt.prev_stmt, func.ConstantNone)
     assert not any(
         isinstance(stmt, (SetDetector, TerminalLogicalMeasurement))
         for stmt in main.callable_region.stmts()
@@ -137,6 +140,9 @@ def test_remove_postprocessing_and_terminal_measure_2():
     # check that calling twice doesn't do anything
     result = RemovePostProcessing(main.dialects, delete_terminal_measure=True)(main)
     assert not result.has_done_something
+    assert (last_stmt := main.callable_region.blocks[-1].last_stmt) is not None
+    assert isinstance(last_stmt, func.Return)
+    assert isinstance(last_stmt.prev_stmt, func.ConstantNone)
 
     assert not any(
         isinstance(stmt, TerminalLogicalMeasurement)


### PR DESCRIPTION
In pr #643 The insertion of the constant None value was after the terminal measurement which messed up the ordering of the SSA Values breaking the dominance principle. This PR adds a test to check for this as well as the fix to fix the insertion ordering. 