### PR TITLE
ci: reset git index between backport loop iterations

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -112,6 +112,12 @@ jobs:
             let skipped = [];
 
             for (const version of versions) {
+              // Ensure a clean index before each attempt in case a previous iteration
+              // left the tree dirty (e.g. cherry-pick --abort silently failed)
+              execSync('git cherry-pick --abort 2>/dev/null || true');
+              execSync('git reset --hard HEAD 2>/dev/null || true');
+              execSync('git clean -fd 2>/dev/null || true');
+
               const branch = `release-${version.replace('.', '-')}`;
               const backportBranch = `${branch}-backport-pr${prNum}`;
               try {
@@ -129,12 +135,14 @@ jobs:
                     // Empty cherry-pick: commit is already on the release branch
                     core.info(`Commit ${commit} is already present on ${branch}. Skipping.`);
                     execSync('git cherry-pick --abort || true');
+                    execSync('git reset --hard HEAD || true');
                     skipped.push({ version, branch, reason: 'already present on release branch' });
                     continue;
                   }
                   // Real conflict: abort and report
                   const conflictFiles = execSync('git diff --name-only --diff-filter=U', { encoding: 'utf8' }).trim();
                   execSync('git cherry-pick --abort || true');
+                  execSync('git reset --hard HEAD || true');
                   const reason = `cherry-pick conflict in: ${conflictFiles || 'unknown files'}`;
                   core.warning(`${branch}: ${reason}`);
                   errors.push({ version, branch, reason });
@@ -165,6 +173,8 @@ jobs:
                 successes.push({ version, branch, backportPrNum: pr.data.number });
 
               } catch (e) {
+                execSync('git cherry-pick --abort 2>/dev/null || true');
+                execSync('git reset --hard HEAD 2>/dev/null || true');
                 core.warning(`${branch}: ${e.message}`);
                 errors.push({ version, branch, reason: e.message });
                 continue;


### PR DESCRIPTION
## Summary

Fixes a bug where a failed backport attempt poisons subsequent attempts in the same workflow run.

**Root cause:** When `git cherry-pick --no-commit` hits conflicts, it stages the conflicting files and sets `CHERRY_PICK_HEAD`. The cleanup calls `git cherry-pick --abort || true` — but if `--abort` fails for any reason, the `|| true` silently swallows it, leaving the index dirty. The next iteration then tries `git checkout -B <next-branch> origin/<next-branch>` and git refuses with:

```
error: you need to resolve your current index first
```

This caused the `release-0-10` backport to fail in [run 26575605228](https://github.com/QuEraComputing/bloqade-lanes/actions/runs/26575605228/job/78293954446) purely because `release-0-7` conflicted before it.

**Fix (4 spots):**
- Add `cherry-pick --abort`, `reset --hard HEAD`, and `clean -fd` at the **top of each loop iteration** — the primary defense, ensures every version starts from a clean tree regardless of what happened before
- Add `git reset --hard HEAD` after each `cherry-pick --abort` in the two inner error paths (empty cherry-pick and real conflict)
- Add `cherry-pick --abort` + `reset --hard HEAD` in the outer `catch` block so unexpected failures (e.g. a push error mid-loop) also clean up

## Test plan

- [ ] Merge a PR that has `backport vX.Y` labels for multiple release branches where at least one is expected to conflict — verify the conflict is reported but the remaining branches still attempt successfully
- [ ] Merge a PR with a single `backport vX.Y` label that applies cleanly — verify backport PR is created as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)