### PR TITLE
feat: add Gemini MLE and baseline helpers

### DIFF
--- a/python/bloqade/gemini/decoding/__init__.py
+++ b/python/bloqade/gemini/decoding/__init__.py
@@ -1,3 +1,10 @@
+from .baselines import (
+    infer_distilled_sign_vector as infer_distilled_sign_vector,
+    infer_factory_target as infer_factory_target,
+    injected_baseline as injected_baseline,
+    naive_distilled_summary as naive_distilled_summary,
+    naive_injected_summary as naive_injected_summary,
+)
 from .constants import (
     DEFAULT_BASIS_LABELS as DEFAULT_BASIS_LABELS,
     DEFAULT_IDEAL_FACTORY_ACCEPTANCE as DEFAULT_IDEAL_FACTORY_ACCEPTANCE,
@@ -20,6 +27,7 @@ from .mld import (
     train_mld_decoder_pair as train_mld_decoder_pair,
     train_mld_decoder_pair_from_task as train_mld_decoder_pair_from_task,
 )
+from .mle import build_mle_decoders as build_mle_decoders
 from .msd import (
     TomographyKernels as TomographyKernels,
     build_decoder_kernel_bundle as build_decoder_kernel_bundle,
@@ -83,12 +91,18 @@ __all__ = [
     "build_injected_kernel_bundle",
     "build_measurement_maps",
     "build_mld_decoders_from_pair",
+    "build_mle_decoders",
     "build_msd_primitives",
     "build_task_map",
     "estimate_mld_ancilla_scores",
     "estimate_mld_ancilla_scores_from_tasks",
     "evaluate_curve",
     "evaluate_mld_curve",
+    "infer_distilled_sign_vector",
+    "infer_factory_target",
+    "injected_baseline",
+    "naive_distilled_summary",
+    "naive_injected_summary",
     "produce_tomography_kernels",
     "run_task",
     "split_factory_bits",

--- a/python/bloqade/gemini/decoding/baselines.py
+++ b/python/bloqade/gemini/decoding/baselines.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+
+import numpy as np
+from bloqade.analysis.tomography import (
+    DEFAULT_TARGET_BLOCH,
+    FidelitySummary,
+    fidelity_from_counts,
+    logical_expectation,
+)
+from bloqade.decoders.dem import make_layout_only_dem
+
+from .constants import (
+    DEFAULT_BASIS_LABELS,
+    DEFAULT_IDEAL_FACTORY_ACCEPTANCE,
+)
+from .layout import (
+    _ancilla_matches_valid_targets,
+    _normalize_valid_factory_targets,
+    split_factory_bits,
+)
+from .sampling import SimulatorTask, run_task
+from .types import TableDecoderClass
+
+
+# TODO: technically maybe we don't need these cases where we
+# infer the sign vector. Ideally, this should be fixed/taken care of by the user..
+def infer_factory_target(
+    task_map: Mapping[str, SimulatorTask],
+    *,
+    shots: int = 12_000,
+    basis_labels: Sequence[str] = DEFAULT_BASIS_LABELS,
+    ideal_factory_acceptance: float = DEFAULT_IDEAL_FACTORY_ACCEPTANCE,
+) -> np.ndarray:
+    """Infer the noiseless factory target branch from simulated task data.
+
+    Args:
+        task_map: Basis-labeled task map to sample without noise.
+        shots: Number of noiseless shots to sample per basis.
+        basis_labels: Basis labels to evaluate.
+        ideal_factory_acceptance: Expected factory acceptance fraction used to
+            choose among observed branches.
+
+    Returns:
+        Factory target observable pattern as a ``uint8`` array.
+    """
+
+    counts: Counter[tuple[int, ...]] = Counter()
+    for basis in basis_labels:
+        data = run_task(task_map[basis], shots, with_noise=False)
+        for row in data.observables[:, 1:]:
+            counts[tuple(map(int, row))] += 1
+
+    total = sum(counts.values())
+    ranked = sorted(
+        counts.items(),
+        key=lambda item: (abs(item[1] / total - ideal_factory_acceptance), -item[1]),
+    )
+    print("Top noiseless ancilla branches:")
+    for pattern, count in ranked[:8]:
+        print(pattern, count / total)
+    return np.asarray(ranked[0][0], dtype=np.uint8)
+
+
+def infer_distilled_sign_vector(
+    task_map: Mapping[str, SimulatorTask],
+    *,
+    valid_factory_targets: np.ndarray | Sequence[Sequence[int]] | Sequence[int],
+    shots: int = 12_000,
+    basis_labels: Sequence[str] = DEFAULT_BASIS_LABELS,
+    target_bloch: np.ndarray = DEFAULT_TARGET_BLOCH,
+) -> np.ndarray:
+    """Infer the sign convention aligning accepted outputs to a target state.
+
+    Args:
+        task_map: Basis-labeled task map to sample without noise.
+        valid_factory_targets: Valid corrected factory observable patterns.
+        shots: Number of noiseless shots to sample per basis.
+        basis_labels: Basis labels to evaluate.
+        target_bloch: Target Bloch vector used to choose the sign convention.
+
+    Returns:
+        Three-element sign vector for X/Y/Z tomography.
+    """
+
+    targets = _normalize_valid_factory_targets(valid_factory_targets)
+    corrected: dict[str, np.ndarray] = {}
+    for basis in basis_labels:
+        data = run_task(task_map[basis], shots, with_noise=False)
+        mask = _ancilla_matches_valid_targets(data.observables[:, 1:], targets)
+        corrected[basis] = data.observables[mask, 0].astype(np.uint8)
+
+    raw_bloch = np.array(
+        [
+            logical_expectation(corrected["X"]),
+            logical_expectation(corrected["Y"]),
+            logical_expectation(corrected["Z"]),
+        ]
+    )
+
+    sign_candidates = [
+        np.array([sx, sy, sz], dtype=np.float64)
+        for sx in (-1.0, 1.0)
+        for sy in (-1.0, 1.0)
+        for sz in (-1.0, 1.0)
+    ]
+    scored = sorted(
+        (
+            (float(np.dot(raw_bloch * sign, target_bloch)), sign)
+            for sign in sign_candidates
+        ),
+        key=lambda item: item[0],
+        reverse=True,
+    )
+
+    print("Noiseless accepted-branch Bloch:", raw_bloch)
+    print("Chosen distilled sign vector:", scored[0][1], "score:", scored[0][0])
+    return scored[0][1]
+
+
+# NOTE: is NOT used in the decoders notebook, but is used in the reprod notebook
+# (for naive postselection) -- ideally, customize decoders path to take in a
+# decoder that just postselects on 0
+def naive_injected_summary(
+    task_map: Mapping[str, SimulatorTask],
+    *,
+    sign_vector: Sequence[float],
+    binary_precision: int | None = None,
+    shots: int,
+    require_zero_detectors: bool = False,
+    min_accepted_per_basis: int = 50,
+    basis_labels: Sequence[str] = DEFAULT_BASIS_LABELS,
+    target_bloch: np.ndarray = DEFAULT_TARGET_BLOCH,
+    max_grid_points: int = 1_500_000,
+) -> dict[str, object]:
+    """Summarize the injected baseline without a decoder.
+
+    Args:
+        task_map: Basis-labeled injected task map.
+        sign_vector: Per-axis sign convention for fidelity reconstruction.
+        binary_precision: Precision used by Bayesian tomography scoring.
+        shots: Number of shots to sample per basis.
+        require_zero_detectors: Whether to postselect on all detector bits zero.
+        min_accepted_per_basis: Minimum accepted samples required per basis.
+        basis_labels: Basis labels to evaluate.
+        target_bloch: Target Bloch vector for fidelity calculation.
+        max_grid_points: Maximum adaptive grid size for Bayesian tomography.
+
+    Returns:
+        Fidelity summary augmented with accepted-fraction metadata.
+    """
+
+    corrected: dict[str, np.ndarray] = {}
+    accepted_fraction_by_basis: dict[str, float] = {}
+
+    for basis in basis_labels:
+        data = run_task(task_map[basis], shots, with_noise=True)
+        mask = np.ones(len(data.observables), dtype=bool)
+        if require_zero_detectors:
+            mask &= np.all(data.detectors == 0, axis=1)
+
+        corrected[basis] = data.observables[mask, 0].astype(np.uint8)
+        accepted_fraction_by_basis[basis] = float(np.mean(mask))
+
+    if min(len(corrected[basis]) for basis in basis_labels) < min_accepted_per_basis:
+        raise RuntimeError("Too few accepted injected shots.")
+
+    return {
+        **fidelity_from_counts(
+            corrected["X"],
+            corrected["Y"],
+            corrected["Z"],
+            binary_precision,
+            sign_vector=sign_vector,
+            target_bloch=target_bloch,
+            max_grid_points=max_grid_points,
+        ),
+        "accepted_fraction": float(np.mean(list(accepted_fraction_by_basis.values()))),
+        "accepted_fraction_by_basis": accepted_fraction_by_basis,
+    }
+
+
+# NOTE: is NOT used in the decoders notebook, but is used in the reprod notebook
+# (for naive postselection) -- ideally, customize decoders path to take in a
+# decoder that just postselects on 0
+def naive_distilled_summary(
+    task_map: Mapping[str, SimulatorTask],
+    *,
+    valid_factory_targets: np.ndarray | Sequence[Sequence[int]] | Sequence[int],
+    sign_vector: Sequence[float],
+    binary_precision: int | None = None,
+    shots: int,
+    require_zero_ancilla_detectors: bool = False,
+    min_accepted_per_basis: int = 50,
+    basis_labels: Sequence[str] = DEFAULT_BASIS_LABELS,
+    target_bloch: np.ndarray = DEFAULT_TARGET_BLOCH,
+    max_grid_points: int = 1_500_000,
+) -> dict[str, object]:
+    """Summarize distilled-task performance with naive factory postselection.
+
+    Args:
+        task_map: Basis-labeled distilled task map.
+        valid_factory_targets: Valid factory observable patterns.
+        sign_vector: Per-axis sign convention for fidelity reconstruction.
+        binary_precision: Precision used by Bayesian tomography scoring.
+        shots: Number of shots to sample per basis.
+        require_zero_ancilla_detectors: Whether to also require zero factory
+            detector bits.
+        min_accepted_per_basis: Minimum accepted samples required per basis.
+        basis_labels: Basis labels to evaluate.
+        target_bloch: Target Bloch vector for fidelity calculation.
+        max_grid_points: Maximum adaptive grid size for Bayesian tomography.
+
+    Returns:
+        Fidelity summary augmented with accepted-fraction metadata and targets.
+    """
+
+    targets = _normalize_valid_factory_targets(valid_factory_targets)
+    corrected: dict[str, np.ndarray] = {}
+    accepted_fraction_by_basis: dict[str, float] = {}
+    total_kept = 0
+    total_shots = 0
+
+    for basis in basis_labels:
+        data = run_task(task_map[basis], shots, with_noise=True)
+        anc_det, anc_obs = split_factory_bits(data.detectors, data.observables)
+        mask = np.asarray(_ancilla_matches_valid_targets(anc_obs, targets), dtype=bool)
+        if require_zero_ancilla_detectors:
+            mask &= np.all(anc_det == 0, axis=1)
+
+        corrected[basis] = data.observables[mask, 0].astype(np.uint8)
+        accepted_fraction_by_basis[basis] = float(np.mean(mask))
+        total_kept += int(np.sum(mask))
+        total_shots += len(mask)
+
+    if min(len(corrected[basis]) for basis in basis_labels) < min_accepted_per_basis:
+        raise RuntimeError("Too few accepted distilled shots.")
+
+    return {
+        **fidelity_from_counts(
+            corrected["X"],
+            corrected["Y"],
+            corrected["Z"],
+            binary_precision,
+            sign_vector=sign_vector,
+            target_bloch=target_bloch,
+            max_grid_points=max_grid_points,
+        ),
+        "accepted_fraction": total_kept / total_shots,
+        "accepted_fraction_by_basis": accepted_fraction_by_basis,
+        "valid_factory_targets": tuple(
+            tuple(int(x) for x in row.tolist()) for row in targets
+        ),
+    }
+
+
+def injected_baseline(
+    task_map: Mapping[str, SimulatorTask],
+    *,
+    eval_shots: int,
+    binary_precision: int | None = None,
+    table_decoder_cls: TableDecoderClass,
+    sign_vector: Sequence[float],
+    target_bloch: np.ndarray = DEFAULT_TARGET_BLOCH,
+    raw: bool = False,
+    training_task_map: Mapping[str, SimulatorTask] | None = None,
+    basis_labels: Sequence[str] = DEFAULT_BASIS_LABELS,
+    uncertainty_backend: str = "wilson",
+    sim_type: str = "tsim",
+    max_grid_points: int = 1_500_000,
+) -> FidelitySummary:
+    """Estimate injected-state fidelity with an optional table-decoder correction.
+
+    Args:
+        task_map: Basis-labeled injected task map to evaluate.
+        eval_shots: Number of shots to sample per basis.
+        binary_precision: Precision used by Bayesian tomography scoring.
+        table_decoder_cls: Table decoder class used when ``raw`` is false.
+        sign_vector: Per-axis sign convention for fidelity reconstruction.
+        target_bloch: Target Bloch vector for fidelity calculation.
+        raw: If true, skip decoder training and use raw observable bits.
+        training_task_map: Optional separate task map used for decoder training.
+        basis_labels: Basis labels to evaluate.
+        uncertainty_backend: Fidelity uncertainty backend.
+        sim_type: Simulator backend for ``DemoTask`` instances.
+        TODO: be more precise for `max_grid_points`
+        max_grid_points: Maximum adaptive grid size for Bayesian tomography.
+
+    Returns:
+        Fidelity summary for the injected baseline.
+    """
+
+    corrected: dict[str, np.ndarray] = {}
+    for basis in basis_labels:
+        evaluation_dataset = run_task(
+            task_map[basis],
+            eval_shots,
+            with_noise=True,
+            sim_type=sim_type,
+        )
+        if raw:
+            corrected[basis] = evaluation_dataset.observables[:, 0].astype(np.uint8)
+            continue
+
+        training_dataset = evaluation_dataset
+        if training_task_map is not None:
+            training_dataset = run_task(
+                training_task_map[basis],
+                eval_shots,
+                with_noise=True,
+                sim_type=sim_type,
+            )
+
+        decoder = table_decoder_cls.from_det_obs_shots(
+            make_layout_only_dem(
+                training_dataset.detectors.shape[1],
+                training_dataset.observables.shape[1],
+            ),
+            np.concatenate(
+                [training_dataset.detectors, training_dataset.observables], axis=1
+            ).astype(bool),
+        )
+        bits = []
+        for det, obs in zip(
+            evaluation_dataset.detectors,
+            evaluation_dataset.observables,
+            strict=True,
+        ):
+            flip = np.asarray(decoder.decode(det.astype(bool)), dtype=np.uint8)
+            bits.append(int(obs[0] ^ flip[0]))
+        corrected[basis] = np.asarray(bits, dtype=np.uint8)
+
+    return fidelity_from_counts(
+        corrected["X"],
+        corrected["Y"],
+        corrected["Z"],
+        binary_precision,
+        sign_vector=sign_vector,
+        target_bloch=target_bloch,
+        uncertainty_backend=uncertainty_backend,
+        max_grid_points=max_grid_points,
+    )

--- a/python/bloqade/gemini/decoding/mle.py
+++ b/python/bloqade/gemini/decoding/mle.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import numpy as np
+from bloqade.decoders import ConfidenceDecoder
+from bloqade.decoders.bit_packing import pack_boolean_array
+from bloqade.decoders.dem import detector_error_model_matrices, matrix_to_dem
+
+from .layout import DEFAULT_SYNDROME_LAYOUT, SyndromeLayout
+from .postselection import DecoderAdapter, _make_decoder_adapter
+from .types import DetectorErrorModelTask
+
+
+def build_mle_decoders(
+    task: DetectorErrorModelTask,
+    *,
+    gurobi_decoder_cls: type[ConfidenceDecoder],
+    layout: SyndromeLayout = DEFAULT_SYNDROME_LAYOUT,
+) -> DecoderAdapter:
+    """Build full and factory MLE decoder adapters from a task DEM.
+
+    Args:
+        task: Object exposing the full detector error model.
+        gurobi_decoder_cls: Confidence-capable decoder class used for both the
+            full and factory DEMs.
+        layout: Syndrome layout separating output and factory syndrome bits.
+
+    Returns:
+        Decoder adapter with full-output decoding and factory confidence
+        decoding.
+    """
+
+    dem_data = detector_error_model_matrices(task)
+    full_dem = matrix_to_dem(dem_data["H"], dem_data["O"], dem_data["priors"])
+    factory_dem = matrix_to_dem(
+        dem_data["H"][layout.output_detector_count :, :],
+        dem_data["O"][layout.output_observable_count :, :],
+        dem_data["priors"],
+    )
+
+    full_decoder = gurobi_decoder_cls(full_dem)
+    factory_decoder = gurobi_decoder_cls(factory_dem)
+    # TODO: this attribute should be defined by the MLE decoder class
+    score_mode = str(getattr(factory_decoder, "confidence_score_mode", "confidence"))
+
+    def factory_decode_impl(syndrome: np.ndarray) -> tuple[np.ndarray, float]:
+        correction, confidence = factory_decoder.decode_with_confidence(
+            syndrome.astype(bool)
+        )
+        return np.asarray(correction, dtype=np.uint8), float(np.float64(confidence))
+
+    adapter = _make_decoder_adapter(
+        full_decoder=full_decoder,
+        factory_decoder=factory_decoder,
+        full_syndrome_length=full_dem.num_detectors,
+        factory_syndrome_length=factory_dem.num_detectors,
+        factory_decode_impl=factory_decode_impl,
+        factory_score_mode=score_mode,
+    )
+    sample_syndrome = np.zeros(factory_dem.num_detectors, dtype=np.uint8)
+    adapter.decode_factory(int(pack_boolean_array(sample_syndrome)[0]))
+    return adapter


### PR DESCRIPTION
## Dependencies

Same-repo stack:
- Code/API dependencies:
  - #697 for constants, layout helpers, and shared task/decoder types.
  - #698 for `SimulatorTask` and `run_task`.
  - #701 for `DecoderAdapter` and `_make_decoder_adapter`.
- Merge order: currently stacked after #702, but this is review order only.
- This PR is base for: #704.

Cross-repo dependencies:
- Direct code/API dependencies:
  - QuEraComputing/bloqade-decoders#35 for `bloqade.decoders.bit_packing.pack_boolean_array`.
  - QuEraComputing/bloqade-decoders#37 for `bloqade.decoders.dem.{detector_error_model_matrices,matrix_to_dem,make_layout_only_dem}`.
  - QuEraComputing/bloqade-circuit#783 for `bloqade.analysis.tomography.{DEFAULT_TARGET_BLOCH,fidelity_from_counts,logical_expectation}` used by baseline helpers.
- Inherited from #697:
  - QuEraComputing/bloqade-decoders#36 for `SparseTableDecoder` in the table-decoder type facade.
- Transitive stack dependencies:
  - QuEraComputing/bloqade-decoders#37 is currently stacked after #36/#35; this PR directly imports #35 and #37 symbols, while #36 is inherited from #697.
  - QuEraComputing/bloqade-circuit#782 only because #783 is stacked on it; this PR does not directly import `WrapAddressAnalysis`.
- Does not depend on:
  - #699 or #700 by code.
  - #702 by code; this PR's MLE/baseline helpers do not import the MLD suite.
  - QuEraComputing/bloqade-circuit#782 directly.
- Required for CI: yes, MLE construction uses decoder bit-packing/DEM helpers and tomography summaries.

Review status:
- Draft until dependencies are merged/released: yes.

## Summary

- Adds MLE decoder construction helpers.
- Adds raw, injected, and distilled baseline helpers.

## Review focus

- DEM conversion and baseline construction semantics.
- API shape versus notebook-visible behavior.

## Test plan

- `uv run --index-strategy=unsafe-best-match pytest python/tests/gemini/test_decoding_imports.py python/tests/demo/test_msd_utils.py -q` -> `41 passed in 18.46s`.
- Targeted ruff command -> passed.
- `uv run --index-strategy=unsafe-best-match pyright python/bloqade/gemini/decoding` -> `0 errors, 0 warnings`.
