### PR TITLE
feat: add Gemini decoding core package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 ]
 dependencies = [
     "bloqade-circuit[cirq, qasm2, tsim]~=0.14.1",
+    "bloqade-decoders~=0.6.0",
     "bloqade-tsim~=0.1.3",
     "bloqade-core~=0.6.3",
     "deprecated>=1.3.1",

--- a/python/bloqade/gemini/__init__.py
+++ b/python/bloqade/gemini/__init__.py
@@ -1,4 +1,4 @@
-from . import common as common, logical as logical
+from . import common as common, decoding as decoding, logical as logical
 from .device import (
     DetectorResult as DetectorResult,
     GeminiLogicalDevice as GeminiLogicalDevice,

--- a/python/bloqade/gemini/decoding/__init__.py
+++ b/python/bloqade/gemini/decoding/__init__.py
@@ -1,0 +1,35 @@
+from .constants import (
+    DEFAULT_BASIS_LABELS as DEFAULT_BASIS_LABELS,
+    DEFAULT_IDEAL_FACTORY_ACCEPTANCE as DEFAULT_IDEAL_FACTORY_ACCEPTANCE,
+    DEFAULT_TARGET_BLOCH as DEFAULT_TARGET_BLOCH,
+)
+from .layout import (
+    DEFAULT_SYNDROME_LAYOUT as DEFAULT_SYNDROME_LAYOUT,
+    SyndromeLayout as SyndromeLayout,
+    split_factory_bits as split_factory_bits,
+)
+from .measurement_maps import build_measurement_maps as build_measurement_maps
+from .types import (
+    DetectorErrorModelTask as DetectorErrorModelTask,
+    KirinKernel as KirinKernel,
+    MeasurementMap as MeasurementMap,
+    SquinKernel as SquinKernel,
+    TableDecoderClass as TableDecoderClass,
+    TsimCircuit as TsimCircuit,
+)
+
+__all__ = [
+    "DEFAULT_BASIS_LABELS",
+    "DEFAULT_IDEAL_FACTORY_ACCEPTANCE",
+    "DEFAULT_SYNDROME_LAYOUT",
+    "DEFAULT_TARGET_BLOCH",
+    "DetectorErrorModelTask",
+    "KirinKernel",
+    "MeasurementMap",
+    "SquinKernel",
+    "SyndromeLayout",
+    "TableDecoderClass",
+    "TsimCircuit",
+    "build_measurement_maps",
+    "split_factory_bits",
+]

--- a/python/bloqade/gemini/decoding/constants.py
+++ b/python/bloqade/gemini/decoding/constants.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from bloqade.analysis.tomography import DEFAULT_TARGET_BLOCH
+
+DEFAULT_BASIS_LABELS = ("X", "Y", "Z")
+DEFAULT_IDEAL_FACTORY_ACCEPTANCE = 1.0 / 6.0
+
+__all__ = [
+    "DEFAULT_BASIS_LABELS",
+    "DEFAULT_IDEAL_FACTORY_ACCEPTANCE",
+    "DEFAULT_TARGET_BLOCH",
+]

--- a/python/bloqade/gemini/decoding/layout.py
+++ b/python/bloqade/gemini/decoding/layout.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class SyndromeLayout:
+    """Column layout describing output versus factory syndrome bits.
+
+    Attributes:
+        output_detector_count: Number of leading detector columns that belong
+            to the output logical qubit.
+        output_observable_count: Number of leading observable columns that
+            belong to the output logical qubit.
+    """
+
+    output_detector_count: int = 3
+    output_observable_count: int = 1
+
+
+DEFAULT_SYNDROME_LAYOUT = SyndromeLayout()
+
+
+def split_factory_bits(
+    detectors: np.ndarray,
+    observables: np.ndarray,
+    *,
+    layout: SyndromeLayout = DEFAULT_SYNDROME_LAYOUT,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return factory detector and observable bits after output columns.
+
+    Args:
+        detectors: Detector sample matrix.
+        observables: Observable sample matrix.
+        layout: Syndrome layout specifying how many leading columns are output
+            bits.
+
+    Returns:
+        A pair ``(factory_detectors, factory_observables)``.
+    """
+
+    return (
+        detectors[:, layout.output_detector_count :],
+        observables[:, layout.output_observable_count :],
+    )
+
+
+# This is used for us to help us, via simulation, get the noiseless expected
+# observable from the circuit.
+def _normalize_valid_factory_targets(
+    valid_factory_targets: np.ndarray | Sequence[Sequence[int]] | Sequence[int],
+) -> np.ndarray:
+    """Normalize one or more valid factory targets into a unique 2D array."""
+
+    targets = np.asarray(valid_factory_targets, dtype=np.uint8)
+    if targets.ndim == 1:
+        targets = targets.reshape(1, -1)
+    if targets.ndim != 2:
+        raise ValueError(
+            "valid_factory_targets must be a 1D factory syndrome or a 2D array "
+            "of valid factory syndromes."
+        )
+    if targets.shape[0] == 0 or targets.shape[1] == 0:
+        raise ValueError("Need at least one non-empty valid factory syndrome.")
+    return np.unique(targets, axis=0)
+
+
+def _ancilla_matches_valid_targets(
+    ancilla_observables: np.ndarray,
+    valid_factory_targets: np.ndarray | Sequence[Sequence[int]] | Sequence[int],
+) -> np.ndarray | bool:
+    """Test whether ancilla observable rows match any valid target pattern."""
+
+    targets = _normalize_valid_factory_targets(valid_factory_targets)
+    ancilla_observables = np.asarray(ancilla_observables, dtype=np.uint8)
+    if ancilla_observables.ndim == 1:
+        if ancilla_observables.shape[0] != targets.shape[1]:
+            raise ValueError(
+                "Ancilla syndrome length does not match valid factory target length."
+            )
+        return bool(np.any(np.all(targets == ancilla_observables, axis=1)))
+    if ancilla_observables.ndim == 2:
+        if ancilla_observables.shape[1] != targets.shape[1]:
+            raise ValueError(
+                "Ancilla syndrome width does not match valid factory target length."
+            )
+        return np.any(
+            np.all(
+                ancilla_observables[:, None, :] == targets[None, :, :],
+                axis=2,
+            ),
+            axis=1,
+        )
+    raise ValueError("Ancilla observables must be a 1D shot or 2D batch array.")

--- a/python/bloqade/gemini/decoding/measurement_maps.py
+++ b/python/bloqade/gemini/decoding/measurement_maps.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from .types import MeasurementMap
+
+
+def build_measurement_maps(
+    num_logical_qubits: int,
+) -> tuple[MeasurementMap, MeasurementMap]:
+    """Return Steane-7 measurement maps for a logical-qubit register.
+
+    Args:
+        num_logical_qubits: Number of logical Steane blocks in the task.
+
+    Returns:
+        A ``(m2dets, m2obs)`` pair suitable for Gemini logical task
+        construction.
+    """
+
+    from bloqade.lanes.steane_defaults import steane7_m2dets, steane7_m2obs
+
+    return steane7_m2dets(num_logical_qubits), steane7_m2obs(num_logical_qubits)

--- a/python/bloqade/gemini/decoding/types.py
+++ b/python/bloqade/gemini/decoding/types.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any, Protocol, TypeAlias
+
+import stim
+import tsim as tsim_backend
+from bloqade.decoders import SparseTableDecoder, TableDecoder
+from kirin import ir
+
+KirinKernel: TypeAlias = ir.Method[..., Any]
+SquinKernel: TypeAlias = KirinKernel
+TsimCircuit: TypeAlias = tsim_backend.Circuit
+MeasurementMap: TypeAlias = list[list[int]]
+TableDecoderClass: TypeAlias = type[TableDecoder] | type[SparseTableDecoder]
+
+
+class DetectorErrorModelTask(Protocol):
+    @property
+    def detector_error_model(self) -> stim.DetectorErrorModel: ...


### PR DESCRIPTION
## Dependencies

Same-repo stack:
- Code/API dependencies: none within `bloqade-lanes`; base is `jasonh/stdlib_firstit`.
- Merge order: first lanes PR in the stack.
- This PR is base for: #698.

Cross-repo dependencies:
- Direct code/API dependencies:
  - QuEraComputing/bloqade-decoders#36 for `bloqade.decoders.SparseTableDecoder`, imported by `bloqade.gemini.decoding.types.TableDecoderClass`.
  - QuEraComputing/bloqade-circuit#783 for `bloqade.analysis.tomography.DEFAULT_TARGET_BLOCH`, imported by `bloqade.gemini.decoding.constants`.
- Required for CI: yes, this PR imports the new decoder/tomography public APIs and declares `bloqade-decoders`.

Review status:
- Draft until dependencies are merged/released: yes.

## Summary

- Adds the `bloqade.gemini.decoding` package shell.
- Adds constants, shared types, layout helpers, and measurement-map helpers.
- Adds lazy public facades and declares `bloqade-decoders~=0.6.0`.

## Review focus

- Public module layout and dependency boundary.
- Lazy imports in package facades.

## Review Notes
- There is a monstrous amount of exports in the [__init__.py file](https://github.com/QuEraComputing/bloqade-lanes/pull/697/changes#diff-7074f2a014c04fa6289c872d10d37b97886efec016c7011227e272dc4ded8cdb) so that future PR's don't have to update this file (we use a dictionary of strings to support lazy imports... but this might not be the best design)
- `DetectorErrorModelTask` is used in `build_mle_decoders` to specify a task that just exposes a DEM to construct MLE decoders.

## Test plan

- Final lanes stack: `uv run --index-strategy=unsafe-best-match pytest python/tests/gemini/test_decoding_imports.py python/tests/demo/test_msd_utils.py -q` -> `41 passed in 18.46s`.
- Final lanes stack: targeted ruff command -> passed.
- Final lanes stack: `uv run --index-strategy=unsafe-best-match pyright python/bloqade/gemini/decoding` -> `0 errors, 0 warnings`.
