### PR TITLE
feat: made cirq an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
     { name = "Phillip Weinberg", email = "pweinberg@quera.com" }
 ]
 dependencies = [
-    "bloqade-circuit[cirq, qasm2]~=0.14.1",
+    "bloqade-circuit[qasm2]~=0.14.1",
     "bloqade-core~=0.6.4",
     "deprecated>=1.3.1",
     "kirin-toolchain~=0.22.6",
@@ -28,8 +28,8 @@ cudaq = [
     "cudaq>=0.13.0",
     "qbraid-qir[squin]>=0.5.1",
 ]
-tsim = [
-    "bloqade-circuit[tsim]~=0.14.1",
+sim = [
+    "bloqade-circuit[cirq, tsim]~=0.14.1",
     "bloqade-tsim~=0.1.3",
 ]
 visualization = [

--- a/python/benchmarks/utils/qasm_to_squin_kernel.py
+++ b/python/benchmarks/utils/qasm_to_squin_kernel.py
@@ -10,13 +10,12 @@ import tempfile
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, cast
+from typing import TYPE_CHECKING, Callable, cast
 
-import cirq
 import numpy as np
-from bloqade.cirq_utils.parallelize import parallelize
-from cirq.contrib.qasm_import import circuit_from_qasm
-from cirq.linalg.decompositions import deconstruct_single_qubit_matrix_into_angles
+
+if TYPE_CHECKING:
+    import cirq  # type: ignore[reportMissingImports]
 
 U3_RE = re.compile(
     r"^\s*squin\.u3\(\s*([^,]+)\s*,\s*([^,]+)\s*,\s*([^,]+)\s*,\s*q\[(\d+)\]\s*\)\s*$"
@@ -43,10 +42,23 @@ def _format_float(value: float) -> str:
     return f"{value:.12g}"
 
 
+def _load_cirq():
+    try:
+        import cirq  # type: ignore[reportMissingImports]
+    except ImportError as exc:
+        raise ImportError(
+            "QASM-to-SQUIN conversion requires the optional `sim` extra. "
+            "Install it with `bloqade-lanes[sim]` or `uv sync --extra sim`."
+        ) from exc
+
+    return cirq
+
+
 def _qubit_sort_key(qubit: cirq.Qid) -> tuple[int, int, int, str]:
-    if isinstance(qubit, cirq.LineQubit):
+    cirq_mod = _load_cirq()
+    if isinstance(qubit, cirq_mod.LineQubit):
         return (0, qubit.x, 0, "")
-    if isinstance(qubit, cirq.GridQubit):
+    if isinstance(qubit, cirq_mod.GridQubit):
         return (1, qubit.row, qubit.col, "")
     return (2, 0, 0, str(qubit))
 
@@ -62,12 +74,13 @@ def _normalize_kernel_name(name: str) -> str:
 
 def _strip_terminal_measurements(circuit: cirq.Circuit) -> tuple[cirq.Circuit, int]:
     """Drop measurements that are terminal on each measured qubit."""
+    cirq_mod = _load_cirq()
     moments = list(circuit)
     last_non_measure_moment: dict[cirq.Qid, int] = {}
 
     for idx, moment in enumerate(moments):
         for op in moment.operations:
-            if cirq.is_measurement(op):
+            if cirq_mod.is_measurement(op):
                 continue
             for qubit in op.qubits:
                 last_non_measure_moment[qubit] = idx
@@ -78,7 +91,7 @@ def _strip_terminal_measurements(circuit: cirq.Circuit) -> tuple[cirq.Circuit, i
     for idx, moment in enumerate(moments):
         kept_ops: list[cirq.Operation] = []
         for op in moment.operations:
-            if not cirq.is_measurement(op):
+            if not cirq_mod.is_measurement(op):
                 kept_ops.append(op)
                 continue
 
@@ -91,14 +104,17 @@ def _strip_terminal_measurements(circuit: cirq.Circuit) -> tuple[cirq.Circuit, i
             measurement_count += 1
 
         if kept_ops:
-            kept_moments.append(cirq.Moment(kept_ops))
+            kept_moments.append(cirq_mod.Moment(kept_ops))
 
-    return cirq.Circuit(kept_moments), measurement_count
+    return cirq_mod.Circuit(kept_moments), measurement_count
 
 
 def _to_cz_native_cirq(circuit: cirq.Circuit) -> cirq.Circuit:
     """Rewrite a circuit into CZ + single-qubit native operations."""
-    return cirq.optimize_for_target_gateset(circuit, gateset=cirq.CZTargetGateset())
+    cirq_mod = _load_cirq()
+    return cirq_mod.optimize_for_target_gateset(
+        circuit, gateset=cirq_mod.CZTargetGateset()
+    )
 
 
 def _strip_qasm_barriers(qasm_text: str) -> tuple[str, int]:
@@ -116,7 +132,8 @@ def _strip_qasm_barriers(qasm_text: str) -> tuple[str, int]:
 
 def _load_qasm_circuit(qasm_text: str) -> tuple[cirq.Circuit, int]:
     """Load OpenQASM with Cirq's native parser and compatibility fallback."""
-    from_qasm = getattr(cirq.Circuit, "from_qasm", None)
+    cirq_mod = _load_cirq()
+    from_qasm = getattr(cirq_mod.Circuit, "from_qasm", None)
     if callable(from_qasm):
         try:
             parser = cast(Callable[[str], cirq.Circuit], from_qasm)
@@ -126,6 +143,10 @@ def _load_qasm_circuit(qasm_text: str) -> tuple[cirq.Circuit, int]:
 
     qasm_without_barriers, dropped = _strip_qasm_barriers(qasm_text)
     try:
+        from cirq.contrib.qasm_import import (  # type: ignore[reportMissingImports]
+            circuit_from_qasm,
+        )
+
         return circuit_from_qasm(qasm_without_barriers), dropped
     except Exception as fallback_error:
         raise ValueError(
@@ -136,6 +157,7 @@ def _load_qasm_circuit(qasm_text: str) -> tuple[cirq.Circuit, int]:
 
 def circuit_to_squin_decorator_source(circuit: cirq.Circuit, kernel_name: str) -> str:
     """Render a Cirq circuit as decorator-style SQUIN Python source."""
+    cirq_mod = _load_cirq()
     qubits = sorted(circuit.all_qubits(), key=_qubit_sort_key)
     index_by_qubit = {qb: idx for idx, qb in enumerate(qubits)}
 
@@ -160,15 +182,19 @@ def circuit_to_squin_decorator_source(circuit: cirq.Circuit, kernel_name: str) -
             if gate is None:
                 raise ValueError(f"Unsupported gate-less operation: {op!r}")
 
-            if cirq.is_measurement(op):
+            if cirq_mod.is_measurement(op):
                 raise ValueError(
                     "Measurement operations are not supported in SQUIN kernels."
                 )
 
             if len(op.qubits) == 1:
-                mat = cirq.unitary(op, default=None)
+                mat = cirq_mod.unitary(op, default=None)
                 if mat is None:
                     raise ValueError(f"Unsupported single-qubit operation: {op!r}")
+
+                from cirq.linalg.decompositions import (  # type: ignore[reportMissingImports]
+                    deconstruct_single_qubit_matrix_into_angles,
+                )
 
                 z0, y, z1 = deconstruct_single_qubit_matrix_into_angles(mat)
                 # Cirq returns ZYZ angles in order (z0, y, z1) such that
@@ -187,7 +213,7 @@ def circuit_to_squin_decorator_source(circuit: cirq.Circuit, kernel_name: str) -
                 )
                 continue
 
-            if isinstance(gate, cirq.CZPowGate):
+            if isinstance(gate, cirq_mod.CZPowGate):
                 if len(op.qubits) != 2:
                     raise ValueError(f"Unexpected CZ arity: {op!r}")
                 if gate.exponent != 1 or gate.global_shift != 0:
@@ -351,13 +377,26 @@ def parallelize_squin_blocks(source: str) -> str:
 
 
 def _simulate_cirq_statevector(circuit: cirq.Circuit) -> np.ndarray:
+    cirq_mod = _load_cirq()
     qubits = sorted(circuit.all_qubits(), key=_qubit_sort_key)
     # pyqrack/bloqade treats q[0] as least-significant in basis ordering.
     # Reverse Cirq's qubit order to align statevector indexing conventions.
     qubits = list(reversed(qubits))
-    sim = cirq.Simulator(dtype=np.complex128)
+    sim = cirq_mod.Simulator(dtype=np.complex128)
     result = sim.simulate(circuit, qubit_order=qubits)
     return np.asarray(result.final_state_vector, dtype=np.complex128)
+
+
+def _parallelize(circuit: cirq.Circuit) -> cirq.Circuit:
+    try:
+        from bloqade.cirq_utils.parallelize import parallelize
+    except ImportError as exc:
+        raise ImportError(
+            "QASM-to-SQUIN conversion requires the optional `sim` extra. "
+            "Install it with `bloqade-lanes[sim]` or `uv sync --extra sim`."
+        ) from exc
+
+    return parallelize(circuit)
 
 
 def _simulate_squin_statevector(kernel_path: Path, kernel_name: str) -> np.ndarray:
@@ -476,7 +515,7 @@ def main() -> int:
     qasm_text = qasm_path.read_text(encoding="utf-8")
     circuit, dropped_barriers = _load_qasm_circuit(qasm_text)
     unitary_circuit, dropped_measurements = _strip_terminal_measurements(circuit)
-    parallelized = parallelize(unitary_circuit)
+    parallelized = _parallelize(unitary_circuit)
     squin_source = circuit_to_squin_decorator_source(parallelized, kernel_name)
     transformed_source = parallelize_squin_blocks(squin_source)
 

--- a/python/tests/benchmarks/test_qasm_to_squin_kernel.py
+++ b/python/tests/benchmarks/test_qasm_to_squin_kernel.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import cirq
 import numpy as np
+import pytest
 from benchmarks.utils.qasm_to_squin_kernel import (
     _load_qasm_circuit,
     _qubit_sort_key,
@@ -32,6 +32,8 @@ def test_strip_qasm_barriers_handles_global_and_explicit_statements():
 
 
 def test_load_qasm_circuit_accepts_barrier_forms():
+    pytest.importorskip("cirq")
+
     qasm = "\n".join(
         [
             "OPENQASM 2.0;",
@@ -51,12 +53,16 @@ def test_load_qasm_circuit_accepts_barrier_forms():
 
 
 def test_qubit_sort_key_orders_line_qubits_numerically():
+    cirq = pytest.importorskip("cirq")
+
     qubits = [cirq.LineQubit(10), cirq.LineQubit(2)]
     ordered = sorted(qubits, key=_qubit_sort_key)
     assert ordered == [cirq.LineQubit(2), cirq.LineQubit(10)]
 
 
 def test_circuit_to_squin_decorator_source_is_deterministic_within_moment():
+    cirq = pytest.importorskip("cirq")
+
     q0, q1, q2 = cirq.LineQubit.range(3)
     circuit1 = cirq.Circuit(cirq.Moment([cirq.Z(q2), cirq.X(q1), cirq.Y(q0)]))
     circuit2 = cirq.Circuit(cirq.Moment([cirq.Y(q0), cirq.Z(q2), cirq.X(q1)]))

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ name = "bloqade-lanes"
 version = "0.11.0.dev0"
 source = { editable = "." }
 dependencies = [
-    { name = "bloqade-circuit", extra = ["cirq", "qasm2"] },
+    { name = "bloqade-circuit", extra = ["qasm2"] },
     { name = "bloqade-core" },
     { name = "deprecated" },
     { name = "kahip" },
@@ -307,8 +307,8 @@ cudaq = [
     { name = "cudaq", version = "0.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "qbraid-qir", extra = ["squin"] },
 ]
-tsim = [
-    { name = "bloqade-circuit", extra = ["tsim"] },
+sim = [
+    { name = "bloqade-circuit", extra = ["cirq", "tsim"] },
     { name = "bloqade-tsim" },
 ]
 visualization = [
@@ -356,10 +356,10 @@ doc = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bloqade-circuit", extras = ["cirq", "qasm2"], specifier = "~=0.14.1" },
-    { name = "bloqade-circuit", extras = ["tsim"], marker = "extra == 'tsim'", specifier = "~=0.14.1" },
+    { name = "bloqade-circuit", extras = ["cirq", "tsim"], marker = "extra == 'sim'", specifier = "~=0.14.1" },
+    { name = "bloqade-circuit", extras = ["qasm2"], specifier = "~=0.14.1" },
     { name = "bloqade-core", specifier = "~=0.6.4" },
-    { name = "bloqade-tsim", marker = "extra == 'tsim'", specifier = "~=0.1.3" },
+    { name = "bloqade-tsim", marker = "extra == 'sim'", specifier = "~=0.1.3" },
     { name = "cudaq", marker = "extra == 'cudaq'", specifier = ">=0.13.0" },
     { name = "deprecated", specifier = ">=1.3.1" },
     { name = "kahip", specifier = ">=3.25" },
@@ -373,7 +373,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "scipy", marker = "extra == 'visualization'", specifier = ">=1.15.3" },
 ]
-provides-extras = ["cudaq", "tsim", "visualization"]
+provides-extras = ["cudaq", "sim", "visualization"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Make Cirq optional for the base `bloqade-lanes` install by moving Cirq-backed simulation/conversion dependencies into the `sim` extra.

- Remove the `cirq` extra from the required `bloqade-circuit` dependency.
- Add a `sim` optional extra that installs `bloqade-circuit[cirq, tsim]` and `bloqade-tsim`.
- Lazily import Cirq inside the QASM-to-SQUIN benchmark utility so importing the module does not require the optional `sim` extra.
- Update benchmark tests to use `pytest.importorskip("cirq")` only for tests that require Cirq.
- Refresh `uv.lock` to reflect the new optional-extra layout.

## Details

The QASM conversion utility still uses Cirq for parsing, native-gate conversion, qubit ordering, and statevector verification. Those paths now go through local imports, with a clearer install hint if the optional dependency is missing:

```text
Install it with `bloqade-lanes[sim]` or `uv sync --extra sim`.
```

Pure helpers in `test_qasm_to_squin_kernel.py` continue to run without Cirq installed, while Cirq-dependent tests are skipped in optional-free environments and run normally when CI/local installs include `--all-extras`.

## Testing

Ran:

```bash
uv run pyright python
uv run pytest python/tests/benchmarks/test_qasm_to_squin_kernel.py
uv run black --check python/benchmarks/utils/qasm_to_squin_kernel.py python/tests/benchmarks/test_qasm_to_squin_kernel.py
```

Results:

```text
pyright: 0 errors, 0 warnings
pytest: 2 passed, 3 skipped
black: 2 files would be left unchanged
```
