### PR TITLE
feat: add Gemini decoding task sampling

### DIFF
--- a/python/bloqade/gemini/decoding/__init__.py
+++ b/python/bloqade/gemini/decoding/__init__.py
@@ -9,6 +9,17 @@ from .layout import (
     split_factory_bits as split_factory_bits,
 )
 from .measurement_maps import build_measurement_maps as build_measurement_maps
+from .sampling import (
+    BasisDataset as BasisDataset,
+    DetectorObservableResult as DetectorObservableResult,
+    SimulatorTask as SimulatorTask,
+    run_task as run_task,
+)
+from .tasks import (
+    DemoTask as DemoTask,
+    GeminiDecoderTask as GeminiDecoderTask,
+    ObservableFrame as ObservableFrame,
+)
 from .types import (
     DetectorErrorModelTask as DetectorErrorModelTask,
     KirinKernel as KirinKernel,
@@ -19,17 +30,24 @@ from .types import (
 )
 
 __all__ = [
+    "BasisDataset",
     "DEFAULT_BASIS_LABELS",
     "DEFAULT_IDEAL_FACTORY_ACCEPTANCE",
     "DEFAULT_SYNDROME_LAYOUT",
     "DEFAULT_TARGET_BLOCH",
+    "DemoTask",
     "DetectorErrorModelTask",
+    "DetectorObservableResult",
+    "GeminiDecoderTask",
     "KirinKernel",
     "MeasurementMap",
+    "ObservableFrame",
+    "SimulatorTask",
     "SquinKernel",
     "SyndromeLayout",
     "TableDecoderClass",
     "TsimCircuit",
     "build_measurement_maps",
+    "run_task",
     "split_factory_bits",
 ]

--- a/python/bloqade/gemini/decoding/sampling.py
+++ b/python/bloqade/gemini/decoding/sampling.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Literal, Protocol, overload
+
+import numpy as np
+
+from .tasks import DemoTask, ObservableFrame
+
+
+@dataclass(frozen=True)
+class BasisDataset:
+    """Detector and observable samples for one tomography basis.
+
+    Attributes:
+        detectors: Detector samples with shape ``(shots, num_detectors)``.
+        observables: Observable samples with shape ``(shots, num_observables)``.
+    """
+
+    detectors: np.ndarray
+    observables: np.ndarray
+
+
+class DetectorObservableResult(Protocol):
+    @property
+    def detectors(self) -> object: ...
+
+    @property
+    def observables(self) -> object: ...
+
+
+class SimulatorTask(Protocol):
+    @overload
+    def run(
+        self,
+        shots: int,
+        with_noise: bool = True,
+        *,
+        run_detectors: Literal[False] = ...,
+    ) -> object: ...
+
+    @overload
+    def run(
+        self,
+        shots: int,
+        with_noise: bool = True,
+        *,
+        run_detectors: Literal[True],
+    ) -> DetectorObservableResult: ...
+
+    @overload
+    def run(
+        self,
+        shots: int,
+        with_noise: bool = True,
+        *,
+        run_detectors: bool,
+    ) -> object | DetectorObservableResult: ...
+
+
+# TODO: This is a wrapper to support both GeminiLogicalSimulatorTask and DemoTask.
+# Ideally, we can substitute this with something that better allows the user to
+# swap either using tsim or clifft as simulator backends.
+def _run_simulator_task(
+    task: SimulatorTask,
+    shots: int,
+    *,
+    with_noise: bool,
+    run_detectors: bool,
+    sim_type: str,
+) -> DetectorObservableResult:
+    """Run a simulator task through the selected backend."""
+
+    if not run_detectors:
+        raise ValueError("_run_simulator_task is only used for detector sampling.")
+    if isinstance(task, DemoTask):
+        return task.run(
+            shots,
+            with_noise=with_noise,
+            run_detectors=run_detectors,
+            sim_type=sim_type,
+        )
+    if sim_type != "tsim":
+        raise ValueError(
+            f"sim_type is {sim_type}; currently, the only supported simulator "
+            "backends are 'tsim' and 'clifft'"
+        )
+    return task.run(shots, with_noise=with_noise, run_detectors=run_detectors)
+
+
+# TODO: has separate clifft explicit check to avoid converting from
+# np.array -> list -> np.array. I think the problem is that DetectorResult
+# contains lists, so we have to do conversions to numpy arrays. So that's why
+# we are currently calling a clifft method that returns np.array's directly.
+# To change this, we'd need to change the task.run() interface/the DetectorResult
+# return type.
+def _sample_task_raw(
+    task: SimulatorTask,
+    shots: int,
+    *,
+    with_noise: bool = True,
+    chunk_size: int | None = None,
+    sim_type: str = "tsim",
+) -> BasisDataset:
+    """Sample detector and observable arrays without observable-frame rebasing."""
+
+    if isinstance(task, DemoTask) and sim_type == "clifft":
+        if chunk_size is None or shots <= chunk_size:
+            detectors, observables = task.sample_clifft_det_obs(
+                shots,
+                with_noise=with_noise,
+            )
+            return BasisDataset(detectors=detectors, observables=observables)
+
+        det_chunks = []
+        obs_chunks = []
+        remaining = shots
+        while remaining > 0:
+            batch = min(chunk_size, remaining)
+            detectors, observables = task.sample_clifft_det_obs(
+                batch,
+                with_noise=with_noise,
+            )
+            det_chunks.append(detectors)
+            obs_chunks.append(observables)
+            remaining -= batch
+
+        return BasisDataset(
+            detectors=np.concatenate(det_chunks, axis=0),
+            observables=np.concatenate(obs_chunks, axis=0),
+        )
+
+    if chunk_size is None or shots <= chunk_size:
+        result = _run_simulator_task(
+            task,
+            shots,
+            with_noise=with_noise,
+            run_detectors=True,
+            sim_type=sim_type,
+        )
+        return BasisDataset(
+            detectors=np.asarray(result.detectors, dtype=np.uint8),
+            observables=np.asarray(result.observables, dtype=np.uint8),
+        )
+
+    det_chunks = []
+    obs_chunks = []
+    remaining = shots
+    while remaining > 0:
+        batch = min(chunk_size, remaining)
+        result = _run_simulator_task(
+            task,
+            batch,
+            with_noise=with_noise,
+            run_detectors=True,
+            sim_type=sim_type,
+        )
+        det_chunks.append(np.asarray(result.detectors, dtype=np.uint8))
+        obs_chunks.append(np.asarray(result.observables, dtype=np.uint8))
+        remaining -= batch
+
+    return BasisDataset(
+        detectors=np.concatenate(det_chunks, axis=0),
+        observables=np.concatenate(obs_chunks, axis=0),
+    )
+
+
+def _compute_observable_reference(
+    task: DemoTask,
+    *,
+    shots: int = 64,
+    sim_type: str = "tsim",
+) -> np.ndarray:
+    """Compute the deterministic noiseless observable reference for a task."""
+
+    if task.observable_reference is not None:
+        return np.asarray(task.observable_reference, dtype=np.uint8)
+
+    reference_result = _run_simulator_task(
+        task,
+        shots,
+        with_noise=False,
+        run_detectors=True,
+        sim_type=sim_type,
+    )
+    reference_obs = np.asarray(reference_result.observables, dtype=np.uint8)
+    unique_rows = np.unique(reference_obs, axis=0)
+    if len(unique_rows) != 1:
+        raise RuntimeError(
+            "Expected a deterministic noiseless observable reference row for this task."
+        )
+    task.observable_reference = unique_rows[0].copy()
+    return np.asarray(task.observable_reference, dtype=np.uint8)
+
+
+def _rebase_dataset_observables(
+    dataset: BasisDataset,
+    reference: np.ndarray,
+) -> BasisDataset:
+    """XOR dataset observables by a reference observable row."""
+
+    return BasisDataset(
+        detectors=dataset.detectors,
+        observables=dataset.observables ^ reference.reshape(1, -1),
+    )
+
+
+def _normalize_observable_frame(
+    task: SimulatorTask,
+    dataset: BasisDataset,
+    *,
+    sim_type: str = "tsim",
+) -> BasisDataset:
+    """Apply task-specific observable-frame normalization to sampled data."""
+
+    if not isinstance(task, DemoTask):
+        return dataset
+    if task.observable_frame != ObservableFrame.NOISELESS_REFERENCE_FLIPS:
+        return dataset
+    reference = _compute_observable_reference(task, sim_type=sim_type)
+    return _rebase_dataset_observables(dataset, reference)
+
+
+def _iter_task_datasets(
+    task: SimulatorTask,
+    shots: int,
+    *,
+    with_noise: bool = True,
+    chunk_size: int | None = None,
+    sim_type: str = "tsim",
+) -> Iterator[BasisDataset]:
+    """Yield sampled datasets in chunks, applying observable-frame normalization."""
+
+    remaining = int(shots)
+    if remaining < 0:
+        raise ValueError("shots must be non-negative.")
+    if remaining == 0:
+        return
+
+    if chunk_size is None:
+        chunk_size = remaining
+
+    while remaining > 0:
+        batch = min(int(chunk_size), remaining)
+        result = _run_simulator_task(
+            task,
+            batch,
+            with_noise=with_noise,
+            run_detectors=True,
+            sim_type=sim_type,
+        )
+        dataset = BasisDataset(
+            detectors=np.asarray(result.detectors, dtype=np.uint8),
+            observables=np.asarray(result.observables, dtype=np.uint8),
+        )
+        yield _normalize_observable_frame(task, dataset, sim_type=sim_type)
+        remaining -= batch
+
+
+def run_task(
+    task: SimulatorTask,
+    shots: int,
+    *,
+    with_noise: bool = True,
+    chunk_size: int | None = None,
+    sim_type: str = "tsim",
+) -> BasisDataset:
+    """Sample a simulator task and return detector/observable arrays.
+    Note that the simulator backend is currently configured through the "sim_type" argument.
+
+    Args:
+        task: Simulator task or ``DemoTask`` to sample.
+        shots: Number of shots to sample.
+        with_noise: Whether to sample the noisy circuit path.
+        chunk_size: Optional maximum shots per simulator call. ``None`` samples
+            all shots in one call.
+        sim_type: Simulator backend, currently ``"tsim"`` or ``"clifft"`` for
+            ``DemoTask`` instances.
+
+    Returns:
+        A ``BasisDataset`` containing detector and observable arrays.
+    """
+
+    return _normalize_observable_frame(
+        task,
+        _sample_task_raw(
+            task,
+            shots,
+            with_noise=with_noise,
+            chunk_size=chunk_size,
+            sim_type=sim_type,
+        ),
+        sim_type=sim_type,
+    )

--- a/python/bloqade/gemini/decoding/tasks.py
+++ b/python/bloqade/gemini/decoding/tasks.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from functools import cached_property
+from typing import TYPE_CHECKING, Generic, Literal, TypeVar, cast, overload
+
+import numpy as np
+import stim
+import tsim as tsim_backend
+
+from bloqade.gemini.device import DetectorResult, GeminiLogicalSimulatorTask, Result
+
+RetType = TypeVar("RetType")
+
+if TYPE_CHECKING:
+    from clifft import Program, SampleResult
+
+
+# TODO: ideally, not sure if we even want this ObservableFrame class.
+class ObservableFrame(str, Enum):
+    """Observable-frame normalization modes for demo tasks."""
+
+    RAW = "raw"
+    NOISELESS_REFERENCE_FLIPS = "noiseless_reference_flips"
+
+
+def _clifft_compatible_stim_text(circuit: tsim_backend.Circuit) -> str:
+    """Return Stim text with instruction tags stripped for CliffT parsing."""
+
+    # CliffT currently rejects Stim instruction tags like I_ERROR[loss](0).
+    # The tags are metadata, so stripping them preserves the sampled semantics.
+    return "\n".join(
+        re.sub(r"^([A-Z][A-Z0-9_]*)(\[[^\]\n]+\])", r"\1", line)
+        for line in str(circuit).splitlines()
+    )
+
+
+@dataclass
+class DemoTask(Generic[RetType]):
+    """Task wrapper adding observable-frame metadata and CliffT sampling.
+
+    Args:
+        task: Underlying Gemini logical simulator task.
+        observable_frame: Observable normalization mode applied by sampling
+            helpers.
+        observable_reference: Optional cached noiseless observable reference
+            used for rebasing special tasks.
+        metadata: Implementation metadata used by special task construction.
+    """
+
+    task: GeminiLogicalSimulatorTask[RetType]
+    observable_frame: ObservableFrame = ObservableFrame.RAW
+    observable_reference: np.ndarray | None = None
+    # TODO: this is SOLELY to pass down the "special" logical kernel for the "prefix_prepare" path.
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.task, name)
+
+    @property
+    def detector_error_model(self) -> stim.DetectorErrorModel:
+        return self.task.detector_error_model
+
+    @cached_property
+    def clifft_tsim_program(self) -> Program:
+        import clifft
+
+        return clifft.compile(_clifft_compatible_stim_text(self.task.tsim_circuit))
+
+    @cached_property
+    def clifft_noiseless_tsim_program(self) -> Program:
+        import clifft
+
+        return clifft.compile(
+            _clifft_compatible_stim_text(self.task.noiseless_tsim_circuit)
+        )
+
+    @overload
+    def _run_clifft(
+        self,
+        shots: int = 1,
+        with_noise: bool = True,
+        *,
+        run_detectors: Literal[False] = ...,
+        seed: int | None = None,
+    ) -> Result[RetType]: ...
+
+    @overload
+    def _run_clifft(
+        self,
+        shots: int = 1,
+        with_noise: bool = True,
+        *,
+        run_detectors: Literal[True],
+        seed: int | None = None,
+    ) -> DetectorResult: ...
+
+    @overload
+    def _run_clifft(
+        self,
+        shots: int = 1,
+        with_noise: bool = True,
+        *,
+        run_detectors: bool = False,
+        seed: int | None = None,
+    ) -> Result[RetType] | DetectorResult: ...
+
+    # TODO: check if _run_clifft() is ever called with run()... because I think we might be calling sample_clifft_det_obs always?
+    def _run_clifft(
+        self,
+        shots: int = 1,
+        with_noise: bool = True,
+        *,
+        run_detectors: bool = False,
+        seed: int | None = None,
+    ) -> Result[RetType] | DetectorResult:
+        sample_result = self._sample_clifft(shots, with_noise=with_noise, seed=seed)
+
+        fidelity_min, fidelity_max = self.task.fidelity_bounds()
+        if run_detectors:
+            return DetectorResult(
+                _detector_error_model=self.task.detector_error_model,
+                _fidelity_min=fidelity_min,
+                _fidelity_max=fidelity_max,
+                _detectors=np.asarray(sample_result.detectors, dtype=bool).tolist(),
+                _observables=np.asarray(sample_result.observables, dtype=bool).tolist(),
+            )
+
+        return Result(
+            np.asarray(sample_result.measurements, dtype=bool).tolist(),
+            self.task.detector_error_model,
+            self.task._post_processing,
+            fidelity_min,
+            fidelity_max,
+        )
+
+    # TODO: not sure if I like this overload logic, but it mirrors GeminiLogicalSimulatorTask; do we need it/can we get rid of it?
+    @overload
+    def run(
+        self,
+        shots: int = 1,
+        with_noise: bool = True,
+        *,
+        run_detectors: Literal[False] = ...,
+        sim_type: str = "tsim",
+        seed: int | None = None,
+    ) -> Result[RetType]: ...
+
+    @overload
+    def run(
+        self,
+        shots: int = 1,
+        with_noise: bool = True,
+        *,
+        run_detectors: Literal[True],
+        sim_type: str = "tsim",
+        seed: int | None = None,
+    ) -> DetectorResult: ...
+
+    @overload
+    def run(
+        self,
+        shots: int = 1,
+        with_noise: bool = True,
+        *,
+        run_detectors: bool = False,
+        sim_type: str = "tsim",
+        seed: int | None = None,
+    ) -> Result[RetType] | DetectorResult: ...
+
+    def run(
+        self,
+        shots: int = 1,
+        with_noise: bool = True,
+        *,
+        run_detectors: bool = False,
+        sim_type: str = "tsim",
+        seed: int | None = None,
+    ) -> Result[RetType] | DetectorResult:
+        if sim_type == "tsim":
+            return self.task.run(
+                shots,
+                with_noise=with_noise,
+                run_detectors=run_detectors,
+            )
+        if sim_type != "clifft":
+            raise ValueError(
+                f"sim_type is {sim_type}; currently, the only supported simulator "
+                "backends are 'tsim' and 'clifft'"
+            )
+        return self._run_clifft(
+            shots,
+            with_noise,
+            run_detectors=run_detectors,
+            seed=seed,
+        )
+
+    def _sample_clifft(
+        self,
+        shots: int,
+        *,
+        with_noise: bool = True,
+        seed: int | None = None,
+    ) -> SampleResult:
+        import clifft
+
+        program = (
+            self.clifft_tsim_program
+            if with_noise
+            else self.clifft_noiseless_tsim_program
+        )
+        sample_kwargs: dict[str, int] = {"shots": int(shots)}
+        if seed is not None:
+            sample_kwargs["seed"] = int(seed)
+        return cast("SampleResult", clifft.sample(program, **sample_kwargs))
+
+    def sample_clifft_det_obs(
+        self,
+        shots: int,
+        *,
+        with_noise: bool = True,
+        seed: int | None = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        sample_result = self._sample_clifft(shots, with_noise=with_noise, seed=seed)
+        return (
+            np.asarray(sample_result.detectors, dtype=np.uint8),
+            np.asarray(sample_result.observables, dtype=np.uint8),
+        )
+
+
+GeminiDecoderTask = DemoTask
+_ObservableFrame = ObservableFrame


### PR DESCRIPTION
## Dependencies

Same-repo stack:
- Code/API dependencies:
  - #697 for the `bloqade.gemini.decoding` package shell and public facade this PR extends.
- Merge order: intended to merge after #697.
- This PR is base for: #699.

Cross-repo dependencies:
- Direct code/API dependencies introduced by this PR: none.
- Inherited from #697:
  - QuEraComputing/bloqade-decoders#36 for `SparseTableDecoder` in the table-decoder type facade.
  - QuEraComputing/bloqade-circuit#783 for `DEFAULT_TARGET_BLOCH`.
- Required for CI: yes, because the stacked branch includes #697's imports/dependency declaration.

Review status:
- Draft until dependencies are merged/released: yes.

## Summary

- Adds `GeminiDecoderTask`, `ObservableFrame`, `BasisDataset`, and chunked `run_task`.
- Adds CliffT/tsim sampling support.

## Review focus

- Observable frame normalization.
- Sampling chunking behavior and optional CliffT paths.

## Test plan

- `uv run --index-strategy=unsafe-best-match pytest python/tests/gemini/test_decoding_imports.py python/tests/demo/test_msd_utils.py -q` -> `41 passed in 18.46s`.
- Targeted ruff command -> passed.
- `uv run --index-strategy=unsafe-best-match pyright python/bloqade/gemini/decoding` -> `0 errors, 0 warnings`.
