### PR TITLE
fix(python): backport #713 — lazily construct pipeline strategies from arch_spec

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -222,4 +222,4 @@ Breaking changes map to SemVer MAJOR.
 ### Pull Request Labels
 
 - Tag PRs with the `breaking` label when they contain breaking changes
-- Tag non-breaking PRs with `backport v0.9` label for cherry-picking into the current release branch (`release-0-9`)
+- Tag non-breaking PRs with `backport v0.10` label for cherry-picking into the current release branch (`release-0-10`)

--- a/python/bloqade/lanes/analysis/layout/analysis.py
+++ b/python/bloqade/lanes/analysis/layout/analysis.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 @dataclass
 class LayoutHeuristicABC(abc.ABC):
 
+    arch_spec: "ArchSpec"
+
     def _validate_pinned_in_arch(
         self,
         pinned: dict[int, LocationAddress],

--- a/python/bloqade/lanes/pipeline/logical.py
+++ b/python/bloqade/lanes/pipeline/logical.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 
 from bloqade.analysis.validation.simple_nocloning import FlatKernelNoCloningValidation
@@ -114,28 +115,55 @@ class LogicalPipeline:
     transversal_rewrite: bool = False
     simulation: bool = True
 
-    def emit(self, mt: Method, no_raise: bool = True) -> Method:
-        heuristic = (
-            LogicalLayoutHeuristic(arch_spec=self.arch_spec)
-            if self.layout_heuristic is None
-            else self.layout_heuristic
-        )
-        strategy = (
-            PalindromePlacementStrategy(
+    @property
+    def resolved_layout_heuristic(self) -> layout.LayoutHeuristicABC:
+        """Return the active layout heuristic, constructing it from ``arch_spec`` if unset.
+
+        Emits a warning if an explicit heuristic is set whose ``arch_spec``
+        differs from the pipeline's ``arch_spec``.
+        """
+        if self.layout_heuristic is None:
+            return LogicalLayoutHeuristic(arch_spec=self.arch_spec)
+        if self.layout_heuristic.arch_spec != self.arch_spec:
+            warnings.warn(
+                "LogicalPipeline.layout_heuristic was constructed with a different "
+                "arch_spec than the pipeline. Initial qubit layout may not match the "
+                "pipeline architecture. Leave layout_heuristic=None to have it built "
+                "automatically from arch_spec.",
+                stacklevel=2,
+            )
+        return self.layout_heuristic
+
+    @property
+    def resolved_placement_strategy(self) -> placement.PlacementStrategyABC:
+        """Return the active placement strategy, constructing it from ``arch_spec`` if unset.
+
+        Emits a warning if an explicit strategy is set whose ``arch_spec``
+        differs from the pipeline's ``arch_spec``.
+        """
+        if self.placement_strategy is None:
+            return PalindromePlacementStrategy(
                 inner=LogicalPlacementStrategyNoHome(arch_spec=self.arch_spec)
             )
-            if self.placement_strategy is None
-            else self.placement_strategy
-        )
+        if self.placement_strategy.arch_spec != self.arch_spec:
+            warnings.warn(
+                "LogicalPipeline.placement_strategy was constructed with a different "
+                "arch_spec than the pipeline. Compiled moves may not match the pipeline "
+                "architecture. Leave placement_strategy=None to have it built automatically "
+                "from arch_spec, or construct the strategy with the same arch_spec instance.",
+                stacklevel=2,
+            )
+        return self.placement_strategy
 
+    def emit(self, mt: Method, no_raise: bool = True) -> Method:
         out = _LogicalNativeToPlace(
             arch_spec=self.arch_spec, transversal_rewrite=self.transversal_rewrite
         ).emit(mt, no_raise=no_raise)
         self.place_opt_type(out.dialects, no_raise=no_raise)(out)
 
         out = _PlaceToMove(
-            layout_heuristic=heuristic,
-            placement_strategy=strategy,
+            layout_heuristic=self.resolved_layout_heuristic,
+            placement_strategy=self.resolved_placement_strategy,
             insert_initialize=True,
         ).emit(out, no_raise=no_raise)
 

--- a/python/bloqade/lanes/pipeline/physical.py
+++ b/python/bloqade/lanes/pipeline/physical.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 
 from kirin import passes, rewrite
@@ -44,35 +45,69 @@ class PhysicalPipeline:
     Qubits are lowered to place.NewPinnedQubit; no logical initialization
     sequence is inserted.  Validates that the kernel has exactly one terminal
     measure covering all allocated qubits (post-unroll).
+
+    ``arch_spec`` is the single source of truth: when ``layout_heuristic`` or
+    ``placement_strategy`` are ``None`` (the default), they are constructed in
+    ``emit`` using ``self.arch_spec``, guaranteeing consistency.  Pass explicit
+    instances only when you need a fully custom heuristic or strategy; in that
+    case the caller is responsible for arch-spec consistency.
     """
 
     arch_spec: ArchSpec = field(default_factory=get_physical_arch_spec)
     layout_heuristic: layout.LayoutHeuristicABC | None = None
-    placement_strategy: placement.PlacementStrategyABC | None = field(
-        default_factory=make_physical_placement_strategy
-    )
+    placement_strategy: placement.PlacementStrategyABC | None = None
     place_opt_type: type[passes.Pass] = field(default=SequentialPlacePass)
 
-    def emit(self, mt: Method, no_raise: bool = True) -> Method:
-        heuristic = (
-            PhysicalLayoutHeuristicGraphPartitionCenterOut(arch_spec=self.arch_spec)
-            if self.layout_heuristic is None
-            else self.layout_heuristic
-        )
-        strategy = (
-            make_physical_placement_strategy(arch_spec=self.arch_spec)
-            if self.placement_strategy is None
-            else self.placement_strategy
-        )
+    @property
+    def resolved_layout_heuristic(self) -> layout.LayoutHeuristicABC:
+        """Return the active layout heuristic, constructing it from ``arch_spec`` if unset.
 
+        Emits a warning if an explicit heuristic is set whose ``arch_spec``
+        differs from the pipeline's ``arch_spec``.
+        """
+        if self.layout_heuristic is None:
+            return PhysicalLayoutHeuristicGraphPartitionCenterOut(
+                arch_spec=self.arch_spec
+            )
+        if self.layout_heuristic.arch_spec != self.arch_spec:
+            warnings.warn(
+                "PhysicalPipeline.layout_heuristic was constructed with a different "
+                "arch_spec than the pipeline. Initial qubit layout may not match the "
+                "pipeline architecture. Leave layout_heuristic=None to have it built "
+                "automatically from arch_spec.",
+                stacklevel=2,
+            )
+        return self.layout_heuristic
+
+    @property
+    def resolved_placement_strategy(self) -> placement.PlacementStrategyABC:
+        """Return the active placement strategy, constructing it from ``arch_spec`` if unset.
+
+        Emits a warning if an explicit strategy is set whose ``arch_spec``
+        differs from the pipeline's ``arch_spec``.
+        """
+        if self.placement_strategy is None:
+            return make_physical_placement_strategy(arch_spec=self.arch_spec)
+        if self.placement_strategy.arch_spec != self.arch_spec:
+            warnings.warn(
+                "PhysicalPipeline.placement_strategy was constructed with a different "
+                "arch_spec than the pipeline. Compiled moves may not match the pipeline "
+                "architecture. Leave placement_strategy=None to have it built automatically "
+                "from arch_spec, or pass arch_spec= explicitly to "
+                "make_physical_placement_strategy().",
+                stacklevel=2,
+            )
+        return self.placement_strategy
+
+    def emit(self, mt: Method, no_raise: bool = True) -> Method:
         out = _PhysicalNativeToPlace(arch_spec=self.arch_spec).emit(
             mt, no_raise=no_raise
         )
         self.place_opt_type(out.dialects, no_raise=no_raise)(out)
 
         out = _PlaceToMove(
-            layout_heuristic=heuristic,
-            placement_strategy=strategy,
+            layout_heuristic=self.resolved_layout_heuristic,
+            placement_strategy=self.resolved_placement_strategy,
             insert_initialize=False,
         ).emit(out, no_raise=no_raise)
 

--- a/python/tests/analysis/layout/test_layout_analysis_pinned.py
+++ b/python/tests/analysis/layout/test_layout_analysis_pinned.py
@@ -12,8 +12,11 @@ from kirin.dialects import func, ssacfg
 
 from bloqade.lanes.analysis.layout import LayoutAnalysis
 from bloqade.lanes.analysis.layout.analysis import LayoutHeuristicABC
+from bloqade.lanes.arch.gemini.physical import get_arch_spec as get_physical_arch_spec
 from bloqade.lanes.bytecode.encoding import LocationAddress
 from bloqade.lanes.dialects import place
+
+_STUB_ARCH = get_physical_arch_spec()
 
 # ---------------------------------------------------------------------------
 # Minimal stub heuristic (never called by these unit tests)
@@ -67,7 +70,7 @@ def _make_analysis(
     dialects = ir.DialectGroup([ssacfg.dialect, func.dialect, place.dialect])
     return LayoutAnalysis(
         dialects=dialects,
-        heuristic=_StubHeuristic(),
+        heuristic=_StubHeuristic(arch_spec=_STUB_ARCH),
         address_entries=address_entries,
         all_qubits=(),
     )

--- a/python/tests/pipeline/test_logical_pipeline.py
+++ b/python/tests/pipeline/test_logical_pipeline.py
@@ -1,13 +1,15 @@
 """Tests for LogicalPipeline."""
 
 import bloqade.squin as squin
+import pytest
 from bloqade.squin.gate.stmts import S, SqrtX
 
 import bloqade.gemini as gemini
 from bloqade.lanes.dialects import move, place
+from bloqade.lanes.heuristics.logical.layout import LogicalLayoutHeuristic
 from bloqade.lanes.heuristics.logical.placement import LogicalPlacementStrategyNoHome
 from bloqade.lanes.pipeline import LogicalPipeline
-from bloqade.lanes.pipeline.logical import _LogicalNativeToPlace
+from bloqade.lanes.pipeline.logical import _LogicalNativeToPlace, transversal_rewrites
 
 
 def test_logical_pipeline_smoke():
@@ -69,31 +71,89 @@ def test_logical_pipeline_produces_logical_initialize():
     assert len(inits) >= 1
 
 
-def test_logical_pipeline_no_return_moves():
-    """Passing a bare (non-palindrome) strategy disables return moves."""
+def test_logical_pipeline_layout_heuristic_default_is_none():
+    """LogicalPipeline.layout_heuristic defaults to None."""
+    pipeline = LogicalPipeline()
+    assert pipeline.layout_heuristic is None
+
+
+def test_logical_pipeline_resolves_none_to_logical_defaults(monkeypatch):
+    """When layout_heuristic is None, LogicalPipeline passes LogicalLayoutHeuristic
+    to the place→move stage."""
+    from bloqade.lanes.heuristics.logical.layout import LogicalLayoutHeuristic
+    from bloqade.lanes.pipeline.base import _PlaceToMove
+
+    captured: dict = {}
+    _orig_emit = _PlaceToMove.emit
+
+    def spy_emit(self_inner, mt, no_raise=True):
+        captured["layout_heuristic_type"] = type(self_inner.layout_heuristic)
+        return _orig_emit(self_inner, mt, no_raise=no_raise)
+
+    monkeypatch.setattr(_PlaceToMove, "emit", spy_emit)
 
     @gemini.logical.kernel(aggressive_unroll=True)
     def kernel():
-        reg = squin.qalloc(2)
+        reg = squin.qalloc(1)
         squin.h(reg[0])
-        squin.cx(reg[0], reg[1])
         gemini.logical.terminal_measure(reg)
 
-    out = LogicalPipeline(placement_strategy=LogicalPlacementStrategyNoHome()).emit(
-        kernel
+    LogicalPipeline().emit(kernel)
+    assert captured["layout_heuristic_type"] is LogicalLayoutHeuristic
+
+
+def test_logical_pipeline_layout_heuristic_mismatch_warns():
+    """resolved_layout_heuristic warns when the explicit heuristic carries a
+    structurally different arch_spec than the pipeline."""
+    from bloqade.lanes.arch.gemini.physical import (
+        get_arch_spec as get_physical_arch_spec,
     )
-    assert out is not None
+
+    logical_arch = LogicalPipeline().arch_spec
+    physical_arch = get_physical_arch_spec()
+    assert logical_arch != physical_arch
+
+    mismatched_heuristic = LogicalLayoutHeuristic(arch_spec=physical_arch)
+    pipeline = LogicalPipeline(layout_heuristic=mismatched_heuristic)
+
+    with pytest.warns(
+        UserWarning, match="layout_heuristic was constructed with a different"
+    ):
+        result = pipeline.resolved_layout_heuristic
+
+    assert result is mismatched_heuristic
 
 
-def test_logical_pipeline_no_raise_suppresses_validation():
-    """no_raise=True does not raise even when pre-native validation fails."""
+def test_logical_pipeline_placement_strategy_mismatch_warns():
+    """resolved_placement_strategy warns when the explicit strategy carries a
+    structurally different arch_spec than the pipeline."""
+    from bloqade.lanes.arch.gemini.physical import (
+        get_arch_spec as get_physical_arch_spec,
+    )
+
+    logical_arch = LogicalPipeline().arch_spec
+    physical_arch = get_physical_arch_spec()
+    assert logical_arch != physical_arch
+
+    mismatched_strategy = LogicalPlacementStrategyNoHome(arch_spec=physical_arch)
+    pipeline = LogicalPipeline(placement_strategy=mismatched_strategy)
+
+    with pytest.warns(
+        UserWarning, match="placement_strategy was constructed with a different"
+    ):
+        result = pipeline.resolved_placement_strategy
+
+    assert result is mismatched_strategy
+
+
+def test_transversal_rewrites_direct():
+    """transversal_rewrites() rewrites the method in place and returns it."""
 
     @gemini.logical.kernel(aggressive_unroll=True)
-    def invalid_kernel():
-        reg = squin.qalloc(2)
+    def kernel():
+        reg = squin.qalloc(1)
         squin.h(reg[0])
-        squin.cx(reg[0], reg[1])
-        # missing terminal_measure — violates GeminiTerminalMeasurementValidation
+        gemini.logical.terminal_measure(reg)
 
-    out = LogicalPipeline().emit(invalid_kernel, no_raise=True)
-    assert out is not None
+    result = transversal_rewrites(kernel, rewrite_logical_initialize=False)
+    assert result is kernel

--- a/python/tests/pipeline/test_physical_pipeline.py
+++ b/python/tests/pipeline/test_physical_pipeline.py
@@ -1,6 +1,7 @@
 """Tests for the physical pipeline and NewPinnedQubit."""
 
 import bloqade.squin as squin
+import pytest
 from kirin import ir, rewrite
 from kirin.dialects import ilist
 from kirin.ir.exception import ValidationErrorGroup
@@ -8,7 +9,6 @@ from kirin.ir.exception import ValidationErrorGroup
 from bloqade import qubit
 from bloqade.lanes.bytecode.encoding import LocationAddress
 from bloqade.lanes.dialects import move, place
-from bloqade.lanes.heuristics.physical.movement import PhysicalPlacementStrategy
 from bloqade.lanes.pipeline import PhysicalPipeline
 from bloqade.lanes.rewrite.circuit2place import RewriteQubitsToPinnedQubits
 
@@ -53,18 +53,10 @@ def test_physical_pipeline_smoke():
     assert len(fills) == 1
 
 
-def test_physical_pipeline_placement_strategy_default_uses_factory():
-    """PhysicalPipeline should eagerly construct the shared default strategy."""
-    from bloqade.lanes.analysis.placement import PalindromePlacementStrategy
-
+def test_physical_pipeline_placement_strategy_default_is_none():
+    """PhysicalPipeline.placement_strategy defaults to None; emit() constructs it from arch_spec."""
     pipeline = PhysicalPipeline()
-
-    assert isinstance(pipeline.placement_strategy, PalindromePlacementStrategy)
-    assert isinstance(pipeline.placement_strategy.inner, PhysicalPlacementStrategy)
-    traversal = pipeline.placement_strategy.inner.traversal
-    assert traversal.strategy == "entropy"
-    assert traversal.max_goal_candidates == 3
-    assert traversal.max_expansions == 300
+    assert pipeline.placement_strategy is None
 
 
 def test_physical_pipeline_no_new_pinned_remaining():
@@ -95,29 +87,16 @@ def test_physical_pipeline_missing_measure_raises():
         PhysicalPipeline().emit(kernel, no_raise=False)
 
 
-def test_physical_pipeline_no_raise_succeeds_without_terminal_measure():
-    """With no_raise=True, PhysicalPipeline.emit must not raise even when there
-    is no terminal measurement (validation errors are suppressed in lenient mode)."""
-
-    @squin.kernel
-    def kernel():
-        squin.qalloc(1)  # no measurement
-
-    # Should not raise in lenient mode.
-    result = PhysicalPipeline().emit(kernel, no_raise=True)
-    assert result is not None
-
-
 def test_physical_pipeline_resolves_none_to_physical_defaults(monkeypatch):
     """When layout_heuristic and placement_strategy are None, PhysicalPipeline
     resolves them to PhysicalLayoutHeuristicGraphPartitionCenterOut wrapped in
-    PalindromePlacementStrategy(PhysicalPlacementStrategy) before passing them
+    PalindromePlacementStrategy(NoHomePlacementStrategy) before passing them
     to the place→move stage."""
     from bloqade.lanes.analysis.placement import PalindromePlacementStrategy
     from bloqade.lanes.heuristics.physical.layout import (
         PhysicalLayoutHeuristicGraphPartitionCenterOut,
     )
-    from bloqade.lanes.heuristics.physical.placement import PhysicalPlacementStrategy
+    from bloqade.lanes.heuristics.physical.nohome import NoHomePlacementStrategy
     from bloqade.lanes.pipeline.base import _PlaceToMove
 
     captured: dict = {}
@@ -143,4 +122,48 @@ def test_physical_pipeline_resolves_none_to_physical_defaults(monkeypatch):
     )
     strategy = captured["placement_strategy"]
     assert isinstance(strategy, PalindromePlacementStrategy)
-    assert isinstance(strategy.inner, PhysicalPlacementStrategy)
+    assert isinstance(strategy.inner, NoHomePlacementStrategy)
+
+
+def test_physical_pipeline_layout_heuristic_mismatch_warns():
+    """resolved_layout_heuristic warns when the explicit heuristic carries a
+    structurally different arch_spec than the pipeline."""
+    from bloqade.lanes.arch.gemini.logical import get_arch_spec as get_logical_arch_spec
+    from bloqade.lanes.heuristics.logical.layout import LogicalLayoutHeuristic
+
+    physical_arch = PhysicalPipeline().arch_spec
+    logical_arch = get_logical_arch_spec()
+    assert physical_arch != logical_arch
+
+    mismatched_heuristic = LogicalLayoutHeuristic(arch_spec=logical_arch)
+    pipeline = PhysicalPipeline(layout_heuristic=mismatched_heuristic)
+
+    with pytest.warns(
+        UserWarning, match="layout_heuristic was constructed with a different"
+    ):
+        result = pipeline.resolved_layout_heuristic
+
+    assert result is mismatched_heuristic
+
+
+def test_physical_pipeline_placement_strategy_mismatch_warns():
+    """resolved_placement_strategy warns when the explicit strategy carries a
+    structurally different arch_spec than the pipeline."""
+    from bloqade.lanes.arch.gemini.logical import get_arch_spec as get_logical_arch_spec
+    from bloqade.lanes.heuristics.logical.placement import (
+        LogicalPlacementStrategyNoHome,
+    )
+
+    physical_arch = PhysicalPipeline().arch_spec
+    logical_arch = get_logical_arch_spec()
+    assert physical_arch != logical_arch
+
+    mismatched_strategy = LogicalPlacementStrategyNoHome(arch_spec=logical_arch)
+    pipeline = PhysicalPipeline(placement_strategy=mismatched_strategy)
+
+    with pytest.warns(
+        UserWarning, match="placement_strategy was constructed with a different"
+    ):
+        result = pipeline.resolved_placement_strategy
+
+    assert result is mismatched_strategy

--- a/python/tests/pipeline/test_physical_pipeline.py
+++ b/python/tests/pipeline/test_physical_pipeline.py
@@ -90,13 +90,13 @@ def test_physical_pipeline_missing_measure_raises():
 def test_physical_pipeline_resolves_none_to_physical_defaults(monkeypatch):
     """When layout_heuristic and placement_strategy are None, PhysicalPipeline
     resolves them to PhysicalLayoutHeuristicGraphPartitionCenterOut wrapped in
-    PalindromePlacementStrategy(NoHomePlacementStrategy) before passing them
+    PalindromePlacementStrategy(PhysicalPlacementStrategy) before passing them
     to the place→move stage."""
     from bloqade.lanes.analysis.placement import PalindromePlacementStrategy
     from bloqade.lanes.heuristics.physical.layout import (
         PhysicalLayoutHeuristicGraphPartitionCenterOut,
     )
-    from bloqade.lanes.heuristics.physical.nohome import NoHomePlacementStrategy
+    from bloqade.lanes.heuristics.physical.movement import PhysicalPlacementStrategy
     from bloqade.lanes.pipeline.base import _PlaceToMove
 
     captured: dict = {}
@@ -122,7 +122,7 @@ def test_physical_pipeline_resolves_none_to_physical_defaults(monkeypatch):
     )
     strategy = captured["placement_strategy"]
     assert isinstance(strategy, PalindromePlacementStrategy)
-    assert isinstance(strategy.inner, NoHomePlacementStrategy)
+    assert isinstance(strategy.inner, PhysicalPlacementStrategy)
 
 
 def test_physical_pipeline_layout_heuristic_mismatch_warns():


### PR DESCRIPTION
Backport of #713 to `release-0-10`.

## Summary

- `PhysicalPipeline.placement_strategy` default changed from eager `default_factory` to `None`, matching `LogicalPipeline`'s existing pattern
- `resolved_layout_heuristic` and `resolved_placement_strategy` properties added to both pipelines — lazily construct from `arch_spec`, warn on structural mismatch
- `arch_spec: ArchSpec` annotation added to `LayoutHeuristicABC`
- Updated tests

Resolves #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)