### PR TITLE
feat(arch): wire to_json through Python ArchSpec wrapper

### DIFF
--- a/python/bloqade/lanes/arch/spec.py
+++ b/python/bloqade/lanes/arch/spec.py
@@ -259,6 +259,10 @@ class ArchSpec(RustWrapper[_RustArchSpec]):
         )
         return cls(inner)
 
+    def to_json(self) -> str:
+        """Serialize this architecture spec to a JSON string."""
+        return self._inner.to_json()
+
     @property
     def sites_per_word(self) -> int:
         """Get the number of sites per word."""


### PR DESCRIPTION
## Summary

Adds `to_json() -> str` to the Python `ArchSpec` wrapper class (`arch/spec.py`), delegating to the PyO3-backed `_inner.to_json()` added in #688.

```python
from bloqade.lanes.arch.gemini.logical import get_arch_spec

spec = get_arch_spec()
json_str = spec.to_json()                      # serialize
spec2 = type(spec)(spec._inner.from_json(json_str))  # round-trip
```

## Test plan

- [x] `uv run pytest python/tests -m "not slow"` — 1382 passed, 0 failed
- [x] Pre-commit hooks pass (isort, black, ruff, pyright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)