### PR TITLE
feat: made tsim lazy import for device/simulator.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,7 @@ authors = [
     { name = "Phillip Weinberg", email = "pweinberg@quera.com" }
 ]
 dependencies = [
-    "bloqade-circuit[cirq, qasm2, tsim]~=0.14.1",
-    "bloqade-tsim~=0.1.3",
+    "bloqade-circuit[cirq, qasm2]~=0.14.1",
     "bloqade-core~=0.6.4",
     "deprecated>=1.3.1",
     "kirin-toolchain~=0.22.6",
@@ -28,6 +27,10 @@ requires-python = ">= 3.10"
 cudaq = [
     "cudaq>=0.13.0",
     "qbraid-qir[squin]>=0.5.1",
+]
+tsim = [
+    "bloqade-circuit[tsim]~=0.14.1",
+    "bloqade-tsim~=0.1.3",
 ]
 visualization = [
     "matplotlib>=3.9.4",

--- a/python/bloqade/gemini/device/simulator.py
+++ b/python/bloqade/gemini/device/simulator.py
@@ -15,14 +15,13 @@ from typing import (
 )
 
 import numpy as np
-import tsim as tsim_backend
 from bloqade.analysis.fidelity import FidelityAnalysis
 from kirin import ir, rewrite
 from stim import DetectorErrorModel
 
-from bloqade import tsim
-
 if TYPE_CHECKING:
+    import tsim as tsim_backend  # type: ignore[reportMissingImports]
+
     from bloqade.lanes.analysis import atom
     from bloqade.lanes.arch.spec import ArchSpec
     from bloqade.lanes.rewrite.move2squin.noise import LogicalNoiseModelABC
@@ -34,6 +33,18 @@ def _default_noise_model() -> "LogicalNoiseModelABC":
     from bloqade.lanes.noise_model import generate_logical_noise_model
 
     return generate_logical_noise_model()
+
+
+def _tsim():
+    try:
+        from bloqade import tsim
+    except ImportError as exc:
+        raise ImportError(
+            "Gemini logical simulation requires the optional `tsim` extra. "
+            "Install it with `bloqade-lanes[tsim]` or `uv sync --extra tsim`."
+        ) from exc
+
+    return tsim
 
 
 @dataclass(frozen=True)
@@ -212,7 +223,7 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
 
         physical_squin_kernel = self.physical_squin_kernel.similar()
         rewrite.Walk(RemoveReturn()).rewrite(physical_squin_kernel.code)
-        return tsim.Circuit(physical_squin_kernel)
+        return _tsim().Circuit(physical_squin_kernel)
 
     @cached_property
     def noiseless_tsim_circuit(self) -> tsim_backend.Circuit:
@@ -221,7 +232,7 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
 
         noiseless_kernel = self.noiseless_physical_squin_kernel.similar()
         rewrite.Walk(RemoveReturn()).rewrite(noiseless_kernel.code)
-        return tsim.Circuit(noiseless_kernel)
+        return _tsim().Circuit(noiseless_kernel)
 
     @cached_property
     def measurement_sampler(self):

--- a/python/tests/gemini/test_optional_tsim_import.py
+++ b/python/tests/gemini/test_optional_tsim_import.py
@@ -1,0 +1,51 @@
+import subprocess
+import sys
+import textwrap
+
+
+def test_logical_device_import_does_not_import_tsim():
+    code = textwrap.dedent("""
+        import sys
+
+        from bloqade.gemini import logical as gemini_logical
+        from bloqade.gemini import GeminiLogicalDevice
+
+        assert gemini_logical is not None
+        assert GeminiLogicalDevice.__name__ == "GeminiLogicalDevice"
+
+        loaded_tsim = sorted(
+            name
+            for name in sys.modules
+            if name == "tsim"
+            or name.startswith("tsim.")
+            or name == "bloqade.tsim"
+            or name.startswith("bloqade.tsim.")
+        )
+        if loaded_tsim:
+            raise SystemExit(f"unexpected tsim imports: {loaded_tsim}")
+        """)
+
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_logical_simulator_import_does_not_import_tsim():
+    code = textwrap.dedent("""
+        import sys
+
+        from bloqade.gemini import GeminiLogicalSimulator
+
+        assert GeminiLogicalSimulator.__name__ == "GeminiLogicalSimulator"
+
+        loaded_tsim = sorted(
+            name
+            for name in sys.modules
+            if name == "tsim"
+            or name.startswith("tsim.")
+            or name == "bloqade.tsim"
+            or name.startswith("bloqade.tsim.")
+        )
+        if loaded_tsim:
+            raise SystemExit(f"unexpected tsim imports: {loaded_tsim}")
+        """)
+
+    subprocess.run([sys.executable, "-c", code], check=True)

--- a/uv.lock
+++ b/uv.lock
@@ -290,9 +290,8 @@ name = "bloqade-lanes"
 version = "0.11.0.dev0"
 source = { editable = "." }
 dependencies = [
-    { name = "bloqade-circuit", extra = ["cirq", "qasm2", "tsim"] },
+    { name = "bloqade-circuit", extra = ["cirq", "qasm2"] },
     { name = "bloqade-core" },
-    { name = "bloqade-tsim" },
     { name = "deprecated" },
     { name = "kahip" },
     { name = "kirin-toolchain" },
@@ -307,6 +306,10 @@ cudaq = [
     { name = "cudaq", version = "0.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "cudaq", version = "0.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "qbraid-qir", extra = ["squin"] },
+]
+tsim = [
+    { name = "bloqade-circuit", extra = ["tsim"] },
+    { name = "bloqade-tsim" },
 ]
 visualization = [
     { name = "matplotlib" },
@@ -353,9 +356,10 @@ doc = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bloqade-circuit", extras = ["cirq", "qasm2", "tsim"], specifier = "~=0.14.1" },
+    { name = "bloqade-circuit", extras = ["cirq", "qasm2"], specifier = "~=0.14.1" },
+    { name = "bloqade-circuit", extras = ["tsim"], marker = "extra == 'tsim'", specifier = "~=0.14.1" },
     { name = "bloqade-core", specifier = "~=0.6.4" },
-    { name = "bloqade-tsim", specifier = "~=0.1.3" },
+    { name = "bloqade-tsim", marker = "extra == 'tsim'", specifier = "~=0.1.3" },
     { name = "cudaq", marker = "extra == 'cudaq'", specifier = ">=0.13.0" },
     { name = "deprecated", specifier = ">=1.3.1" },
     { name = "kahip", specifier = ">=3.25" },
@@ -369,7 +373,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "scipy", marker = "extra == 'visualization'", specifier = ">=1.15.3" },
 ]
-provides-extras = ["cudaq", "visualization"]
+provides-extras = ["cudaq", "tsim", "visualization"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Make `tsim` an optional dependency for `bloqade-lanes` while keeping Gemini logical device imports usable in environments where `tsim` is not installed.

- Move `bloqade-tsim` and the `bloqade-circuit[tsim]` extra out of the base dependency set and into a new `tsim` optional extra.
- Lazily import `tsim` only when a Gemini logical simulator task actually builds a tsim circuit.
- Preserve the `tsim_backend.Circuit` return annotations for simulator APIs using a `TYPE_CHECKING`-only import.
- Add regression coverage that imports `GeminiLogicalDevice` and `GeminiLogicalSimulator` without loading `tsim`.

## Details

`GeminiLogicalSimulator` still exposes `tsim_backend.Circuit` in type annotations, but the runtime dependency is now deferred behind `_tsim()`. If simulation code reaches the tsim circuit construction path without the optional extra installed, it raises an import error with an install hint:

```text
Install it with `bloqade-lanes[tsim]` or `uv sync --extra tsim`.
```

This keeps ordinary Gemini logical imports lightweight while preserving the existing simulator API shape for users who install the `tsim` extra.

## Testing

Ran:

```bash
uv run pytest python/tests/gemini/test_optional_tsim_import.py
uv run pyright python/bloqade/gemini/device/simulator.py python/tests/gemini/test_optional_tsim_import.py
uv run black --check python/bloqade/gemini/device/simulator.py python/tests/gemini/test_optional_tsim_import.py
```

Results:

```text
python/tests/gemini/test_optional_tsim_import.py: 2 passed
pyright: 0 errors, 0 warnings
black: files would be left unchanged
```
