### PR TITLE
feat(python): expose ArchSpec.to_json() via PyO3

### DIFF
--- a/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
@@ -937,6 +937,11 @@ impl PyArchSpec {
         Ok(Self { inner })
     }
 
+    fn to_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.inner)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+    }
+
     #[staticmethod]
     fn from_json_validated(json: &str, py: Python<'_>) -> PyResult<Self> {
         let inner = rs::ArchSpec::from_json_validated(json)

--- a/python/bloqade/lanes/bytecode/_native.pyi
+++ b/python/bloqade/lanes/bytecode/_native.pyi
@@ -652,6 +652,17 @@ class ArchSpec:
         """
         ...
 
+    def to_json(self) -> str:
+        """Serialize this architecture spec to a JSON string.
+
+        Returns:
+            str: JSON representation of the architecture spec.
+
+        Raises:
+            ValueError: If serialization fails.
+        """
+        ...
+
     @staticmethod
     def from_json_validated(json: str) -> ArchSpec:
         """Parse an architecture spec from JSON and validate it.


### PR DESCRIPTION
## Summary

- Adds `to_json() -> str` instance method to the PyO3-backed `ArchSpec` class.
- Delegates to `serde_json::to_string` on the inner Rust type — no new serialization logic needed since `ArchSpec` already derives `Serialize`.
- Updates `_native.pyi` with the corresponding type stub.

Closes #687

## Usage

```python
from bloqade.lanes.bytecode._native import ArchSpec

spec = ArchSpec.from_json(json_str)
json_out = spec.to_json()          # serialize back to string
spec2 = ArchSpec.from_json(json_out)
assert spec == spec2               # round-trip verified
```

## Test plan

- [x] Round-trip smoke test: `ArchSpec.from_json(spec.to_json()) == spec`
- [x] Rust unit tests pass (`cargo test -p bloqade-lanes-bytecode-python`)
- [x] Pre-commit hooks pass (fmt, clippy, pyright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)