### PR TITLE
feat: add Gemini decoding kernel bundles

### DIFF
--- a/python/bloqade/gemini/decoding/__init__.py
+++ b/python/bloqade/gemini/decoding/__init__.py
@@ -3,12 +3,23 @@ from .constants import (
     DEFAULT_IDEAL_FACTORY_ACCEPTANCE as DEFAULT_IDEAL_FACTORY_ACCEPTANCE,
     DEFAULT_TARGET_BLOCH as DEFAULT_TARGET_BLOCH,
 )
+from .kernels import (
+    DecoderPrimitiveSet as DecoderPrimitiveSet,
+    produce_tomography_kernels as produce_tomography_kernels,
+)
 from .layout import (
     DEFAULT_SYNDROME_LAYOUT as DEFAULT_SYNDROME_LAYOUT,
     SyndromeLayout as SyndromeLayout,
     split_factory_bits as split_factory_bits,
 )
 from .measurement_maps import build_measurement_maps as build_measurement_maps
+from .msd import (
+    TomographyKernels as TomographyKernels,
+    build_decoder_kernel_bundle as build_decoder_kernel_bundle,
+    build_injected_decoder_kernel_map as build_injected_decoder_kernel_map,
+    build_injected_kernel_bundle as build_injected_kernel_bundle,
+    build_msd_primitives as build_msd_primitives,
+)
 from .sampling import (
     BasisDataset as BasisDataset,
     DetectorObservableResult as DetectorObservableResult,
@@ -39,6 +50,7 @@ __all__ = [
     "DEFAULT_IDEAL_FACTORY_ACCEPTANCE",
     "DEFAULT_SYNDROME_LAYOUT",
     "DEFAULT_TARGET_BLOCH",
+    "DecoderPrimitiveSet",
     "DemoTask",
     "DetectorErrorModelTask",
     "DetectorObservableResult",
@@ -50,10 +62,16 @@ __all__ = [
     "SquinKernel",
     "SyndromeLayout",
     "TableDecoderClass",
+    "TomographyKernels",
     "TsimCircuit",
     "apply_special_tsim_circuit_strategy",
+    "build_decoder_kernel_bundle",
+    "build_injected_decoder_kernel_map",
+    "build_injected_kernel_bundle",
     "build_measurement_maps",
+    "build_msd_primitives",
     "build_task_map",
+    "produce_tomography_kernels",
     "run_task",
     "split_factory_bits",
 ]

--- a/python/bloqade/gemini/decoding/kernels.py
+++ b/python/bloqade/gemini/decoding/kernels.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from bloqade import qubit, squin
+
+from .types import KirinKernel, SquinKernel
+
+
+# TODO: in principle, these tomography kernels aren't gemini-specific.
+# BUT, right now, the kernels are written in the gemini logical dialect.
+# Can maybe move this code to bloqade-core.
+@dataclass(frozen=True)
+class DecoderPrimitiveSet:
+    """Primitive Squin kernels needed to build MSD decoder tasks.
+
+    Attributes:
+        state_injection_circuit: Squin kernel that prepares the input logical
+            magic states.
+        logical_circuit: Squin kernel for the logical circuit under test.
+    """
+
+    state_injection_circuit: SquinKernel
+    logical_circuit: SquinKernel
+
+    def __getitem__(self, key: str) -> SquinKernel:
+        return getattr(self, key)
+
+
+def _build_tomography_primitives(*, output_qubit: int) -> dict[str, SquinKernel]:
+    """Build X/Y/Z tomography-basis Squin kernels for one output qubit."""
+
+    @squin.kernel
+    def tomography_x(reg):
+        squin.h(reg[output_qubit])
+
+    @squin.kernel
+    def tomography_y(reg):
+        squin.sqrt_z_adj(reg[output_qubit])
+        squin.h(reg[output_qubit])
+
+    @squin.kernel
+    def tomography_z(reg):
+        return
+
+    return {
+        "tomography_x": tomography_x,
+        "tomography_y": tomography_y,
+        "tomography_z": tomography_z,
+    }
+
+
+def _squin_return_none(reg):
+    """Return no value from a generated Squin kernel."""
+
+    return
+
+
+def produce_tomography_kernels(
+    num_qubits: int,
+    logical_kernel: KirinKernel,
+    tomography_kernels: Mapping[str, SquinKernel],
+    return_val_fn: KirinKernel | Callable[[Any], Any],
+    kernel_name: str,
+    *,
+    supply_reg: bool = True,
+) -> Mapping[str, KirinKernel]:
+    """Compose logical and tomography kernels into labeled tomography kernels.
+
+    Args:
+        num_qubits: Number of logical qubits to allocate when ``supply_reg`` is
+            true.
+        logical_kernel: Kernel applied before the tomography rotation.
+        tomography_kernels: Mapping from tomography-kernel name to tomography
+            rotation kernel.
+        return_val_fn: Callable applied to the logical register to produce the
+            returned value for allocated Gemini logical kernels.
+        kernel_name: Prefix for generated kernel names.
+        supply_reg: If true, create Gemini logical kernels that allocate their
+            own register. If false, return Squin kernels that accept ``reg``.
+
+    Returns:
+        Mapping from generated kernel names to generated Kirin kernels.
+    """
+
+    def make_kernel(tomog_kernel: SquinKernel, generated_name: str) -> KirinKernel:
+        def inner_tomog_kernel(reg):
+            logical_kernel(reg)
+            tomog_kernel(reg)
+
+        inner_tomog_kernel.__name__ = generated_name
+        inner_tomog_kernel.__qualname__ = generated_name
+        inner_kernel = squin.kernel(inner_tomog_kernel)
+
+        if not supply_reg:
+            return inner_kernel
+
+        def alloc_kernel():
+            reg = qubit.qalloc(num_qubits)
+            inner_kernel(reg)
+            return return_val_fn(reg)
+
+        alloc_kernel.__name__ = generated_name
+        alloc_kernel.__qualname__ = generated_name
+        from bloqade.gemini import logical as gemini_logical
+
+        return gemini_logical.kernel(aggressive_unroll=True)(alloc_kernel)
+
+    return {
+        f"{kernel_name}_{tomog_kernel_key.split('_')[-1]}": make_kernel(
+            tomog_kernel,
+            f"{kernel_name}_{tomog_kernel_key.split('_')[-1]}",
+        )
+        for tomog_kernel_key, tomog_kernel in tomography_kernels.items()
+    }
+
+
+# This is to give us a dictionary of form {"X": ..., "Y": ..., "Z": ...} for
+# downstream consumption.
+def _kernels_by_tomography_basis(
+    kernels: Mapping[str, KirinKernel],
+) -> dict[str, KirinKernel]:
+    """Rekey generated tomography kernels by basis label."""
+
+    return {
+        kernel_name.split("_")[-1].upper(): kernel
+        for kernel_name, kernel in kernels.items()
+    }

--- a/python/bloqade/gemini/decoding/msd.py
+++ b/python/bloqade/gemini/decoding/msd.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Literal
+
+from kirin.dialects import ilist
+
+from bloqade import squin
+
+from .kernels import (
+    DecoderPrimitiveSet,
+    _build_tomography_primitives,
+    _kernels_by_tomography_basis,
+    _squin_return_none,
+    produce_tomography_kernels,
+)
+from .special_tasks import _attach_special_circuit_kernel
+from .types import KirinKernel
+
+
+def _default_post_processing():
+    from bloqade.gemini.logical.stdlib import default_post_processing
+
+    return default_post_processing
+
+
+@dataclass(frozen=True)
+class TomographyKernels:
+    # TODO, mtg: make things specific in the beginning.
+    """Actual tomography kernels plus private decoder-reference kernels.
+
+    Attributes:
+        actual: Basis-labeled kernels for the full noisy/input-prepared logical
+            circuit.
+        _special: Private basis-labeled kernels used internally for
+            special/reference task construction.
+    """
+
+    actual: dict[str, KirinKernel]
+    _special: dict[str, KirinKernel] = field(repr=False)
+
+
+# NOTE: this is basically what the user would "instantiate" for this specific
+# MSD experiment
+def build_msd_primitives(
+    theta: float,
+    phi: float,
+    lam: float,
+    *,
+    log: bool = True,
+) -> DecoderPrimitiveSet:
+    """Build the state-preparation and logical-circuit primitives for MSD.
+
+    Args:
+        theta: U3 ``theta`` angle for input magic-state preparation.
+        phi: U3 ``phi`` angle for input magic-state preparation.
+        lam: U3 ``lambda`` angle for input magic-state preparation.
+        log: If true, print a progress message.
+
+    Returns:
+        Primitive Squin kernels for the MSD state injection and logical circuit.
+    """
+
+    if log:
+        print("Building MSD primitives...")
+
+    @squin.kernel
+    def msd_magic_prep(reg):
+        squin.broadcast.u3(theta, phi, lam, reg)
+
+    @squin.kernel
+    def msd_forward(reg):
+        squin.broadcast.sqrt_x(ilist.IList([reg[0], reg[1], reg[4]]))
+        squin.broadcast.cz(ilist.IList([reg[0], reg[2]]), ilist.IList([reg[1], reg[3]]))
+        squin.broadcast.sqrt_y(ilist.IList([reg[0], reg[3]]))
+        squin.broadcast.cz(ilist.IList([reg[0], reg[3]]), ilist.IList([reg[2], reg[4]]))
+        squin.sqrt_x_adj(reg[0])
+        squin.broadcast.cz(ilist.IList([reg[0], reg[1]]), ilist.IList([reg[4], reg[3]]))
+        squin.broadcast.sqrt_x_adj(reg)
+
+    return DecoderPrimitiveSet(
+        state_injection_circuit=msd_magic_prep,
+        logical_circuit=msd_forward,
+    )
+
+
+def build_decoder_kernel_bundle(
+    primitive_set: DecoderPrimitiveSet,
+    # TODO: get rid of logical qubits argument here?
+    num_logical_qubits: int = 5,
+    output_qubit: int = 0,
+    # TODO: have to pass down special_kernel_strategy here?
+    special_kernel_strategy: Literal[
+        "prefix_prepare", "compiled_inverse_prefix"
+    ] = "prefix_prepare",
+) -> TomographyKernels:
+    """Build tomography kernels for actual and special MSD tasks.
+
+    Args:
+        primitive_set: Primitive state-injection and logical-circuit kernels.
+        num_logical_qubits: Number of logical qubits in the MSD logical circuit.
+        output_qubit: Logical qubit measured as the output state.
+        special_kernel_strategy: Strategy expected for the special task path.
+
+    Returns:
+        A ``TomographyKernels`` containing basis-labeled kernel maps.
+
+    Raises:
+        ValueError: If ``special_kernel_strategy`` is unsupported.
+    """
+
+    if special_kernel_strategy not in {"prefix_prepare", "compiled_inverse_prefix"}:
+        raise ValueError(
+            "special_kernel_strategy must be 'prefix_prepare' or "
+            "'compiled_inverse_prefix'."
+        )
+
+    tomography_primitives = _build_tomography_primitives(output_qubit=output_qubit)
+    state_injection_circuit = primitive_set.state_injection_circuit
+    logical_circuit = primitive_set.logical_circuit
+
+    @squin.kernel
+    def actual_logical_kernel(reg):
+        state_injection_circuit(reg)
+        logical_circuit(reg)
+
+    @squin.kernel
+    def special_logical_kernel(reg):
+        logical_circuit(reg)
+
+    default_post_processing = _default_post_processing()
+    actual_kernels = produce_tomography_kernels(
+        num_logical_qubits,
+        actual_logical_kernel,
+        tomography_primitives,
+        default_post_processing,
+        "msd_actual",
+    )
+    special_task_kernels = produce_tomography_kernels(
+        num_logical_qubits,
+        special_logical_kernel,
+        tomography_primitives,
+        default_post_processing,
+        "msd_special",
+    )
+    special_circuit_sources = _kernels_by_tomography_basis(
+        produce_tomography_kernels(
+            num_logical_qubits,
+            special_logical_kernel,
+            tomography_primitives,
+            _squin_return_none,
+            "msd_special_circuit",
+            supply_reg=False,
+        )
+    )
+
+    actual = _kernels_by_tomography_basis(actual_kernels)
+    if special_kernel_strategy == "prefix_prepare":
+        # TODO: think about a cleaner way to pass down this information? Do I have to pass down this "special_kernel_{x, y, z}"?
+        special = {
+            basis: _attach_special_circuit_kernel(
+                kernel,
+                special_circuit_sources[basis],
+                num_qubits=num_logical_qubits,
+            )
+            for basis, kernel in _kernels_by_tomography_basis(
+                special_task_kernels
+            ).items()
+        }
+    else:
+        special = dict(actual)
+
+    return TomographyKernels(
+        actual=actual,
+        _special=special,
+    )
+
+
+def build_injected_kernel_bundle(
+    theta: float,
+    phi: float,
+    lam: float,
+    *,
+    output_qubit: int = 0,
+) -> TomographyKernels:
+    """Build injected-state evaluation and decoder-reference kernels.
+
+    Args:
+        theta: U3 ``theta`` angle for the injected input state.
+        phi: U3 ``phi`` angle for the injected input state.
+        lam: U3 ``lambda`` angle for the injected input state.
+        output_qubit: Logical qubit measured by the tomography kernels.
+
+    Returns:
+        A bundle whose ``actual`` kernels prepare the requested injected state
+        and whose ``special`` kernels prepare ideal X/Y/Z decoder references.
+    """
+
+    tomography_primitives = _build_tomography_primitives(output_qubit=output_qubit)
+
+    @squin.kernel
+    def injected_logical_kernel(reg):
+        squin.u3(theta, phi, lam, reg[0])
+
+    default_post_processing = _default_post_processing()
+    injected_kernels = produce_tomography_kernels(
+        1,
+        injected_logical_kernel,
+        tomography_primitives,
+        default_post_processing,
+        "injected",
+    )
+
+    return TomographyKernels(
+        actual=_kernels_by_tomography_basis(injected_kernels),
+        _special=build_injected_decoder_kernel_map(output_qubit=output_qubit),
+    )
+
+
+def build_injected_decoder_kernel_map(
+    *,
+    output_qubit: int = 0,
+) -> dict[str, KirinKernel]:
+    """Build ideal injected-state tomography kernels for decoder calibration.
+
+    Args:
+        output_qubit: Logical qubit measured by the tomography kernels.
+
+    Returns:
+        Basis-labeled kernels for ideal X/Y/Z injected reference states.
+    """
+
+    h_theta = 0.5 * math.pi
+    h_phi = 0.0
+    hs_theta = 0.5 * math.pi
+    hs_phi = -0.5 * math.pi
+    lam = 0.0
+    tomography_primitives = _build_tomography_primitives(output_qubit=output_qubit)
+
+    @squin.kernel
+    def injected_decoder_x_logical_kernel(reg):
+        squin.u3(h_theta, h_phi, lam, reg[0])
+
+    @squin.kernel
+    def injected_decoder_y_logical_kernel(reg):
+        squin.u3(hs_theta, hs_phi, lam, reg[0])
+
+    @squin.kernel
+    def injected_decoder_z_logical_kernel(reg):
+        squin.u3(0.0, 0.0, 0.0, reg[0])
+
+    default_post_processing = _default_post_processing()
+    return {
+        **_kernels_by_tomography_basis(
+            produce_tomography_kernels(
+                1,
+                injected_decoder_x_logical_kernel,
+                {"tomography_x": tomography_primitives["tomography_x"]},
+                default_post_processing,
+                "injected_decoder",
+            )
+        ),
+        **_kernels_by_tomography_basis(
+            produce_tomography_kernels(
+                1,
+                injected_decoder_y_logical_kernel,
+                {"tomography_y": tomography_primitives["tomography_y"]},
+                default_post_processing,
+                "injected_decoder",
+            )
+        ),
+        **_kernels_by_tomography_basis(
+            produce_tomography_kernels(
+                1,
+                injected_decoder_z_logical_kernel,
+                {"tomography_z": tomography_primitives["tomography_z"]},
+                default_post_processing,
+                "injected_decoder",
+            )
+        ),
+    }


### PR DESCRIPTION
## Dependencies

Same-repo stack:
- Code/API dependencies:
  - #697 for shared kernel type aliases.
  - #699 for `_attach_special_circuit_kernel` used by the MSD kernel bundle helpers.
- Merge order: intended to merge after #699.
- This PR is base for: #701 by branch stack order only; #701 does not import kernels/MSD helpers from this PR.

Cross-repo dependencies:
- Direct code/API dependencies introduced by this PR: none.
- Inherited from #697:
  - QuEraComputing/bloqade-decoders#36 for `SparseTableDecoder` in the table-decoder type facade.
  - QuEraComputing/bloqade-circuit#783 for `DEFAULT_TARGET_BLOCH`.
- Indirect runtime/CI dependency:
  - QuEraComputing/bloqade-circuit#782 may be needed if tests/runtime compile the generated Gemini logical kernels through existing `bloqade.gemini.logical.group`, which imports `bloqade.squin.rewrite.WrapAddressAnalysis`. This PR's new `kernels.py`/`msd.py` modules do not directly import `WrapAddressAnalysis`.
- Required for CI: yes, because the stacked branch includes #697's imports/dependency declaration; runtime tests that compile generated logical kernels may also need #782.

Review status:
- Draft until dependencies are merged/released: yes.

## Summary

- Adds tomography kernel composition.
- Adds `DecoderPrimitiveSet`, `TomographyKernels`, and MSD/injected primitive bundles.

## Review focus

- Kernel composition naming and ordering.
- MSD-specific code staying isolated in `msd.py`.

## Test plan

- `uv run --index-strategy=unsafe-best-match pytest python/tests/gemini/test_decoding_imports.py python/tests/demo/test_msd_utils.py -q` -> `41 passed in 18.46s`.
- Targeted ruff command -> passed.
- `uv run --index-strategy=unsafe-best-match pyright python/bloqade/gemini/decoding` -> `0 errors, 0 warnings`.
