### PR TITLE
feat: changed default context_name in GeminiTaskMixin

### DIFF
--- a/python/bloqade/gemini/device/logical/task.py
+++ b/python/bloqade/gemini/device/logical/task.py
@@ -23,7 +23,7 @@ class GeminiTaskMixin:
 
     program_language: str = "squin"
     future_cls: type[GeminiLogicalFuture] = GeminiLogicalFuture
-    context_name: str = "gemini-logical"
+    context_name: str = "gemini-squin-logical-10q"
 
     @property
     def program_language_version(self) -> str:


### PR DESCRIPTION
Setting context_name to be "gemini-squin-logical-10q".