### PR TITLE
feat(arch): broadcast Steane state-prep into a single parallel kernel

### DIFF
--- a/python/benchmarks/harness/runner.py
+++ b/python/benchmarks/harness/runner.py
@@ -164,11 +164,15 @@ class BenchmarkRunner:
                 logical_initialize=True,
             )
             move_mt = transversal_rewrites(move_mt)
+            # aggressive_unroll is required so the broadcasted state-prep loops
+            # (ilist.map/foldl in the init kernels) are fully unrolled; otherwise
+            # FidelityAnalysis cannot resolve the per-qubit noise channels behind
+            # the rolled loops and reports an inflated fidelity.
             physical_squin = MoveToSquinLogical(
                 arch_spec=placement_strategy.arch_spec,
                 noise_model=generate_logical_noise_model(),
                 add_noise=True,
-                aggressive_unroll=False,
+                aggressive_unroll=True,
             ).emit(move_mt)
             analysis = FidelityAnalysis(physical_squin.dialects)
             analysis.run(physical_squin)

--- a/python/bloqade/lanes/arch/gemini/logical/upstream.py
+++ b/python/bloqade/lanes/arch/gemini/logical/upstream.py
@@ -1,4 +1,4 @@
-from typing import Iterator, Literal, TypeVar
+from typing import Any, Iterator, Literal, TypeVar
 
 from kirin import ir, rewrite
 from kirin.dialects import debug, ilist
@@ -30,26 +30,80 @@ def steane7_transversal_map(address: AddressType) -> Iterator[AddressType] | Non
     return (address.replace(site_id=base + i) for i in range(7))
 
 
+N = TypeVar("N")
+
+BroadcastInitKernel = ir.Method[
+    [
+        ilist.IList[float, Any],
+        ilist.IList[float, Any],
+        ilist.IList[float, Any],
+        ilist.IList[ilist.IList[qubit.Qubit, Literal[7]], Any],
+    ],
+    None,
+]
+"""Broadcasted Steane [[7,1,3]] initialization kernel.
+
+Runs state-prep in parallel over ``N`` logical qubits: per-qubit ``theta``/
+``phi``/``lam`` lists and a list of ``N`` seven-qubit physical registers.
+"""
+
+
+@squin.kernel
+def steane7_initialize_broadcast(
+    theta: ilist.IList[float, N],
+    phi: ilist.IList[float, N],
+    lam: ilist.IList[float, N],
+    qubits: ilist.IList[ilist.IList[qubit.Qubit, Literal[7]], N],
+):
+
+    num_rows = len(qubits)
+    num_cols = len(qubits[0])
+
+    def _new_row(j: int):
+        def _get(i: int):
+            return qubits[i][j]
+
+        return ilist.map(_get, ilist.range(num_rows))
+
+    qubits_t = ilist.map(_new_row, ilist.range(num_cols))
+
+    def get_rows(indices):
+        def _inner(cumulant, i):
+            return cumulant + qubits_t[i]
+
+        return ilist.foldl(_inner, indices, ilist.IList([]))
+
+    debug.info("Begin Steane7 Initialize")
+    for i in range(len(theta)):
+        qubit = qubits[i][6]
+        squin.u3(theta[i], phi[i], lam[i], qubit)
+
+    evens = [0, 2, 4, 6]
+    odds = [1, 3, 5]
+
+    squin.broadcast.sqrt_y_adj(get_rows([0, 1, 2, 3, 4, 5]))
+    squin.broadcast.cz(get_rows(odds), get_rows(evens[1:]))
+    squin.broadcast.sqrt_y(get_rows([6]))
+    squin.broadcast.cz(get_rows(evens[:-1]), get_rows([3, 5, 6]))
+    squin.broadcast.sqrt_y(get_rows([2, 3, 4, 5, 6]))
+    squin.broadcast.cz(get_rows(evens[:-1]), get_rows(odds))
+    squin.broadcast.sqrt_y(get_rows([1, 2, 4]))
+    squin.broadcast.x(get_rows([3]))
+    squin.broadcast.z(get_rows([1, 5]))
+
+    debug.info("End Steane7 Initialize")
+
+
 @squin.kernel
 def steane7_initialize(
     theta: float, phi: float, lam: float, qubits: ilist.IList[qubit.Qubit, Literal[7]]
 ):
-    debug.info("Begin Steane7 Initialize")
-    squin.u3(theta, phi, lam, qubits[6])
-    squin.broadcast.sqrt_y_adj(qubits[:6])
-    evens = qubits[::2]  # [0, 2, 4, 6]
-    odds = qubits[1::2]  # [1, 3, 5]
-
-    # Fixed: CZ pairs should be (1,2), (3,4), (5,6) not (1,0), (3,2), (5,4)
-    squin.broadcast.cz(odds, evens[1:])
-    squin.sqrt_y(qubits[6])
-    squin.broadcast.cz(evens[:-1], ilist.IList([qubits[3], qubits[5], qubits[6]]))
-    squin.broadcast.sqrt_y(qubits[2:])
-    squin.broadcast.cz(evens[:-1], odds)
-    squin.broadcast.sqrt_y(ilist.IList([qubits[1], qubits[2], qubits[4]]))
-    squin.x(qubits[3])
-    squin.broadcast.z(ilist.IList([qubits[1], qubits[5]]))
-    debug.info("End Steane7 Initialize")
+    return steane7_initialize_broadcast(
+        ilist.IList([theta]),
+        ilist.IList([phi]),
+        ilist.IList([lam]),
+        ilist.IList([qubits]),
+    )
 
 
 def steane7_initialize_with_noise(
@@ -66,10 +120,7 @@ def steane7_initialize_with_noise(
     sitter_pz: float = 0.0,
     sit_loss_prob: float = 0.0,
     loss: bool = True,
-) -> tuple[
-    ir.Method[[float, float, float, ilist.IList[qubit.Qubit, Literal[7]]], None],
-    ir.Method[[float, float, float, ilist.IList[qubit.Qubit, Literal[7]]], None],
-]:
+) -> tuple[BroadcastInitKernel, BroadcastInitKernel]:
     """Return (clean_kernel, noisy_kernel) for Steane [[7,1,3]] initialization.
 
     The clean kernel is the ideal initialization circuit. The noisy kernel is
@@ -104,107 +155,131 @@ def steane7_initialize_with_noise(
     """
 
     @squin.kernel
-    def noisy_initialize(
-        theta: float,
-        phi: float,
-        lam: float,
-        qubits: ilist.IList[qubit.Qubit, Literal[7]],
+    def noisy_initialize_broadcast(
+        theta: ilist.IList[float, N],
+        phi: ilist.IList[float, N],
+        lam: ilist.IList[float, N],
+        qubits: ilist.IList[ilist.IList[qubit.Qubit, Literal[7]], N],
     ):
+
+        num_rows = len(qubits)
+        num_cols = len(qubits[0])
+
+        def _new_row(j: int):
+            def _get(i: int):
+                return qubits[i][j]
+
+            return ilist.map(_get, ilist.range(num_rows))
+
+        qubits_t = ilist.map(_new_row, ilist.range(num_cols))
+
+        def get_rows(indices):
+            def _inner(cumulant, i):
+                return cumulant + qubits_t[i]
+
+            return ilist.foldl(_inner, indices, ilist.IList([]))
+
         debug.info("Begin Steane7 Noisy Initialize")
 
-        # U3 on qubit 6
-        squin.u3(theta, phi, lam, qubits[6])
-        squin.single_qubit_pauli_channel(local_px, local_py, local_pz, qubits[6])
-        if loss:
-            squin.qubit_loss(local_loss_prob, qubits[6])
+        evens = [0, 2, 4, 6]
+        odds = [1, 3, 5]
 
-        # sqrt_y_adj on qubits 0-5
-        squin.broadcast.sqrt_y_adj(qubits[:6])
+        # U3 on column 6
+        for i in range(len(theta)):
+            squin.u3(theta[i], phi[i], lam[i], qubits[i][6])
         squin.broadcast.single_qubit_pauli_channel(
-            local_px, local_py, local_pz, qubits[:6]
+            local_px, local_py, local_pz, get_rows([6])
         )
         if loss:
-            squin.broadcast.qubit_loss(local_loss_prob, qubits[:6])
+            squin.broadcast.qubit_loss(local_loss_prob, get_rows([6]))
 
-        evens = qubits[::2]  # [0, 2, 4, 6]
-        odds = qubits[1::2]  # [1, 3, 5]
+        # sqrt_y_adj on columns 0-5
+        squin.broadcast.sqrt_y_adj(get_rows([0, 1, 2, 3, 4, 5]))
+        squin.broadcast.single_qubit_pauli_channel(
+            local_px, local_py, local_pz, get_rows([0, 1, 2, 3, 4, 5])
+        )
+        if loss:
+            squin.broadcast.qubit_loss(local_loss_prob, get_rows([0, 1, 2, 3, 4, 5]))
 
         # CZ layer 1: controls=odds (sitters), targets=evens[1:] (movers)
-        squin.broadcast.cz(odds, evens[1:])
+        squin.broadcast.cz(get_rows(odds), get_rows(evens[1:]))
         squin.broadcast.single_qubit_pauli_channel(
-            sitter_px, sitter_py, sitter_pz, odds
+            sitter_px, sitter_py, sitter_pz, get_rows(odds)
         )
         squin.broadcast.single_qubit_pauli_channel(
-            mover_px, mover_py, mover_pz, evens[1:]
+            mover_px, mover_py, mover_pz, get_rows(evens[1:])
         )
         if loss:
-            squin.broadcast.qubit_loss(sit_loss_prob, odds)
-            squin.broadcast.qubit_loss(move_loss_prob, evens[1:])
+            squin.broadcast.qubit_loss(sit_loss_prob, get_rows(odds))
+            squin.broadcast.qubit_loss(move_loss_prob, get_rows(evens[1:]))
 
-        # sqrt_y on qubit 6
-        squin.sqrt_y(qubits[6])
-        squin.single_qubit_pauli_channel(local_px, local_py, local_pz, qubits[6])
+        # sqrt_y on column 6
+        squin.broadcast.sqrt_y(get_rows([6]))
+        squin.broadcast.single_qubit_pauli_channel(
+            local_px, local_py, local_pz, get_rows([6])
+        )
         if loss:
-            squin.qubit_loss(local_loss_prob, qubits[6])
+            squin.broadcast.qubit_loss(local_loss_prob, get_rows([6]))
 
         # CZ layer 2: controls=evens[:-1] (movers), targets=[3,5,6] (sitters)
-        cz_targets = ilist.IList([qubits[3], qubits[5], qubits[6]])
-        squin.broadcast.cz(evens[:-1], cz_targets)
+        squin.broadcast.cz(get_rows(evens[:-1]), get_rows([3, 5, 6]))
         squin.broadcast.single_qubit_pauli_channel(
-            mover_px, mover_py, mover_pz, evens[:-1]
+            mover_px, mover_py, mover_pz, get_rows(evens[:-1])
         )
         squin.broadcast.single_qubit_pauli_channel(
-            sitter_px, sitter_py, sitter_pz, cz_targets
+            sitter_px, sitter_py, sitter_pz, get_rows([3, 5, 6])
         )
         if loss:
-            squin.broadcast.qubit_loss(move_loss_prob, evens[:-1])
-            squin.broadcast.qubit_loss(sit_loss_prob, cz_targets)
+            squin.broadcast.qubit_loss(move_loss_prob, get_rows(evens[:-1]))
+            squin.broadcast.qubit_loss(sit_loss_prob, get_rows([3, 5, 6]))
 
-        # sqrt_y on qubits 2-6
-        squin.broadcast.sqrt_y(qubits[2:])
+        # sqrt_y on columns 2-6
+        squin.broadcast.sqrt_y(get_rows([2, 3, 4, 5, 6]))
         squin.broadcast.single_qubit_pauli_channel(
-            local_px, local_py, local_pz, qubits[2:]
+            local_px, local_py, local_pz, get_rows([2, 3, 4, 5, 6])
         )
         if loss:
-            squin.broadcast.qubit_loss(local_loss_prob, qubits[2:])
+            squin.broadcast.qubit_loss(local_loss_prob, get_rows([2, 3, 4, 5, 6]))
 
         # CZ layer 3: controls=evens[:-1] (sitters), targets=odds (movers)
-        squin.broadcast.cz(evens[:-1], odds)
+        squin.broadcast.cz(get_rows(evens[:-1]), get_rows(odds))
         squin.broadcast.single_qubit_pauli_channel(
-            sitter_px, sitter_py, sitter_pz, evens[:-1]
+            sitter_px, sitter_py, sitter_pz, get_rows(evens[:-1])
         )
-        squin.broadcast.single_qubit_pauli_channel(mover_px, mover_py, mover_pz, odds)
+        squin.broadcast.single_qubit_pauli_channel(
+            mover_px, mover_py, mover_pz, get_rows(odds)
+        )
         if loss:
-            squin.broadcast.qubit_loss(sit_loss_prob, evens[:-1])
-            squin.broadcast.qubit_loss(move_loss_prob, odds)
+            squin.broadcast.qubit_loss(sit_loss_prob, get_rows(evens[:-1]))
+            squin.broadcast.qubit_loss(move_loss_prob, get_rows(odds))
 
         # sqrt_y on [1, 2, 4]
-        correction_qubits = ilist.IList([qubits[1], qubits[2], qubits[4]])
-        squin.broadcast.sqrt_y(correction_qubits)
+        squin.broadcast.sqrt_y(get_rows([1, 2, 4]))
         squin.broadcast.single_qubit_pauli_channel(
-            local_px, local_py, local_pz, correction_qubits
+            local_px, local_py, local_pz, get_rows([1, 2, 4])
         )
         if loss:
-            squin.broadcast.qubit_loss(local_loss_prob, correction_qubits)
+            squin.broadcast.qubit_loss(local_loss_prob, get_rows([1, 2, 4]))
 
-        # X on qubit 3
-        squin.x(qubits[3])
-        squin.single_qubit_pauli_channel(local_px, local_py, local_pz, qubits[3])
+        # X on column 3
+        squin.broadcast.x(get_rows([3]))
+        squin.broadcast.single_qubit_pauli_channel(
+            local_px, local_py, local_pz, get_rows([3])
+        )
         if loss:
-            squin.qubit_loss(local_loss_prob, qubits[3])
+            squin.broadcast.qubit_loss(local_loss_prob, get_rows([3]))
 
         # Z on [1, 5]
-        z_qubits = ilist.IList([qubits[1], qubits[5]])
-        squin.broadcast.z(z_qubits)
+        squin.broadcast.z(get_rows([1, 5]))
         squin.broadcast.single_qubit_pauli_channel(
-            local_px, local_py, local_pz, z_qubits
+            local_px, local_py, local_pz, get_rows([1, 5])
         )
         if loss:
-            squin.broadcast.qubit_loss(local_loss_prob, z_qubits)
+            squin.broadcast.qubit_loss(local_loss_prob, get_rows([1, 5]))
 
         debug.info("End Steane7 Noisy Initialize")
 
-    return steane7_initialize, noisy_initialize
+    return steane7_initialize_broadcast, noisy_initialize_broadcast
 
 
 class SpecializeGemini:

--- a/python/bloqade/lanes/arch/gemini/logical/upstream.py
+++ b/python/bloqade/lanes/arch/gemini/logical/upstream.py
@@ -184,98 +184,103 @@ def steane7_initialize_with_noise(
         evens = [0, 2, 4, 6]
         odds = [1, 3, 5]
 
+        # Cache each column selection once; every gate layer applies a Pauli
+        # channel (and optional loss) to the same qubits it gated.
+        col6 = get_rows([6])
+        cols0_5 = get_rows([0, 1, 2, 3, 4, 5])
+        cols_odds = get_rows(odds)
+        cols_evens_tail = get_rows(evens[1:])  # [2, 4, 6]
+        cols_evens_head = get_rows(evens[:-1])  # [0, 2, 4]
+        cols_356 = get_rows([3, 5, 6])
+        cols2_6 = get_rows([2, 3, 4, 5, 6])
+        cols124 = get_rows([1, 2, 4])
+        col3 = get_rows([3])
+        cols15 = get_rows([1, 5])
+
         # U3 on column 6
         for i in range(len(theta)):
             squin.u3(theta[i], phi[i], lam[i], qubits[i][6])
-        squin.broadcast.single_qubit_pauli_channel(
-            local_px, local_py, local_pz, get_rows([6])
-        )
+        squin.broadcast.single_qubit_pauli_channel(local_px, local_py, local_pz, col6)
         if loss:
-            squin.broadcast.qubit_loss(local_loss_prob, get_rows([6]))
+            squin.broadcast.qubit_loss(local_loss_prob, col6)
 
         # sqrt_y_adj on columns 0-5
-        squin.broadcast.sqrt_y_adj(get_rows([0, 1, 2, 3, 4, 5]))
+        squin.broadcast.sqrt_y_adj(cols0_5)
         squin.broadcast.single_qubit_pauli_channel(
-            local_px, local_py, local_pz, get_rows([0, 1, 2, 3, 4, 5])
+            local_px, local_py, local_pz, cols0_5
         )
         if loss:
-            squin.broadcast.qubit_loss(local_loss_prob, get_rows([0, 1, 2, 3, 4, 5]))
+            squin.broadcast.qubit_loss(local_loss_prob, cols0_5)
 
         # CZ layer 1: controls=odds (sitters), targets=evens[1:] (movers)
-        squin.broadcast.cz(get_rows(odds), get_rows(evens[1:]))
+        squin.broadcast.cz(cols_odds, cols_evens_tail)
         squin.broadcast.single_qubit_pauli_channel(
-            sitter_px, sitter_py, sitter_pz, get_rows(odds)
+            sitter_px, sitter_py, sitter_pz, cols_odds
         )
         squin.broadcast.single_qubit_pauli_channel(
-            mover_px, mover_py, mover_pz, get_rows(evens[1:])
+            mover_px, mover_py, mover_pz, cols_evens_tail
         )
         if loss:
-            squin.broadcast.qubit_loss(sit_loss_prob, get_rows(odds))
-            squin.broadcast.qubit_loss(move_loss_prob, get_rows(evens[1:]))
+            squin.broadcast.qubit_loss(sit_loss_prob, cols_odds)
+            squin.broadcast.qubit_loss(move_loss_prob, cols_evens_tail)
 
         # sqrt_y on column 6
-        squin.broadcast.sqrt_y(get_rows([6]))
-        squin.broadcast.single_qubit_pauli_channel(
-            local_px, local_py, local_pz, get_rows([6])
-        )
+        squin.broadcast.sqrt_y(col6)
+        squin.broadcast.single_qubit_pauli_channel(local_px, local_py, local_pz, col6)
         if loss:
-            squin.broadcast.qubit_loss(local_loss_prob, get_rows([6]))
+            squin.broadcast.qubit_loss(local_loss_prob, col6)
 
         # CZ layer 2: controls=evens[:-1] (movers), targets=[3,5,6] (sitters)
-        squin.broadcast.cz(get_rows(evens[:-1]), get_rows([3, 5, 6]))
+        squin.broadcast.cz(cols_evens_head, cols_356)
         squin.broadcast.single_qubit_pauli_channel(
-            mover_px, mover_py, mover_pz, get_rows(evens[:-1])
+            mover_px, mover_py, mover_pz, cols_evens_head
         )
         squin.broadcast.single_qubit_pauli_channel(
-            sitter_px, sitter_py, sitter_pz, get_rows([3, 5, 6])
+            sitter_px, sitter_py, sitter_pz, cols_356
         )
         if loss:
-            squin.broadcast.qubit_loss(move_loss_prob, get_rows(evens[:-1]))
-            squin.broadcast.qubit_loss(sit_loss_prob, get_rows([3, 5, 6]))
+            squin.broadcast.qubit_loss(move_loss_prob, cols_evens_head)
+            squin.broadcast.qubit_loss(sit_loss_prob, cols_356)
 
         # sqrt_y on columns 2-6
-        squin.broadcast.sqrt_y(get_rows([2, 3, 4, 5, 6]))
+        squin.broadcast.sqrt_y(cols2_6)
         squin.broadcast.single_qubit_pauli_channel(
-            local_px, local_py, local_pz, get_rows([2, 3, 4, 5, 6])
+            local_px, local_py, local_pz, cols2_6
         )
         if loss:
-            squin.broadcast.qubit_loss(local_loss_prob, get_rows([2, 3, 4, 5, 6]))
+            squin.broadcast.qubit_loss(local_loss_prob, cols2_6)
 
         # CZ layer 3: controls=evens[:-1] (sitters), targets=odds (movers)
-        squin.broadcast.cz(get_rows(evens[:-1]), get_rows(odds))
+        squin.broadcast.cz(cols_evens_head, cols_odds)
         squin.broadcast.single_qubit_pauli_channel(
-            sitter_px, sitter_py, sitter_pz, get_rows(evens[:-1])
+            sitter_px, sitter_py, sitter_pz, cols_evens_head
         )
         squin.broadcast.single_qubit_pauli_channel(
-            mover_px, mover_py, mover_pz, get_rows(odds)
+            mover_px, mover_py, mover_pz, cols_odds
         )
         if loss:
-            squin.broadcast.qubit_loss(sit_loss_prob, get_rows(evens[:-1]))
-            squin.broadcast.qubit_loss(move_loss_prob, get_rows(odds))
+            squin.broadcast.qubit_loss(sit_loss_prob, cols_evens_head)
+            squin.broadcast.qubit_loss(move_loss_prob, cols_odds)
 
         # sqrt_y on [1, 2, 4]
-        squin.broadcast.sqrt_y(get_rows([1, 2, 4]))
+        squin.broadcast.sqrt_y(cols124)
         squin.broadcast.single_qubit_pauli_channel(
-            local_px, local_py, local_pz, get_rows([1, 2, 4])
+            local_px, local_py, local_pz, cols124
         )
         if loss:
-            squin.broadcast.qubit_loss(local_loss_prob, get_rows([1, 2, 4]))
+            squin.broadcast.qubit_loss(local_loss_prob, cols124)
 
         # X on column 3
-        squin.broadcast.x(get_rows([3]))
-        squin.broadcast.single_qubit_pauli_channel(
-            local_px, local_py, local_pz, get_rows([3])
-        )
+        squin.broadcast.x(col3)
+        squin.broadcast.single_qubit_pauli_channel(local_px, local_py, local_pz, col3)
         if loss:
-            squin.broadcast.qubit_loss(local_loss_prob, get_rows([3]))
+            squin.broadcast.qubit_loss(local_loss_prob, col3)
 
         # Z on [1, 5]
-        squin.broadcast.z(get_rows([1, 5]))
-        squin.broadcast.single_qubit_pauli_channel(
-            local_px, local_py, local_pz, get_rows([1, 5])
-        )
+        squin.broadcast.z(cols15)
+        squin.broadcast.single_qubit_pauli_channel(local_px, local_py, local_pz, cols15)
         if loss:
-            squin.broadcast.qubit_loss(local_loss_prob, get_rows([1, 5]))
+            squin.broadcast.qubit_loss(local_loss_prob, cols15)
 
         debug.info("End Steane7 Noisy Initialize")
 

--- a/python/bloqade/lanes/rewrite/move2squin/__init__.py
+++ b/python/bloqade/lanes/rewrite/move2squin/__init__.py
@@ -8,6 +8,7 @@ from .gates import (
 )
 from .noise import (
     InsertNoise as InsertNoise,
+    LogicalInitKernel as LogicalInitKernel,
     LogicalNoiseModelABC as LogicalNoiseModelABC,
     NoiseModelABC as NoiseModelABC,
     SimpleLogicalNoiseModel as SimpleLogicalNoiseModel,

--- a/python/bloqade/lanes/rewrite/move2squin/gates.py
+++ b/python/bloqade/lanes/rewrite/move2squin/gates.py
@@ -1,7 +1,6 @@
 import math
 from dataclasses import dataclass, field
 from functools import singledispatchmethod
-from typing import Any
 
 from bloqade.squin.gate import stmts as gate_stmts
 from kirin import ir
@@ -16,14 +15,13 @@ from bloqade.lanes.dialects import move
 
 from ... import utils
 from .base import AtomStateRewriter
+from .noise import LogicalInitKernel
 
 
 @dataclass
 class InsertGates(AtomStateRewriter):
     move_exec_analysis: ForwardFrame[atom.MoveExecution]
-    initialize_kernel: (
-        ir.Method[[float, float, float, ilist.IList[qubit.Qubit, Any]], None] | None
-    ) = None
+    initialize_kernel: LogicalInitKernel | None = None
     measurement_index_map: dict[ZoneAddress, dict[LocationAddress, int]] = field(
         init=False, default_factory=dict
     )
@@ -147,6 +145,10 @@ class InsertGates(AtomStateRewriter):
             return rewrite_abc.RewriteResult()
 
         nodes_to_insert: list[ir.Statement] = [tau := py.Constant(math.tau)]
+        theta_rads: list[ir.SSAValue] = []
+        phi_rads: list[ir.SSAValue] = []
+        lam_rads: list[ir.SSAValue] = []
+        regs: list[ir.SSAValue] = []
         for theta, phi, lam, locations in zip(
             node.thetas, node.phis, node.lams, node.location_addresses
         ):
@@ -158,8 +160,26 @@ class InsertGates(AtomStateRewriter):
             nodes_to_insert.append(phi_rad := py.Mult(tau.result, phi))
             nodes_to_insert.append(lam_rad := py.Mult(tau.result, lam))
             nodes_to_insert.append(reg_stmt := ilist.New(qubit_ssa))
-            inputs = (theta_rad.result, phi_rad.result, lam_rad.result, reg_stmt.result)
-            nodes_to_insert.append(func.Invoke(inputs, callee=self.initialize_kernel))
+            theta_rads.append(theta_rad.result)
+            phi_rads.append(phi_rad.result)
+            lam_rads.append(lam_rad.result)
+            regs.append(reg_stmt.result)
+
+        nodes_to_insert.append(thetas_reg := ilist.New(tuple(theta_rads)))
+        nodes_to_insert.append(phis_reg := ilist.New(tuple(phi_rads)))
+        nodes_to_insert.append(lams_reg := ilist.New(tuple(lam_rads)))
+        nodes_to_insert.append(qubits_reg := ilist.New(tuple(regs)))
+        nodes_to_insert.append(
+            func.Invoke(
+                (
+                    thetas_reg.result,
+                    phis_reg.result,
+                    lams_reg.result,
+                    qubits_reg.result,
+                ),
+                callee=self.initialize_kernel,
+            )
+        )
 
         for n in nodes_to_insert:
             n.insert_before(node)

--- a/python/bloqade/lanes/rewrite/move2squin/noise.py
+++ b/python/bloqade/lanes/rewrite/move2squin/noise.py
@@ -24,6 +24,22 @@ from .base import AtomStateRewriter
 
 Len = TypeVar("Len")
 
+LogicalInitKernel = ir.Method[
+    [
+        ilist.IList[float, Any],
+        ilist.IList[float, Any],
+        ilist.IList[float, Any],
+        ilist.IList[ilist.IList[qubit.Qubit, Any], Any],
+    ],
+    None,
+]
+"""Broadcasted logical-initialization kernel.
+
+Applies the state-prep circuit in parallel over ``N`` qubit groups. Takes
+per-group ``theta``/``phi``/``lam`` lists and a list of ``N`` seven-qubit
+registers, rather than a single group's scalars and register.
+"""
+
 
 class NoiseModelABC(abc.ABC):
     """Abstract base class for noise models used during move-to-squin compilation.
@@ -72,10 +88,7 @@ class NoiseModelABC(abc.ABC):
 
     def get_logical_initialize(
         self,
-    ) -> tuple[
-        ir.Method[[float, float, float, ilist.IList[qubit.Qubit, Any]], None] | None,
-        ir.Method[[float, float, float, ilist.IList[qubit.Qubit, Any]], None] | None,
-    ]:
+    ) -> tuple[LogicalInitKernel | None, LogicalInitKernel | None]:
         """Return (clean_kernel, noisy_kernel) for logical initialization.
 
         The clean kernel is used by InsertGates for the noiseless initialization.
@@ -126,12 +139,8 @@ class SimpleNoiseModel(NoiseModelABC):
     local_rz_noise: ir.Method[[ilist.IList[qubit.Qubit, Any], float], None]
     global_r_noise: ir.Method[[ilist.IList[qubit.Qubit, Any], float, float], None]
     local_r_noise: ir.Method[[ilist.IList[qubit.Qubit, Any], float, float], None]
-    logical_initialize_clean: (
-        ir.Method[[float, float, float, ilist.IList[qubit.Qubit, Any]], None] | None
-    ) = None
-    logical_initialize_noisy: (
-        ir.Method[[float, float, float, ilist.IList[qubit.Qubit, Any]], None] | None
-    ) = None
+    logical_initialize_clean: LogicalInitKernel | None = None
+    logical_initialize_noisy: LogicalInitKernel | None = None
 
     def get_logical_initialize(self):
         return self.logical_initialize_clean, self.logical_initialize_noisy
@@ -174,10 +183,7 @@ class LogicalNoiseModelABC(NoiseModelABC):
     @abc.abstractmethod
     def get_logical_initialize(
         self,
-    ) -> tuple[
-        ir.Method[[float, float, float, ilist.IList[qubit.Qubit, Any]], None],
-        ir.Method[[float, float, float, ilist.IList[qubit.Qubit, Any]], None],
-    ]:
+    ) -> tuple[LogicalInitKernel, LogicalInitKernel]:
         """Return ``(clean_kernel, noisy_kernel)`` for logical initialization.
 
         Both kernels must be provided. The clean kernel is used by InsertGates.
@@ -200,10 +206,7 @@ class SimpleLogicalNoiseModel(LogicalNoiseModelABC, SimpleNoiseModel):
 
     def get_logical_initialize(
         self,
-    ) -> tuple[
-        ir.Method[[float, float, float, ilist.IList[qubit.Qubit, Any]], None],
-        ir.Method[[float, float, float, ilist.IList[qubit.Qubit, Any]], None],
-    ]:
+    ) -> tuple[LogicalInitKernel, LogicalInitKernel]:
         assert (
             self.logical_initialize_clean is not None
         ), "logical_initialize_clean must be set"
@@ -216,12 +219,8 @@ class SimpleLogicalNoiseModel(LogicalNoiseModelABC, SimpleNoiseModel):
     def from_simple(
         cls,
         noise_model: SimpleNoiseModel,
-        logical_initialize_clean: ir.Method[
-            [float, float, float, ilist.IList[qubit.Qubit, Any]], None
-        ],
-        logical_initialize_noisy: ir.Method[
-            [float, float, float, ilist.IList[qubit.Qubit, Any]], None
-        ],
+        logical_initialize_clean: LogicalInitKernel,
+        logical_initialize_noisy: LogicalInitKernel,
     ) -> "SimpleLogicalNoiseModel":
         """Create from an existing :class:`SimpleNoiseModel` plus init kernels."""
         return cls(
@@ -242,9 +241,7 @@ class SimpleLogicalNoiseModel(LogicalNoiseModelABC, SimpleNoiseModel):
 class InsertNoise(AtomStateRewriter):
     atom_state_map: ForwardFrame[atom.MoveExecution]
     noise_model: NoiseModelABC
-    initialize_noise_kernel: (
-        ir.Method[[float, float, float, ilist.IList[qubit.Qubit, Any]], None] | None
-    ) = None
+    initialize_noise_kernel: LogicalInitKernel | None = None
 
     def rewrite_Statement(self, node: ir.Statement) -> rewrite_abc.RewriteResult:
         if (trait := node.get_trait(move.EmitsState)) is None:
@@ -357,6 +354,10 @@ class InsertNoise(AtomStateRewriter):
             return rewrite_abc.RewriteResult()
 
         nodes_to_insert: list[ir.Statement] = [tau := py.Constant(math.tau)]
+        theta_rads: list[ir.SSAValue] = []
+        phi_rads: list[ir.SSAValue] = []
+        lam_rads: list[ir.SSAValue] = []
+        regs: list[ir.SSAValue] = []
         for theta, phi, lam, locations in zip(
             node.thetas, node.phis, node.lams, node.location_addresses
         ):
@@ -368,15 +369,26 @@ class InsertNoise(AtomStateRewriter):
             nodes_to_insert.append(phi_rad := py.Mult(tau.result, phi))
             nodes_to_insert.append(lam_rad := py.Mult(tau.result, lam))
             nodes_to_insert.append(reg_stmt := ilist.New(qubit_ssa))
-            inputs = (
-                theta_rad.result,
-                phi_rad.result,
-                lam_rad.result,
-                reg_stmt.result,
+            theta_rads.append(theta_rad.result)
+            phi_rads.append(phi_rad.result)
+            lam_rads.append(lam_rad.result)
+            regs.append(reg_stmt.result)
+
+        nodes_to_insert.append(thetas_reg := ilist.New(tuple(theta_rads)))
+        nodes_to_insert.append(phis_reg := ilist.New(tuple(phi_rads)))
+        nodes_to_insert.append(lams_reg := ilist.New(tuple(lam_rads)))
+        nodes_to_insert.append(qubits_reg := ilist.New(tuple(regs)))
+        nodes_to_insert.append(
+            func.Invoke(
+                (
+                    thetas_reg.result,
+                    phis_reg.result,
+                    lams_reg.result,
+                    qubits_reg.result,
+                ),
+                callee=self.initialize_noise_kernel,
             )
-            nodes_to_insert.append(
-                func.Invoke(inputs, callee=self.initialize_noise_kernel)
-            )
+        )
 
         for n in reversed(nodes_to_insert):
             n.insert_after(node)

--- a/python/bloqade/lanes/transform.py
+++ b/python/bloqade/lanes/transform.py
@@ -1,28 +1,26 @@
 import abc
 from dataclasses import dataclass, field
-from typing import Any
 
 from bloqade.rewrite.passes import aggressive_unroll as agg
 from bloqade.squin.rewrite import SquinU3ToClifford
 from kirin import ir, rewrite
-from kirin.dialects import ilist, scf
+from kirin.dialects import scf
 from kirin.passes import TypeInfer
 
-from bloqade import qubit, squin
+from bloqade import squin
 from bloqade.lanes.analysis import atom
 from bloqade.lanes.arch.spec import ArchSpec
 from bloqade.lanes.dialects import move
 from bloqade.lanes.rewrite import move2squin
 from bloqade.lanes.rewrite.move2squin import (
+    LogicalInitKernel as LogicalInitKernel,
     LogicalNoiseModelABC as LogicalNoiseModelABC,
     NoiseModelABC as NoiseModelABC,
     SimpleLogicalNoiseModel as SimpleLogicalNoiseModel,
     SimpleNoiseModel as SimpleNoiseModel,
 )
 
-InitKernel = (
-    ir.Method[[float, float, float, ilist.IList[qubit.Qubit, Any]], None] | None
-)
+InitKernel = LogicalInitKernel | None
 
 
 @dataclass

--- a/python/tests/benchmarks/test_runner.py
+++ b/python/tests/benchmarks/test_runner.py
@@ -110,7 +110,9 @@ def test_estimate_fidelity_runs_for_logical_mode(monkeypatch):
     assert calls["emit_move_mt"] is fake_move_mt
     assert calls["transform_noise_model"] is fake_noise_model
     assert calls["transform_add_noise"] is True
-    assert calls["transform_aggressive_unroll"] is False
+    # Broadcasted state-prep loops must be fully unrolled so FidelityAnalysis
+    # can see the per-qubit noise channels.
+    assert calls["transform_aggressive_unroll"] is True
 
 
 def test_estimate_fidelity_runs_for_physical_mode(monkeypatch):

--- a/python/tests/rewrite/move2squin/test_gate.py
+++ b/python/tests/rewrite/move2squin/test_gate.py
@@ -17,7 +17,10 @@ from bloqade.lanes.rewrite.move2squin import base, gates
 
 @squin.kernel
 def initialize(
-    theta: float, phi: float, lam: float, qubits: ilist.IList[bloqade_types.Qubit, Any]
+    theta: ilist.IList[float, Any],
+    phi: ilist.IList[float, Any],
+    lam: ilist.IList[float, Any],
+    qubits: ilist.IList[ilist.IList[bloqade_types.Qubit, Any], Any],
 ):
     return
 
@@ -403,20 +406,25 @@ def test_gate_rewrite_physical_initialize():
     expected_block = ir.Block(
         [
             tau := py.Constant(math.tau),
-            theta_rad := py.Mult(tau.result, theta),
-            phi_rad := py.Mult(tau.result, phi),
-            lam_rad := py.Mult(tau.result, lam),
+            theta_rad_0 := py.Mult(tau.result, theta),
+            phi_rad_0 := py.Mult(tau.result, phi),
+            lam_rad_0 := py.Mult(tau.result, lam),
             zero_reg := ilist.New((zero,)),
-            func.Invoke(
-                (theta_rad.result, phi_rad.result, lam_rad.result, zero_reg.result),
-                callee=initialize,
-            ),
-            theta_rad := py.Mult(tau.result, theta),
-            phi_rad := py.Mult(tau.result, phi),
-            lam_rad := py.Mult(tau.result, lam),
+            theta_rad_1 := py.Mult(tau.result, theta),
+            phi_rad_1 := py.Mult(tau.result, phi),
+            lam_rad_1 := py.Mult(tau.result, lam),
             one_reg := ilist.New((one,)),
+            thetas_reg := ilist.New((theta_rad_0.result, theta_rad_1.result)),
+            phis_reg := ilist.New((phi_rad_0.result, phi_rad_1.result)),
+            lams_reg := ilist.New((lam_rad_0.result, lam_rad_1.result)),
+            qubits_reg := ilist.New((zero_reg.result, one_reg.result)),
             func.Invoke(
-                (theta_rad.result, phi_rad.result, lam_rad.result, one_reg.result),
+                (
+                    thetas_reg.result,
+                    phis_reg.result,
+                    lams_reg.result,
+                    qubits_reg.result,
+                ),
                 callee=initialize,
             ),
             gate_node,

--- a/python/tests/rewrite/move2squin/test_noise.py
+++ b/python/tests/rewrite/move2squin/test_noise.py
@@ -1,10 +1,11 @@
+import math
 from typing import Any
 
 from bloqade.test_utils import assert_nodes
 from bloqade.types import Qubit as Qubit
 from kirin import ir, rewrite
 from kirin.analysis import forward
-from kirin.dialects import func, ilist
+from kirin.dialects import func, ilist, py
 
 from bloqade import qubit, squin
 from bloqade.lanes.analysis import atom
@@ -62,6 +63,16 @@ def global_r_noise_kernel(
 @squin.kernel
 def local_r_noise_kernel(
     qubits: ilist.IList[qubit.Qubit, Any], theta: float, phi: float
+):
+    return
+
+
+@squin.kernel
+def initialize_noise_kernel(
+    theta: ilist.IList[float, Any],
+    phi: ilist.IList[float, Any],
+    lam: ilist.IList[float, Any],
+    qubits: ilist.IList[ilist.IList[qubit.Qubit, Any], Any],
 ):
     return
 
@@ -353,6 +364,93 @@ def test_insert_global_gate_noise():
             func.Invoke(
                 inputs=(reg.result, axis_angle, rotation_angle),
                 callee=global_r_noise_kernel,
+            ),
+        ]
+    )
+
+    assert_nodes(test_block, expected_block)
+
+
+def test_insert_physical_initialize_noise():
+    state = ir.TestValue()
+    theta = ir.TestValue()
+    phi = ir.TestValue()
+    lam = ir.TestValue()
+    test_block = ir.Block(
+        [
+            node := move.PhysicalInitialize(
+                current_state=state,
+                thetas=(theta, theta),
+                phis=(phi, phi),
+                lams=(lam, lam),
+                location_addresses=(
+                    (LocationAddress(0, 0),),
+                    (LocationAddress(1, 0),),
+                ),
+            )
+        ]
+    )
+
+    physical_ssa_values = {
+        0: (zero := ir.TestValue()),
+        1: (one := ir.TestValue()),
+    }
+    atom_state: Any = atom.AtomState(
+        data=atom.AtomStateData.new(
+            {
+                0: LocationAddress(0, 0),
+                1: LocationAddress(1, 0),
+            }
+        )
+    )
+    atom_state_map = forward.ForwardFrame(node, entries={node.result: atom_state})
+
+    rewrite.Walk(
+        noise.InsertNoise(
+            arch_spec=get_arch_spec(),
+            physical_ssa_values=physical_ssa_values,  # type: ignore
+            atom_state_map=atom_state_map,
+            noise_model=MODEL,
+            initialize_noise_kernel=initialize_noise_kernel,
+        )
+    ).rewrite(test_block)
+
+    # The noisy kernel is invoked once with the per-group angles and registers
+    # packed into ilists (broadcast over all logical qubits), inserted after the
+    # PhysicalInitialize node.
+    expected_block = ir.Block(
+        [
+            move.PhysicalInitialize(
+                current_state=state,
+                thetas=(theta, theta),
+                phis=(phi, phi),
+                lams=(lam, lam),
+                location_addresses=(
+                    (LocationAddress(0, 0),),
+                    (LocationAddress(1, 0),),
+                ),
+            ),
+            tau := py.Constant(math.tau),
+            theta_rad_0 := py.Mult(tau.result, theta),
+            phi_rad_0 := py.Mult(tau.result, phi),
+            lam_rad_0 := py.Mult(tau.result, lam),
+            zero_reg := ilist.New((zero,)),
+            theta_rad_1 := py.Mult(tau.result, theta),
+            phi_rad_1 := py.Mult(tau.result, phi),
+            lam_rad_1 := py.Mult(tau.result, lam),
+            one_reg := ilist.New((one,)),
+            thetas_reg := ilist.New((theta_rad_0.result, theta_rad_1.result)),
+            phis_reg := ilist.New((phi_rad_0.result, phi_rad_1.result)),
+            lams_reg := ilist.New((lam_rad_0.result, lam_rad_1.result)),
+            qubits_reg := ilist.New((zero_reg.result, one_reg.result)),
+            func.Invoke(
+                (
+                    thetas_reg.result,
+                    phis_reg.result,
+                    lams_reg.result,
+                    qubits_reg.result,
+                ),
+                callee=initialize_noise_kernel,
             ),
         ]
     )


### PR DESCRIPTION
## Summary

Rewrites the Steane state-prep so it is emitted as a **single broadcasted kernel invoke** running in parallel across all logical qubits, instead of one invoke per logical qubit. This is the structural change behind the diagram-rendering fix for #641.

Previously, `MoveToSquin` rewrote each `PhysicalInitialize` set into its own sequential block (one `func.Invoke` of the single-qubit state-prep per logical qubit). In the Stim diagram those rendered as disjoint, sequential layers rather than one parallel layer.

## Changes

- Add `steane7_initialize_broadcast` and a noisy broadcast kernel that apply the Steane [[7,1,3]] state-prep in parallel over `N` logical qubits. Both transpose the `list[list[qubit]]` so the `squin.broadcast.*` operands group by physical column (correct CZ pairing / layout alignment).
- `steane7_initialize` is now a thin single-qubit shim over the broadcast kernel (kept for direct single-register use, e.g. `demo/steane_demo.py`).
- `steane7_initialize_with_noise` returns the broadcast `(clean, noisy)` kernels.
- `InsertGates` (clean) and `InsertNoise` (noisy) `PhysicalInitialize` rewriters now build the per-group `theta`/`phi`/`lam` ilists and the list of registers once, and emit **one** broadcast invoke.
- Add `LogicalInitKernel` / `BroadcastInitKernel` type aliases for the broadcast signature and thread them through the noise model and transform passes.

## Verification

- Full Python suite green (1432 passed, 9 skipped).
- black / isort / ruff / pyright clean on touched modules.
- End-to-end: a 3-logical-qubit circuit now compiles to exactly **1** init-kernel invoke for both the clean (`add_noise=False`) and noisy (`add_noise=True`) paths (was 3).

## Related

- Part of #641 (diagram rendering of injected state-prep).

> ⚠️ **Do not close #641 when this merges.** Fully aligning the diagram layers also requires the upstream Stim change tracked in QuEraComputing/bloqade-circuit#816 (option to insert `TICK` between gates so Stim renders in execution order instead of ASAP). #641 should stay open until that upstream issue is resolved. This PR is intentionally written as "Part of" rather than "Closes".

## Notes

- The unrelated `ipywidgets[sim]` dependency change currently in the working tree was intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
