### PR TITLE
refactor(python): make arch_spec the single source of truth in LogicalPipeline

### DIFF
--- a/python/bloqade/lanes/heuristics/logical/layout.py
+++ b/python/bloqade/lanes/heuristics/logical/layout.py
@@ -11,7 +11,7 @@ from bloqade.lanes.bytecode.encoding import LocationAddress
 
 @dataclass
 class LogicalLayoutHeuristic(LayoutHeuristicABC):
-    arch_spec: ArchSpec = field(default_factory=get_arch_spec, init=False)
+    arch_spec: ArchSpec = field(default_factory=get_arch_spec)
 
     def score_parallelism(
         self,

--- a/python/bloqade/lanes/heuristics/logical/placement.py
+++ b/python/bloqade/lanes/heuristics/logical/placement.py
@@ -176,7 +176,7 @@ class LogicalPlacementMethods:
 
 @dataclass
 class LogicalPlacementStrategy(LogicalPlacementMethods, SingleZonePlacementStrategyABC):
-    arch_spec: ArchSpec = field(default_factory=get_arch_spec, init=False)
+    arch_spec: ArchSpec = field(default_factory=get_arch_spec)
 
     def compute_moves(
         self, state_before: ConcreteState, state_after: ConcreteState
@@ -188,7 +188,7 @@ class LogicalPlacementStrategy(LogicalPlacementMethods, SingleZonePlacementStrat
 
 @dataclass
 class LogicalPlacementStrategyNoHome(LogicalPlacementMethods, PlacementStrategyABC):
-    arch_spec: ArchSpec = field(default_factory=get_arch_spec, init=False)
+    arch_spec: ArchSpec = field(default_factory=get_arch_spec)
     H_lookahead: int = 4
     gamma: float = 0.85
     lambda_lookahead: float = 0.5

--- a/python/bloqade/lanes/logical_mvp.py
+++ b/python/bloqade/lanes/logical_mvp.py
@@ -21,11 +21,8 @@ from bloqade.gemini.logical.validation.measurement.analysis import (
 from bloqade.lanes import visualize
 from bloqade.lanes.analysis import atom, placement
 from bloqade.lanes.analysis.layout import LayoutHeuristicABC
-from bloqade.lanes.analysis.placement import PalindromePlacementStrategy
 from bloqade.lanes.arch.gemini import logical, physical
 from bloqade.lanes.cudaq_integration import cudaq_to_squin, is_cudaq_kernel
-from bloqade.lanes.heuristics.logical import layout as logical_layout
-from bloqade.lanes.heuristics.logical.placement import LogicalPlacementStrategyNoHome
 from bloqade.lanes.noise_model import generate_logical_noise_model
 from bloqade.lanes.pipeline import LogicalPipeline
 from bloqade.lanes.rewrite import transversal
@@ -122,14 +119,6 @@ def compile_squin_to_move(
         ir.Method: The compiled move dialect method.
 
     """
-
-    if layout_heuristic is None:
-        layout_heuristic = logical_layout.LogicalLayoutHeuristic()
-
-    if placement_strategy is None:
-        placement_strategy = PalindromePlacementStrategy(
-            inner=LogicalPlacementStrategyNoHome()
-        )
 
     mt = LogicalPipeline(
         layout_heuristic=layout_heuristic,

--- a/python/bloqade/lanes/pipeline/logical.py
+++ b/python/bloqade/lanes/pipeline/logical.py
@@ -64,28 +64,41 @@ class LogicalPipeline:
 
     Includes Clifford/measurement/no-cloning validation and the full logical
     initialization sequence (InsertInitialize for LogicalQubits).
+
+    ``arch_spec`` is the single source of truth: when ``layout_heuristic`` or
+    ``placement_strategy`` are ``None`` (the default), they are constructed in
+    ``emit`` using ``self.arch_spec``, guaranteeing consistency.  Pass explicit
+    instances only when you need a fully custom heuristic or strategy; in that
+    case the caller is responsible for arch-spec consistency.
     """
 
-    layout_heuristic: layout.LayoutHeuristicABC = field(
-        default_factory=LogicalLayoutHeuristic
-    )
-    placement_strategy: placement.PlacementStrategyABC = field(
-        default_factory=lambda: PalindromePlacementStrategy(
-            inner=LogicalPlacementStrategyNoHome()
-        )
-    )
     arch_spec: ArchSpec = field(default_factory=get_logical_arch_spec)
+    layout_heuristic: layout.LayoutHeuristicABC | None = None
+    placement_strategy: placement.PlacementStrategyABC | None = None
     place_opt_type: type[passes.Pass] = field(default=SequentialPlacePass)
 
     def emit(self, mt: Method, no_raise: bool = True) -> Method:
+        heuristic = (
+            LogicalLayoutHeuristic(arch_spec=self.arch_spec)
+            if self.layout_heuristic is None
+            else self.layout_heuristic
+        )
+        strategy = (
+            PalindromePlacementStrategy(
+                inner=LogicalPlacementStrategyNoHome(arch_spec=self.arch_spec)
+            )
+            if self.placement_strategy is None
+            else self.placement_strategy
+        )
+
         out = _LogicalNativeToPlace(arch_spec=self.arch_spec).emit(
             mt, no_raise=no_raise
         )
         self.place_opt_type(out.dialects, no_raise=no_raise)(out)
 
         out = _PlaceToMove(
-            layout_heuristic=self.layout_heuristic,
-            placement_strategy=self.placement_strategy,
+            layout_heuristic=heuristic,
+            placement_strategy=strategy,
             insert_initialize=True,
         ).emit(out, no_raise=no_raise)
 

--- a/python/tests/heuristics/test_variable_word_size.py
+++ b/python/tests/heuristics/test_variable_word_size.py
@@ -45,19 +45,7 @@ def _make_placement_methods(word_size_y: int) -> LogicalPlacementMethods:
 
 def _make_nohome(word_size_y: int) -> LogicalPlacementStrategyNoHome:
     arch_spec = _make_arch(word_size_y)
-    placement = LogicalPlacementStrategyNoHome.__new__(LogicalPlacementStrategyNoHome)
-    placement.arch_spec = arch_spec
-    placement.H_lookahead = 4
-    placement.gamma = 0.85
-    placement.lambda_lookahead = 0.5
-    placement.K_candidates = 8
-    placement.large_cost = 1e9
-    placement.lane_move_overhead_cost = 0.0
-    placement.top_bus_signatures = 6
-    placement.bus_reward_rho = 0.7
-    placement._best_path_cache = {}
-    placement.__post_init__()
-    return placement
+    return LogicalPlacementStrategyNoHome(arch_spec=arch_spec)
 
 
 # ── Shared validation helpers ──

--- a/python/tests/test_compile_api_split.py
+++ b/python/tests/test_compile_api_split.py
@@ -33,6 +33,65 @@ def test_logical_mvp_compile_to_move_passes_through_to_pipeline(monkeypatch):
     assert captured["placement_strategy"] is None
 
 
+def test_logical_pipeline_defaults_built_from_arch_spec(monkeypatch):
+    """LogicalPipeline.emit() constructs the default heuristic and strategy from
+    self.arch_spec, not a hardcoded default — verifies the arch_spec propagation fix."""
+    import bloqade.lanes.pipeline.logical as logical_module
+    from bloqade.lanes.analysis.placement import PalindromePlacementStrategy
+    from bloqade.lanes.arch.gemini.logical import get_arch_spec
+    from bloqade.lanes.heuristics.logical.layout import LogicalLayoutHeuristic
+    from bloqade.lanes.heuristics.logical.placement import (
+        LogicalPlacementStrategyNoHome,
+    )
+    from bloqade.lanes.pipeline.logical import LogicalPipeline
+
+    custom_spec = get_arch_spec()
+    captured = {}
+
+    class FakeMethod:
+        dialects = cast(ir.DialectGroup, object())
+
+    fake_out = cast(ir.Method, FakeMethod())
+
+    class _NoOpPass:
+        def __init__(self, dialects: object, **kwargs: object) -> None:
+            pass
+
+        def __call__(self, mt: object) -> None:
+            pass
+
+    from kirin import passes
+
+    FakePassType = cast(type[passes.Pass], _NoOpPass)
+
+    class FakeNativeToPlace:
+        def __init__(self, arch_spec=None):
+            pass
+
+        def emit(self, mt, no_raise=True):
+            return fake_out
+
+    class FakePlaceToMove:
+        def __init__(self, layout_heuristic=None, placement_strategy=None, **kwargs):
+            captured["heuristic"] = layout_heuristic
+            captured["strategy"] = placement_strategy
+
+        def emit(self, mt, no_raise=True):
+            return fake_out
+
+    monkeypatch.setattr(logical_module, "_LogicalNativeToPlace", FakeNativeToPlace)
+    monkeypatch.setattr(logical_module, "_PlaceToMove", FakePlaceToMove)
+
+    pipeline = LogicalPipeline(arch_spec=custom_spec, place_opt_type=FakePassType)
+    pipeline.emit(cast(ir.Method, object()))
+
+    assert isinstance(captured["heuristic"], LogicalLayoutHeuristic)
+    assert captured["heuristic"].arch_spec is custom_spec
+    assert isinstance(captured["strategy"], PalindromePlacementStrategy)
+    assert isinstance(captured["strategy"].inner, LogicalPlacementStrategyNoHome)
+    assert captured["strategy"].inner.arch_spec is custom_spec
+
+
 def test_modular_compile_to_move_allows_strategy_swapping(monkeypatch):
     captured = {}
 

--- a/python/tests/test_compile_api_split.py
+++ b/python/tests/test_compile_api_split.py
@@ -6,24 +6,14 @@ from kirin import ir
 
 from bloqade.lanes import compile as compile_api, logical_mvp
 from bloqade.lanes.analysis.layout import LayoutHeuristicABC
-from bloqade.lanes.analysis.placement import (
-    PalindromePlacementStrategy,
-    PlacementStrategyABC,
-)
-from bloqade.lanes.heuristics.logical import layout as logical_layout
-from bloqade.lanes.heuristics.logical.placement import LogicalPlacementStrategyNoHome
+from bloqade.lanes.analysis.placement import PlacementStrategyABC
 
 
-def test_logical_mvp_compile_to_move_uses_logical_defaults(monkeypatch):
+def test_logical_mvp_compile_to_move_passes_through_to_pipeline(monkeypatch):
     captured = {}
 
     class FakeLogicalPipeline:
-        def __init__(
-            self,
-            layout_heuristic=None,
-            placement_strategy=None,
-            **kwargs,
-        ):
+        def __init__(self, layout_heuristic=None, placement_strategy=None, **kwargs):
             captured["layout_heuristic"] = layout_heuristic
             captured["placement_strategy"] = placement_strategy
 
@@ -38,12 +28,9 @@ def test_logical_mvp_compile_to_move_uses_logical_defaults(monkeypatch):
 
     assert out == "move_ir"
     assert captured["mt"] is marker
-    assert isinstance(
-        captured["layout_heuristic"], logical_layout.LogicalLayoutHeuristic
-    )
-    strategy = captured["placement_strategy"]
-    assert isinstance(strategy, PalindromePlacementStrategy)
-    assert isinstance(strategy.inner, LogicalPlacementStrategyNoHome)
+    # defaults are None — LogicalPipeline.emit constructs them from arch_spec
+    assert captured["layout_heuristic"] is None
+    assert captured["placement_strategy"] is None
 
 
 def test_modular_compile_to_move_allows_strategy_swapping(monkeypatch):


### PR DESCRIPTION
## Summary

- Remove `init=False` from `arch_spec` on `LogicalLayoutHeuristic`, `LogicalPlacementStrategy`, and `LogicalPlacementStrategyNoHome` so it is a normal init parameter with a default factory (consistent with the physical heuristics)
- `LogicalPipeline` now defaults `layout_heuristic` and `placement_strategy` to `None` and constructs them lazily in `emit()` from `self.arch_spec`, matching the `PhysicalPipeline` pattern — eliminates the silent mismatch where `LogicalPipeline(arch_spec=custom)` would use the custom spec for address validation but the hardcoded default spec inside the heuristic and strategy
- Simplify `logical_mvp.compile_squin_to_move` to drop explicit default construction (now redundant); remove dead imports
- Replace the `__new__`+manual-field workaround in `test_variable_word_size` with a normal constructor call

## Test plan

- [ ] `pytest python/tests/test_compile_api_split.py` — updated test passes
- [ ] `pytest python/tests/heuristics/` — all heuristic tests pass
- [ ] `pytest python/tests/integration/ python/tests/gemini/` — integration tests pass
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)