### PR TITLE
feat(visualizer): support custom entropy trace layouts

### DIFF
--- a/debug/custom_layout/demo_custom_layout_entropy.py
+++ b/debug/custom_layout/demo_custom_layout_entropy.py
@@ -1,0 +1,120 @@
+"""Debug demo: entropy search from an explicit initial atom layout.
+
+Run from the repository root:
+
+    uv run python debug/custom_layout/demo_custom_layout_entropy.py
+
+Use ``--no-interactive`` to capture and print the trace summary without opening
+the matplotlib visualizer.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from bloqade import qubit, squin
+from bloqade.lanes.bytecode._native import EntropyScorer
+from bloqade.lanes.bytecode.encoding import LocationAddress
+from bloqade.lanes.visualize.entropy_tree.controller import EntropyTreeController
+from bloqade.lanes.visualize.entropy_tree.state import TreeStateReducer
+from bloqade.lanes.visualize.entropy_tree.tracer import build_entropy_trace
+
+
+@squin.kernel(typeinfer=True, fold=True)
+def custom_layout_kernel():
+    q = qubit.qalloc(4)
+
+    # The CZ acts on q[0] and q[1]. q[2] and q[3] are spectator atoms that
+    # block their starting sites during the traced entropy search.
+    squin.cz(q[0], q[1])
+
+
+CUSTOM_LAYOUT = {
+    # q[0] and q[1] start in different home words, forcing entropy search to
+    # synthesize movement before the CZ can execute.
+    0: LocationAddress(word_id=0, site_id=0, zone_id=0),
+    1: LocationAddress(word_id=4, site_id=7, zone_id=0),
+    # Spectators: included because custom_layout is a full initial layout.
+    2: LocationAddress(word_id=2, site_id=1, zone_id=0),
+    3: LocationAddress(word_id=6, site_id=6, zone_id=0),
+}
+
+
+def _format_location(addr: LocationAddress) -> str:
+    return f"zone={addr.zone_id} word={addr.word_id} site={addr.site_id}"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Visualize entropy search from a custom initial atom layout."
+    )
+    parser.add_argument("--layer-index", type=int, default=0)
+    parser.add_argument("--max-expansions", type=int, default=1000)
+    parser.add_argument("--max-goal-candidates", type=int, default=3)
+    parser.add_argument("--no-interactive", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    max_expansions = None if args.max_expansions < 0 else args.max_expansions
+
+    bundle = build_entropy_trace(
+        kernel=custom_layout_kernel,
+        kernel_name="custom_layout_kernel",
+        layer_index=args.layer_index,
+        max_expansions=max_expansions,
+        max_goal_candidates=args.max_goal_candidates,
+        custom_layout=CUSTOM_LAYOUT,
+    )
+
+    print("Custom initial layout:")
+    for qid, addr in sorted(CUSTOM_LAYOUT.items()):
+        print(f"  q[{qid}] -> {_format_location(addr)}")
+
+    print("\nFirst traced target candidate:")
+    for local_qid, addr in sorted(bundle.traced_target.items()):
+        global_qid = bundle.local_to_global_qid.get(local_qid, local_qid)
+        print(f"  q[{global_qid}] -> {_format_location(addr)}")
+
+    print("\nBlocked spectator locations:")
+    for addr in bundle.blocked_locations:
+        global_qid = bundle.location_to_global_qid.get(addr)
+        label = "unknown" if global_qid is None else f"q[{global_qid}]"
+        print(f"  {label} at {_format_location(addr)}")
+
+    print(
+        f"\nCaptured {len(bundle.steps)} entropy-search steps "
+        f"for CZ stage {args.layer_index}."
+    )
+
+    if args.no_interactive:
+        return 0
+
+    reducer = TreeStateReducer(
+        steps=bundle.steps,
+        root_node_id=bundle.root_node_id,
+        best_buffer_size=bundle.best_buffer_size,
+    )
+    scorer = EntropyScorer(
+        bundle.arch_spec._inner,
+        {qid: loc._inner for qid, loc in bundle.traced_target.items()},
+        [loc._inner for loc in bundle.blocked_locations],
+    )
+    controller = EntropyTreeController(
+        reducer=reducer,
+        arch_spec=bundle.arch_spec,
+        target=bundle.traced_target,
+        root_node_id=bundle.root_node_id,
+        best_buffer_size=bundle.best_buffer_size,
+        scorer=scorer,
+        blocked_locations=bundle.blocked_locations,
+        qid_label_map=bundle.local_to_global_qid or None,
+        blocked_location_labels=bundle.location_to_global_qid or None,
+    )
+    controller.attach()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/bloqade/lanes/visualize/entropy_tree/tracer.py
+++ b/python/bloqade/lanes/visualize/entropy_tree/tracer.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from bloqade.lanes.analysis.layout import LayoutHeuristicABC
 from bloqade.lanes.bytecode._native import EntropyTrace, EntropyTraceStep
 from bloqade.lanes.bytecode.encoding import (
     Direction,
@@ -13,6 +15,8 @@ from bloqade.lanes.bytecode.encoding import (
     LocationAddress,
     MoveType,
 )
+
+CustomLayout = Mapping[int, LocationAddress] | Sequence[LocationAddress]
 
 
 @dataclass(frozen=True)
@@ -53,6 +57,58 @@ class EntropyTraceBundle:
     location_to_global_qid: dict[LocationAddress, int]
     kernel_name: str
     executed_cz_count: int
+
+
+@dataclass
+class _FixedCustomLayoutHeuristic(LayoutHeuristicABC):
+    """Inject a full custom layout through the existing pinned-layout path."""
+
+    base_heuristic: LayoutHeuristicABC
+    custom_layout: CustomLayout
+
+    def compute_layout(
+        self,
+        all_qubits: tuple[int, ...],
+        stages: list[tuple[tuple[int, int], ...]],
+        pinned: dict[int, LocationAddress] | None = None,
+    ) -> tuple[LocationAddress, ...]:
+        _ = stages
+        if pinned:
+            raise ValueError(
+                "custom_layout describes the full initial layout; pinned "
+                "addresses in the IR are not supported at the same time"
+            )
+
+        qids = tuple(sorted(all_qubits))
+        if isinstance(self.custom_layout, Mapping):
+            actual = set(self.custom_layout)
+            expected = set(qids)
+            if actual != expected:
+                missing = sorted(expected - actual)
+                extra = sorted(actual - expected)
+                raise ValueError(
+                    "custom_layout mapping must contain exactly the circuit "
+                    f"qubit IDs; missing={missing}, extra={extra}"
+                )
+            layout = tuple(self.custom_layout[qid] for qid in qids)
+        else:
+            layout = tuple(self.custom_layout)
+            if len(layout) != len(qids):
+                raise ValueError(
+                    "custom_layout sequence length must match the number of "
+                    f"circuit qubits ({len(qids)}), got {len(layout)}"
+                )
+
+        bad_types = [addr for addr in layout if not isinstance(addr, LocationAddress)]
+        if bad_types:
+            raise TypeError("custom_layout values must be LocationAddress instances")
+
+        full_pinned_layout = dict(zip(qids, layout, strict=True))
+        return self.base_heuristic.compute_layout(
+            all_qubits,
+            stages,
+            pinned=full_pinned_layout,
+        )
 
 
 def _decode_lane(lane: tuple[int, int, int, int, int, int]) -> LaneAddress:
@@ -130,12 +186,14 @@ def build_entropy_trace(
     layer_index: int = 0,
     max_expansions: int | None = 1000,
     max_goal_candidates: int | None = None,
+    custom_layout: CustomLayout | None = None,
 ) -> EntropyTraceBundle:
     """Run the compilation pipeline and capture an entropy trace for ``layer_index``.
 
     Drives the full squin->move pipeline with a ``RustPlacementTraversal``
     configured to collect an entropy trace. Returns all the state the
-    visualizer needs to render the trace.
+    visualizer needs to render the trace. When ``custom_layout`` is provided,
+    it must describe the full initial layout for every circuit qubit.
     """
     from bloqade.analysis import address
     from bloqade.analysis.address.lattice import AddressQubit
@@ -151,8 +209,16 @@ def build_entropy_trace(
     from bloqade.lanes.upstream import NativeToPlace, squin_to_move
 
     arch_spec = get_arch_spec()
-    layout_heuristic = PhysicalLayoutHeuristicGraphPartitionCenterOut(
+    default_layout_heuristic = PhysicalLayoutHeuristicGraphPartitionCenterOut(
         arch_spec=arch_spec
+    )
+    layout_heuristic: LayoutHeuristicABC = (
+        default_layout_heuristic
+        if custom_layout is None
+        else _FixedCustomLayoutHeuristic(
+            base_heuristic=default_layout_heuristic,
+            custom_layout=custom_layout,
+        )
     )
 
     goal_candidates = (


### PR DESCRIPTION
## Summary
- Add a programmatic `custom_layout` argument to `build_entropy_trace` for seeding entropy-search visualization from an explicit full initial atom layout.
- Reuse the existing physical layout heuristic's pinned-layout validation by converting the custom layout into a full pinned map.

## Test plan
- pre-commit hooks run during commit: end-of-file, whitespace, isort, black, ruff, pyright


Made with [Cursor](https://cursor.com)