### PR TITLE
ci(backport): force-with-lease push so re-runs update the backport branch

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -160,7 +160,7 @@ jobs:
 
                 // Commit, push, and create PR
                 execSync(`git commit -m "Backport PR #${prNum} (${commit}) to ${branch}"`);
-                execSync(`git push origin ${backportBranch}`);
+                execSync(`git push --force-with-lease origin ${backportBranch}`);
                 const pr = await github.rest.pulls.create({
                   owner: context.repo.owner,
                   repo: context.repo.repo,


### PR DESCRIPTION
## Summary

Changes the backport workflow's push from a plain `git push` to `git push --force-with-lease` when creating the per-version backport branch.

**Why:** on a re-run (e.g. you resolve a cherry-pick conflict and re-trigger, or a prior run already created `release-X-Y-backport-prN` on origin), a plain `git push` fails with a non-fast-forward / ref-exists error and the backport silently breaks. `--force-with-lease` updates the existing branch safely — it only overwrites if the remote ref is still what we expect, so it won't clobber unrelated work.

This aligns our workflow with the equivalent in `bloqade-core`.

## Test plan
- [ ] Re-trigger a backport for a PR whose `release-X-Y-backport-prN` branch already exists → push now succeeds and updates the branch instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)