### PR TITLE
feat(logical): add simulation flag to toggle LogicalInitialize rewrite

### DIFF
--- a/python/bloqade/lanes/pipeline/logical.py
+++ b/python/bloqade/lanes/pipeline/logical.py
@@ -134,10 +134,10 @@ class LogicalPipeline:
         ).emit(out, no_raise=no_raise)
 
         if self.transversal_rewrite:
-            # If running this compilation for simulation pruposes we 
+            # If running this compilation for simulation pruposes we
             # need to rewrite the logical initialize statement
             TransversalRewritePass(
-                mt.dialects, 
+                mt.dialects,
                 transversal_location_map=steane7_transversal_map,
                 rewrite_logical_initialize=self.simulation,
             )(out)

--- a/python/bloqade/lanes/pipeline/logical.py
+++ b/python/bloqade/lanes/pipeline/logical.py
@@ -31,23 +31,6 @@ from bloqade.lanes.rewrite import circuit2place
 from .base import _NativeToPlaceBase, _PlaceToMove
 
 
-def transversal_rewrites(mt: Method) -> Method:
-    """Apply transversal rewrite rules to a squin method.
-
-    Expands logical operations into their transversal (physical qubit) equivalents
-    using the Steane [[7,1,3]] transversal map. The method is rewritten in place.
-
-    Args:
-        mt (Method): The squin method to rewrite.
-
-    Returns:
-        Method: The rewritten method (same object, mutated in place).
-
-    """
-
-    return mt
-
-
 @dataclass
 class _LogicalNativeToPlace(_NativeToPlaceBase):
     transversal_rewrite: bool = False

--- a/python/bloqade/lanes/pipeline/logical.py
+++ b/python/bloqade/lanes/pipeline/logical.py
@@ -31,6 +31,29 @@ from bloqade.lanes.rewrite import circuit2place
 from .base import _NativeToPlaceBase, _PlaceToMove
 
 
+def transversal_rewrites(mt: Method, rewrite_logical_initialize: bool = True) -> Method:
+    """Apply transversal rewrite rules to a squin method.
+
+    Expands logical operations into their transversal (physical qubit) equivalents
+    using the Steane [[7,1,3]] transversal map. The method is rewritten in place.
+
+    Args:
+        mt (Method): The squin method to rewrite.
+        rewrite_logical_initialize (bool): Whether to rewrite the logical initialize statements.
+
+    Returns:
+        Method: The rewritten method (same object, mutated in place).
+
+    """
+    TransversalRewritePass(
+        mt.dialects,
+        transversal_location_map=steane7_transversal_map,
+        rewrite_logical_initialize=rewrite_logical_initialize,
+    )(mt)
+
+    return mt
+
+
 @dataclass
 class _LogicalNativeToPlace(_NativeToPlaceBase):
     transversal_rewrite: bool = False
@@ -119,10 +142,6 @@ class LogicalPipeline:
         if self.transversal_rewrite:
             # If running this compilation for simulation pruposes we
             # need to rewrite the logical initialize statement
-            TransversalRewritePass(
-                mt.dialects,
-                transversal_location_map=steane7_transversal_map,
-                rewrite_logical_initialize=self.simulation,
-            )(out)
+            transversal_rewrites(out, rewrite_logical_initialize=self.simulation)
 
         return out

--- a/python/bloqade/lanes/pipeline/logical.py
+++ b/python/bloqade/lanes/pipeline/logical.py
@@ -112,7 +112,7 @@ class LogicalPipeline:
     placement_strategy: placement.PlacementStrategyABC | None = None
     place_opt_type: type[passes.Pass] = field(default=SequentialPlacePass)
     transversal_rewrite: bool = False
-    simulation: bool = False
+    simulation: bool = True
 
     def emit(self, mt: Method, no_raise: bool = True) -> Method:
         heuristic = (

--- a/python/bloqade/lanes/pipeline/logical.py
+++ b/python/bloqade/lanes/pipeline/logical.py
@@ -45,10 +45,6 @@ def transversal_rewrites(mt: Method) -> Method:
 
     """
 
-    TransversalRewritePass(
-        mt.dialects, transversal_location_map=steane7_transversal_map
-    )(mt)
-
     return mt
 
 
@@ -110,6 +106,7 @@ class LogicalPipeline:
     placement_strategy: placement.PlacementStrategyABC | None = None
     place_opt_type: type[passes.Pass] = field(default=SequentialPlacePass)
     transversal_rewrite: bool = False
+    simulation: bool = False
 
     def emit(self, mt: Method, no_raise: bool = True) -> Method:
         heuristic = (
@@ -137,6 +134,12 @@ class LogicalPipeline:
         ).emit(out, no_raise=no_raise)
 
         if self.transversal_rewrite:
-            out = transversal_rewrites(out)
+            # If running this compilation for simulation pruposes we 
+            # need to rewrite the logical initialize statement
+            TransversalRewritePass(
+                mt.dialects, 
+                transversal_location_map=steane7_transversal_map,
+                rewrite_logical_initialize=self.simulation,
+            )(out)
 
         return out


### PR DESCRIPTION
## Summary
- Add `simulation` flag to `LogicalPipeline` that controls whether `TransversalRewritePass` rewrites `LogicalInitialize` to `PhysicalInitialize`
- Inline the `TransversalRewritePass` invocation in the pipeline so the new `rewrite_logical_initialize` option can be threaded through from the `simulation` flag

## Test plan
- [ ] Verify pipeline with `transversal_rewrite=True, simulation=False` keeps `LogicalInitialize` intact
- [ ] Verify pipeline with `transversal_rewrite=True, simulation=True` rewrites `LogicalInitialize` to `PhysicalInitialize`
- [ ] Verify pipeline with `transversal_rewrite=False` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)