### PR TITLE
feat(search): conflict-graph clique strategy for AOD grid construction

### DIFF
--- a/crates/bloqade-lanes-bytecode-cli/src/policy/eval.rs
+++ b/crates/bloqade-lanes-bytecode-cli/src/policy/eval.rs
@@ -80,6 +80,7 @@ fn run_move(
                 .or(mp.budget.as_ref().map(|b| b.timeout_s))
                 .unwrap_or(10.0),
         ),
+        ..PolicyOptions::default()
     };
     let mut obs = NoOpMoveObserver;
     let t0 = Instant::now();

--- a/crates/bloqade-lanes-bytecode-cli/src/policy/trace.rs
+++ b/crates/bloqade-lanes-bytecode-cli/src/policy/trace.rs
@@ -84,6 +84,7 @@ fn trace_move(
                 .or(mp.budget.as_ref().map(|b| b.timeout_s))
                 .unwrap_or(10.0),
         ),
+        ..PolicyOptions::default()
     };
 
     if json {

--- a/crates/bloqade-lanes-bytecode-python/src/policy_runner_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/policy_runner_python.rs
@@ -288,6 +288,7 @@ impl PyPolicyRunner {
             max_expansions: max_expansions.unwrap_or(100_000),
             timeout_s,
             sandbox: bloqade_lanes_dsl_core::sandbox::SandboxConfig::default(),
+            ..PolicyOptions::default()
         };
 
         let index = Arc::clone(&self.index);

--- a/crates/bloqade-lanes-bytecode-python/src/search_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/search_python.rs
@@ -896,6 +896,7 @@ impl PyEntropyOptions {
                 w_t,
                 collect_entropy_trace,
                 seed,
+                ..EntropyOptions::default()
             },
         })
     }

--- a/crates/bloqade-lanes-search/src/drivers/entropy.rs
+++ b/crates/bloqade-lanes-search/src/drivers/entropy.rs
@@ -28,6 +28,7 @@ use crate::primitives::ordering::{
     cmp_triplet_entry_tiebreak,
 };
 use crate::primitives::path::find_path_occupied;
+use crate::search::options::AodGridStrategy;
 use crate::traits::Goal;
 use bloqade_lanes_bytecode_core::arch::addr::{Direction, LaneAddr, LocationAddr, MoveType};
 use rand::rngs::SmallRng;
@@ -295,6 +296,8 @@ pub struct EntropyParams {
     pub lookahead: bool,
     /// Time-distance blend weight (0.0 = hop-count only, 1.0 = time only).
     pub w_t: f64,
+    /// Strategy for AOD grid construction from selected movers.
+    pub aod_grid_strategy: AodGridStrategy,
 }
 
 impl Default for EntropyParams {
@@ -313,6 +316,7 @@ impl Default for EntropyParams {
             max_movesets_per_group: 3,
             lookahead: false,
             w_t: 0.95,
+            aod_grid_strategy: AodGridStrategy::default(),
         }
     }
 }
@@ -391,6 +395,7 @@ fn build_deadlock_breaker_candidate(
     occupied: &HashSet<u64>,
     all_scores: &[(TripletKey, ScoredEntry)],
     ctx: &SearchContext,
+    aod_grid_strategy: AodGridStrategy,
 ) -> Option<(f64, MoveSet, Config)> {
     let unresolved: HashSet<u32> = ctx
         .targets
@@ -414,7 +419,8 @@ fn build_deadlock_breaker_candidate(
     for ((mt_u8, bus_id, dir_u8), mut qubits) in groups {
         qubits.sort_by(cmp_group_entries);
         let (mt, dir) = decode_triplet_key(mt_u8, dir_u8);
-        let grid_ctx = BusGridContext::new(ctx.index, mt, bus_id, None, dir, occupied);
+        let grid_ctx = BusGridContext::new(ctx.index, mt, bus_id, None, dir, occupied)
+            .with_strategy(aod_grid_strategy);
 
         let mut entries: HashMap<u64, u64> = HashMap::new();
         let mut entry_by_lane: HashMap<u64, ScoredEntry> = HashMap::new();
@@ -959,7 +965,8 @@ pub(crate) fn generate_candidates(
         qubits.sort_by(cmp_group_entries);
         let (mt, dir) = decode_triplet_key(mt_u8, dir_u8);
 
-        let grid_ctx = BusGridContext::new(ctx.index, mt, bus_id, None, dir, &occupied);
+        let grid_ctx = BusGridContext::new(ctx.index, mt, bus_id, None, dir, &occupied)
+            .with_strategy(params.aod_grid_strategy);
 
         let mut entries: HashMap<u64, u64> = HashMap::new();
         let mut entry_by_lane: HashMap<u64, &ScoredEntry> = HashMap::new();
@@ -1018,8 +1025,13 @@ pub(crate) fn generate_candidates(
 
     let mut used_deadlock_breaker = false;
     if candidates.is_empty()
-        && let Some(deadlock_breaker) =
-            build_deadlock_breaker_candidate(config, &occupied, &all_scores, ctx)
+        && let Some(deadlock_breaker) = build_deadlock_breaker_candidate(
+            config,
+            &occupied,
+            &all_scores,
+            ctx,
+            params.aod_grid_strategy,
+        )
     {
         candidates.push(deadlock_breaker);
         used_deadlock_breaker = true;
@@ -2619,6 +2631,60 @@ mod tests {
             trace.steps.iter().any(|step| step.event == "descend"
                 && step.reason.as_deref() == Some("deadlock-breaker")),
             "expected descend step marked with deadlock-breaker reason in trace"
+        );
+    }
+
+    /// E2E wiring test: `EntropyParams::aod_grid_strategy = Clique` reaches
+    /// `generate_candidates` and produces a valid moveset (grids non-empty,
+    /// both movers covered) on a 2-qubit multi-mover fixture.
+    ///
+    /// Fixture mirrors `generate_candidates_emit_aod_rectangles` exactly.
+    #[test]
+    fn aod_grid_strategy_clique_wiring_produces_valid_moveset() {
+        let index = make_index();
+        let config = Config::new([(0, loc(0, 0)), (1, loc(0, 1))]).unwrap();
+        let target_encoded = vec![(0u32, loc(0, 5).encode()), (1u32, loc(0, 6).encode())];
+        let target_locs: Vec<u64> = target_encoded.iter().map(|&(_, enc)| enc).collect();
+        let dist_table = DistanceTable::new(&target_locs, &index);
+        let blocked = HashSet::new();
+        let ctx = SearchContext {
+            index: &index,
+            dist_table: &dist_table,
+            blocked: &blocked,
+            targets: &target_encoded,
+            cz_pairs: None,
+        };
+        let params = EntropyParams {
+            max_movesets_per_group: 4,
+            aod_grid_strategy: AodGridStrategy::Clique,
+            ..EntropyParams::default()
+        };
+
+        let out = generate_candidates(&config, 1, &params, &ctx, 0);
+
+        // At least one candidate must be produced.
+        assert!(
+            !out.is_empty(),
+            "Clique strategy must produce at least one moveset candidate"
+        );
+
+        // Every candidate's moveset must be non-empty (grids non-empty).
+        for (moveset, _, _, _) in &out {
+            assert!(
+                !moveset.encoded_lanes().is_empty(),
+                "moveset lanes must be non-empty"
+            );
+        }
+
+        // At least one candidate must move at least one of the two movers.
+        let any_mover_covered = out.iter().any(|(moveset, new_cfg, _, _)| {
+            let _ = moveset;
+            new_cfg.location_of(0) != config.location_of(0)
+                || new_cfg.location_of(1) != config.location_of(1)
+        });
+        assert!(
+            any_mover_covered,
+            "Clique strategy must produce a candidate that moves at least one qubit"
         );
     }
 }

--- a/crates/bloqade-lanes-search/src/dsl/move_policy_dsl/kernel.rs
+++ b/crates/bloqade-lanes-search/src/dsl/move_policy_dsl/kernel.rs
@@ -52,6 +52,7 @@ use crate::primitives::config::Config;
 use crate::primitives::distance::DistanceTable;
 use crate::primitives::graph::{MoveSet, NodeId, SearchGraph};
 use crate::primitives::lane_index::LaneIndex;
+use crate::search::options::AodGridStrategy;
 
 // ── public types ─────────────────────────────────────────────────────────
 
@@ -74,6 +75,8 @@ pub struct PolicyOptions {
     pub timeout_s: Option<f64>,
     /// Sandbox config for the per-solve evaluator.
     pub sandbox: SandboxConfig,
+    /// Strategy for AOD grid construction from selected movers.
+    pub aod_grid_strategy: AodGridStrategy,
 }
 
 impl Default for PolicyOptions {
@@ -84,6 +87,7 @@ impl Default for PolicyOptions {
             max_expansions: 10_000,
             timeout_s: None,
             sandbox: SandboxConfig::default(),
+            aod_grid_strategy: AodGridStrategy::default(),
         }
     }
 }
@@ -236,6 +240,7 @@ pub fn solve_with_policy(
         dist_table: dist_table.clone(),
         targets: target_pairs.clone(),
         blocked: blocked_set.clone(),
+        aod_grid_strategy: opts.aod_grid_strategy,
     };
     let ctx = Ctx::new(target_pairs.clone(), blocked_set.clone(), arch_wrap);
 
@@ -1028,6 +1033,7 @@ def step(graph, gs, ctx, lib):
             max_expansions: 100,
             timeout_s: Some(5.0),
             sandbox: SandboxConfig::default(),
+            aod_grid_strategy: AodGridStrategy::default(),
         };
 
         let result = solve_with_policy(
@@ -1077,6 +1083,7 @@ def step(graph, gs, ctx, lib):
             max_expansions: 1000,
             timeout_s: Some(5.0),
             sandbox: SandboxConfig::default(),
+            aod_grid_strategy: AodGridStrategy::default(),
         };
 
         let result = solve_with_policy(

--- a/crates/bloqade-lanes-search/src/dsl/move_policy_dsl/lib_move.rs
+++ b/crates/bloqade-lanes-search/src/dsl/move_policy_dsl/lib_move.rs
@@ -30,6 +30,7 @@ use crate::dsl::pipeline::{
 use crate::primitives::config::Config;
 use crate::primitives::distance::DistanceTable;
 use crate::primitives::lane_index::LaneIndex;
+use crate::search::options::AodGridStrategy;
 
 // ── StarlarkConfig ─────────────────────────────────────────────────────
 
@@ -327,6 +328,8 @@ pub struct LibMove {
     pub(super) targets: Vec<(u32, u64)>,
     /// Locations blocked from use as move destinations.
     pub(super) blocked: HashSet<u64>,
+    /// Strategy for AOD grid construction from selected movers.
+    pub(super) aod_grid_strategy: AodGridStrategy,
 }
 
 impl allocative::Allocative for LibMove {
@@ -588,8 +591,13 @@ fn register_lib_methods(builder: &mut starlark::environment::MethodsBuilder) {
         let raw_scored = unpack_scored_list(scored)?;
         let raw_groups = pipeline_group_by_triplet(raw_scored);
 
-        let candidates =
-            pipeline_pack_aod_rectangles(raw_groups, &config.0, &this.index, &this.blocked);
+        let candidates = pipeline_pack_aod_rectangles(
+            raw_groups,
+            &config.0,
+            &this.index,
+            &this.blocked,
+            this.aod_grid_strategy,
+        );
         let items: Vec<Value<'v>> = candidates
             .into_iter()
             .map(|c| heap.alloc(StarlarkPackedCandidate(c)))

--- a/crates/bloqade-lanes-search/src/dsl/move_policy_dsl/observer.rs
+++ b/crates/bloqade-lanes-search/src/dsl/move_policy_dsl/observer.rs
@@ -219,6 +219,7 @@ mod tests {
 
         use crate::dsl::move_policy_dsl::kernel::{PolicyOptions, solve_with_policy};
         use crate::primitives::lane_index::LaneIndex;
+        use crate::search::options::AodGridStrategy;
         use crate::test_utils::example_arch_json;
 
         let spec: ArchSpec = serde_json::from_str(example_arch_json()).unwrap();
@@ -240,6 +241,7 @@ mod tests {
             max_expansions: 32,
             timeout_s: Some(1.0),
             sandbox: SandboxConfig::default(),
+            aod_grid_strategy: AodGridStrategy::default(),
         };
 
         let mut obs = RecordingObserver::default();
@@ -283,6 +285,7 @@ mod tests {
 
         use crate::dsl::move_policy_dsl::kernel::{PolicyOptions, solve_with_policy};
         use crate::primitives::lane_index::LaneIndex;
+        use crate::search::options::AodGridStrategy;
         use crate::test_utils::{example_arch_json, lane, loc};
 
         let spec: ArchSpec = serde_json::from_str(example_arch_json()).unwrap();
@@ -321,6 +324,7 @@ mod tests {
             max_expansions: 32,
             timeout_s: Some(2.0),
             sandbox: SandboxConfig::default(),
+            aod_grid_strategy: AodGridStrategy::default(),
         };
 
         let mut obs = RecordingObserver::default();

--- a/crates/bloqade-lanes-search/src/dsl/pipeline.rs
+++ b/crates/bloqade-lanes-search/src/dsl/pipeline.rs
@@ -30,6 +30,7 @@ use crate::primitives::config::Config;
 use crate::primitives::graph::MoveSet;
 use crate::primitives::lane_index::LaneIndex;
 use crate::primitives::ordering::cmp_moveset_config_tiebreak;
+use crate::search::options::AodGridStrategy;
 
 /// One scored `(qubit, lane)` pair produced by Stage 1 of the pipeline.
 #[derive(Debug, Clone)]
@@ -85,6 +86,7 @@ pub(crate) fn pack_aod_rectangles(
     config: &Config,
     index: &LaneIndex,
     blocked: &HashSet<u64>,
+    aod_grid_strategy: AodGridStrategy,
 ) -> Vec<PackedCandidate> {
     // Build occupied set: blocked locations + qubits already in this config.
     let mut occupied: HashSet<u64> = HashSet::with_capacity(blocked.len() + config.len());
@@ -109,7 +111,8 @@ pub(crate) fn pack_aod_rectangles(
         };
 
         // Build the grid context across all zones for the bus.
-        let grid_ctx = BusGridContext::new(index, mt, bus_id, None, dir, &occupied);
+        let grid_ctx = BusGridContext::new(index, mt, bus_id, None, dir, &occupied)
+            .with_strategy(aod_grid_strategy);
 
         // Build src→lane entries and lane→entry lookup for score lifting
         // and destination derivation.
@@ -257,7 +260,13 @@ mod tests {
         }];
         let groups = group_by_triplet(scored);
         let blocked = HashSet::new();
-        let candidates = pack_aod_rectangles(groups, &config, &index, &blocked);
+        let candidates = pack_aod_rectangles(
+            groups,
+            &config,
+            &index,
+            &blocked,
+            AodGridStrategy::default(),
+        );
         assert!(
             !candidates.is_empty(),
             "should produce at least one candidate"
@@ -288,7 +297,13 @@ mod tests {
             score: 3.0,
         }];
         let groups = group_by_triplet(scored);
-        let candidates = pack_aod_rectangles(groups, &config, &index, &blocked);
+        let candidates = pack_aod_rectangles(
+            groups,
+            &config,
+            &index,
+            &blocked,
+            AodGridStrategy::default(),
+        );
         // No candidate should land qubit 0 on the blocked destination.
         for c in &candidates {
             assert_ne!(c.new_config.location_of(0), Some(dst));

--- a/crates/bloqade-lanes-search/src/generators/greedy.rs
+++ b/crates/bloqade-lanes-search/src/generators/greedy.rs
@@ -16,6 +16,7 @@ use crate::primitives::config::Config;
 use crate::primitives::context::{MoveCandidate, SearchContext, SearchState};
 use crate::primitives::graph::{MoveSet, NodeId};
 use crate::primitives::path::find_path_occupied;
+use crate::search::options::AodGridStrategy;
 use crate::traits::MoveGenerator;
 
 /// Greedy shortest-path move generator.
@@ -23,7 +24,24 @@ use crate::traits::MoveGenerator;
 /// Routes each unresolved qubit along the shortest path to its target,
 /// takes the first lane, groups by bus parameters, and builds
 /// AOD-compatible rectangular grids.
-pub struct GreedyGenerator;
+#[derive(Default)]
+pub struct GreedyGenerator {
+    /// Strategy for AOD grid construction from selected movers.
+    pub aod_grid_strategy: AodGridStrategy,
+}
+
+impl GreedyGenerator {
+    /// Create a new greedy generator with default settings.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Select the AOD grid construction strategy.
+    pub fn with_aod_grid_strategy(mut self, strategy: AodGridStrategy) -> Self {
+        self.aod_grid_strategy = strategy;
+        self
+    }
+}
 
 impl MoveGenerator for GreedyGenerator {
     fn generate(
@@ -90,7 +108,8 @@ impl MoveGenerator for GreedyGenerator {
 
         // 4. For each group, build AOD grids and emit candidates.
         for ((mt, bus_id, dir), entries) in &groups {
-            let grid_ctx = BusGridContext::new(index, *mt, *bus_id, None, *dir, &occupied);
+            let grid_ctx = BusGridContext::new(index, *mt, *bus_id, None, *dir, &occupied)
+                .with_strategy(self.aod_grid_strategy);
             let grids = grid_ctx.build_aod_grids(entries);
 
             for grid in grids {
@@ -156,7 +175,7 @@ mod tests {
 
         let config = Config::new([(0, loc(0, 0))]).unwrap();
         let mut out = Vec::new();
-        GreedyGenerator.generate(&config, NodeId(0), &ctx, &mut state, &mut out);
+        GreedyGenerator::new().generate(&config, NodeId(0), &ctx, &mut state, &mut out);
 
         assert!(!out.is_empty(), "should produce at least one candidate");
 
@@ -197,7 +216,7 @@ mod tests {
 
         let config = Config::new([(0, loc(0, 0))]).unwrap();
         let mut out = Vec::new();
-        GreedyGenerator.generate(&config, NodeId(0), &ctx, &mut state, &mut out);
+        GreedyGenerator::new().generate(&config, NodeId(0), &ctx, &mut state, &mut out);
 
         assert!(out.is_empty(), "no candidates when qubit already at target");
     }

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -26,6 +26,7 @@ use crate::primitives::lane_index::LaneIndex;
 use crate::primitives::ordering::{
     TripletKey, cmp_moveset_config_tiebreak, cmp_triplet_entry_tiebreak,
 };
+use crate::search::options::AodGridStrategy;
 use crate::traits::MoveGenerator;
 
 /// Policy for handling deadlocks (no improving moves available).
@@ -101,6 +102,8 @@ pub struct HeuristicGenerator {
     top_c: Option<usize>,
     /// Counter for deadlock occurrences (single-threaded; each restart gets its own generator).
     deadlock_count: Cell<u32>,
+    /// Strategy for AOD grid construction from selected movers.
+    aod_grid_strategy: AodGridStrategy,
 }
 
 impl Default for HeuristicGenerator {
@@ -118,7 +121,14 @@ impl HeuristicGenerator {
             seed: 0,
             top_c: None,
             deadlock_count: Cell::new(0),
+            aod_grid_strategy: AodGridStrategy::default(),
         }
+    }
+
+    /// Select the AOD grid construction strategy.
+    pub fn with_aod_grid_strategy(mut self, strategy: AodGridStrategy) -> Self {
+        self.aod_grid_strategy = strategy;
+        self
     }
 
     /// Set the deadlock escape policy.
@@ -553,7 +563,8 @@ impl MoveGenerator for HeuristicGenerator {
             // Build grid context from ALL lanes on this bus group (cross-zone).
             let grid_ctx = crate::ops::aod_grid::BusGridContext::new(
                 ctx.index, mt, bus_id, None, dir, &occupied,
-            );
+            )
+            .with_strategy(self.aod_grid_strategy);
 
             // Build entries (src_encoded -> lane_encoded) and a lane -> triple lookup.
             // Each source location has at most one atom, so no overwrites occur.

--- a/crates/bloqade-lanes-search/src/ops/aod_grid.rs
+++ b/crates/bloqade-lanes-search/src/ops/aod_grid.rs
@@ -1,8 +1,16 @@
-//! Two-phase AOD grid construction for the heuristic expander.
+//! AOD grid construction for the heuristic expander.
 //!
-//! Ports the Python `BusContext.build_aod_grids()` algorithm: a greedy
-//! sequential pass forms initial rectangular clusters, then an iterative
-//! merge pass combines compatible clusters into larger rectangles.
+//! `build_aod_grids` dispatches between two strategies based on
+//! [`BusGridContext::strategy`]:
+//!
+//! - **GreedyMerge** (default): a greedy sequential pass forms initial
+//!   rectangular clusters, then an iterative merge pass combines compatible
+//!   clusters into larger rectangles.
+//! - **Clique**: builds a conflict graph whose nodes are valid positions in the
+//!   movers' induced Cartesian product and whose edges connect positions that
+//!   form a valid 2×2 rectangle. Each round finds the maximal clique covering
+//!   the most movers (tie-break: smaller area, then deterministic), emits the
+//!   corresponding rectangle, prunes covered movers, and repeats.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -182,10 +190,227 @@ impl BusGridContext {
             .collect()
     }
 
-    /// Conflict-graph max-clique grid construction (implemented in Task 2).
+    /// Maximum nodes for exact Bron–Kerbosch; above this, use the greedy
+    /// fallback. Bounded by the u64 adjacency bitset (≤64) and enumeration cost.
+    const MAX_EXACT_CLIQUE_NODES: usize = 32;
+
+    /// Conflict-graph max-clique grid construction.
+    ///
+    /// Candidate nodes are the valid positions in the input movers' induced
+    /// Cartesian product; two nodes are adjacent iff their induced 2×2 rectangle
+    /// is valid (so a maximal clique = a maximal valid rectangle). Each round
+    /// emits the rectangle covering the most input movers (tie-break: smaller
+    /// area, then deterministic), then prunes those movers and repeats.
     fn build_aod_grids_clique(&self, entries: &HashMap<u64, u64>) -> Vec<Vec<u64>> {
-        // Placeholder until Task 2. Falls back to greedy so callers still work.
-        self.build_aod_grids_greedy(entries)
+        if entries.is_empty() {
+            return Vec::new();
+        }
+        let mut remaining: HashSet<u64> = entries.keys().copied().collect();
+        let mut out: Vec<Vec<u64>> = Vec::new();
+
+        while !remaining.is_empty() {
+            // Candidate universe: positions in X × Y of the remaining movers.
+            let nodes = self.clique_candidate_nodes(&remaining);
+            if nodes.is_empty() {
+                break;
+            }
+            let movers: &HashSet<u64> = &remaining;
+
+            // Adjacency bitsets: edge iff the 2×2 {A,B} rectangle is valid.
+            let n = nodes.len();
+            let mut adj = vec![0u64; n];
+            for i in 0..n {
+                for j in (i + 1)..n {
+                    let (xi, yi) = nodes[i];
+                    let (xj, yj) = nodes[j];
+                    let xs: BTreeSet<u64> = [xi, xj].into_iter().collect();
+                    let ys: BTreeSet<u64> = [yi, yj].into_iter().collect();
+                    if self.is_valid_rect(&xs, &ys, movers) {
+                        adj[i] |= 1u64 << j;
+                        adj[j] |= 1u64 << i;
+                    }
+                }
+            }
+
+            // Helper: is a node index a remaining mover?
+            let is_mover = |idx: usize| -> bool {
+                self.pos_to_src
+                    .get(&nodes[idx])
+                    .is_some_and(|src| movers.contains(src))
+            };
+
+            // Evaluate a clique (bitset over node indices) by the objective.
+            // Returns None if it covers zero input movers.
+            // Inlined into consider to avoid borrow-checker issues with closures.
+            let mut best_key: Option<(usize, std::cmp::Reverse<usize>, u64)> = None;
+            let mut best_clique: u64 = 0;
+            let mut consider = |clique: u64| {
+                if clique == 0 {
+                    return;
+                }
+                let mut movers_covered = 0usize;
+                let mut bits = clique;
+                while bits != 0 {
+                    let idx = bits.trailing_zeros() as usize;
+                    bits &= bits - 1;
+                    if is_mover(idx) {
+                        movers_covered += 1;
+                    }
+                }
+                if movers_covered == 0 {
+                    return;
+                }
+                let area = clique.count_ones() as usize;
+                // Deterministic tie-break: the clique's raw bitset (lower node
+                // indices, which follow sorted node order, win).
+                let key = (movers_covered, std::cmp::Reverse(area), !clique);
+                if best_key.as_ref().is_none_or(|b| key > *b) {
+                    best_key = Some(key);
+                    best_clique = clique;
+                }
+            };
+
+            if n <= Self::MAX_EXACT_CLIQUE_NODES {
+                let full_p: u64 = if n == 64 { u64::MAX } else { (1u64 << n) - 1 };
+                Self::bron_kerbosch(&adj, 0, full_p, 0, &mut consider);
+            } else {
+                Self::greedy_max_clique(&adj, n, &is_mover, &mut consider);
+            }
+
+            if best_clique == 0 {
+                break; // no mover-covering clique (shouldn't happen while movers remain)
+            }
+
+            // Coordinate sets of the winning clique → complete rectangle.
+            let mut xs = BTreeSet::new();
+            let mut ys = BTreeSet::new();
+            let mut bits = best_clique;
+            while bits != 0 {
+                let idx = bits.trailing_zeros() as usize;
+                bits &= bits - 1;
+                let (x, y) = nodes[idx];
+                xs.insert(x);
+                ys.insert(y);
+            }
+            let lanes = self.rect_to_lanes(&xs, &ys);
+            if lanes.is_empty() {
+                break;
+            }
+
+            // Prune covered movers (sources inside the rectangle).
+            for &x in &xs {
+                for &y in &ys {
+                    if let Some(&src) = self.pos_to_src.get(&(x, y)) {
+                        remaining.remove(&src);
+                    }
+                }
+            }
+            out.push(lanes);
+        }
+
+        out
+    }
+
+    /// Valid positions in the movers' induced X × Y product (each a valid 1×1).
+    /// Sorted for determinism. Capped at 64 nodes (u64 bitset); excess dropped
+    /// deterministically (the greedy fallback handles large sets, and >64 valid
+    /// positions is not expected per bus per step).
+    fn clique_candidate_nodes(&self, movers: &HashSet<u64>) -> Vec<(u64, u64)> {
+        let mut xs = BTreeSet::new();
+        let mut ys = BTreeSet::new();
+        for &src in movers {
+            if let Some(&(x, y)) = self.src_to_pos.get(&src) {
+                xs.insert(x);
+                ys.insert(y);
+            }
+        }
+        let mut nodes = Vec::new();
+        for &x in &xs {
+            for &y in &ys {
+                let px: BTreeSet<u64> = [x].into_iter().collect();
+                let py: BTreeSet<u64> = [y].into_iter().collect();
+                if self.is_valid_rect(&px, &py, movers) {
+                    nodes.push((x, y));
+                    if nodes.len() == 64 {
+                        return nodes;
+                    }
+                }
+            }
+        }
+        nodes
+    }
+
+    /// Bron–Kerbosch with pivoting over a u64 adjacency bitset (≤64 nodes).
+    /// Invokes `visit` on each maximal clique (as a node-index bitset).
+    fn bron_kerbosch(adj: &[u64], r: u64, p: u64, x: u64, visit: &mut impl FnMut(u64)) {
+        if p == 0 && x == 0 {
+            visit(r);
+            return;
+        }
+        // Pivot u ∈ P∪X maximizing |P ∩ adj[u]|.
+        let mut pux = p | x;
+        let mut pivot = 0usize;
+        let mut best = -1i32;
+        while pux != 0 {
+            let u = pux.trailing_zeros() as usize;
+            pux &= pux - 1;
+            let cnt = (p & adj[u]).count_ones() as i32;
+            if cnt > best {
+                best = cnt;
+                pivot = u;
+            }
+        }
+        let mut p = p;
+        let mut x = x;
+        let mut cand = p & !adj[pivot];
+        while cand != 0 {
+            let v = cand.trailing_zeros() as usize;
+            let vbit = 1u64 << v;
+            cand &= cand - 1;
+            Self::bron_kerbosch(adj, r | vbit, p & adj[v], x & adj[v], visit);
+            p &= !vbit;
+            x |= vbit;
+        }
+    }
+
+    /// Greedy maximal-clique fallback for large node sets. Seeds from each mover
+    /// node, extends by highest-degree compatible node, and reports each grown
+    /// clique to `visit`. Deterministic (sorted seeds/candidates).
+    fn greedy_max_clique(
+        adj: &[u64],
+        n: usize,
+        is_mover: &impl Fn(usize) -> bool,
+        visit: &mut impl FnMut(u64),
+    ) {
+        for seed in 0..n {
+            if !is_mover(seed) {
+                continue;
+            }
+            let mut clique = 1u64 << seed;
+            let mut cand = adj[seed];
+            while cand != 0 {
+                // Pick the candidate with the most connections to `cand`
+                // (deterministic: lowest index breaks ties).
+                let mut bits = cand;
+                let mut pick = usize::MAX;
+                let mut best = -1i32;
+                while bits != 0 {
+                    let v = bits.trailing_zeros() as usize;
+                    bits &= bits - 1;
+                    let deg = (adj[v] & cand).count_ones() as i32;
+                    if deg > best {
+                        best = deg;
+                        pick = v;
+                    }
+                }
+                if pick == usize::MAX {
+                    break;
+                }
+                clique |= 1u64 << pick;
+                cand &= adj[pick];
+            }
+            visit(clique);
+        }
     }
 
     /// Form initial clusters via greedy sequential expansion.
@@ -599,5 +824,122 @@ mod tests {
         assert_eq!(ctx.strategy, AodGridStrategy::GreedyMerge);
         let clique = ctx.with_strategy(AodGridStrategy::Clique);
         assert_eq!(clique.strategy, AodGridStrategy::Clique);
+    }
+
+    #[test]
+    fn clique_builds_single_complete_rectangle() {
+        // 2×2 grid, 3 movers + 1 empty filler (13). Clique strategy should
+        // return one complete rectangle of all four lanes.
+        let ctx = make_context(
+            &[((0, 0), 10), ((1, 0), 11), ((0, 1), 12), ((1, 1), 13)],
+            &[(10, 100), (11, 101), (12, 102), (13, 103)],
+            &[],
+        )
+        .with_strategy(AodGridStrategy::Clique);
+        let entries: HashMap<u64, u64> = [(10, 100), (11, 101), (12, 102)].into_iter().collect();
+
+        let grids = ctx.build_aod_grids(&entries);
+        assert_eq!(grids.len(), 1);
+        let mut sorted = grids[0].clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![100, 101, 102, 103]);
+    }
+
+    #[test]
+    fn clique_recovers_rectangle_greedy_would_split() {
+        // Movers at (0,0),(1,1) with valid corners (1,0),(0,1) as empty fillers.
+        // Both strategies must yield one 2×2 rectangle; this locks in that the
+        // clique path completes the rectangle from the movers' product.
+        let ctx = make_context(
+            &[((0, 0), 10), ((1, 1), 13), ((1, 0), 11), ((0, 1), 12)],
+            &[(10, 100), (13, 103), (11, 101), (12, 102)],
+            &[],
+        )
+        .with_strategy(AodGridStrategy::Clique);
+        let entries: HashMap<u64, u64> = [(10, 100), (13, 103)].into_iter().collect();
+
+        let grids = ctx.build_aod_grids(&entries);
+        assert_eq!(grids.len(), 1);
+        let mut sorted = grids[0].clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![100, 101, 102, 103]);
+    }
+
+    #[test]
+    fn clique_emits_only_mover_covering_rectangles() {
+        // One mover at (0,0). A disjoint empty 2×2 region at x∈{5,6}, y∈{5,6}
+        // is a valid rectangle but covers no mover — it must never be emitted.
+        let ctx = make_context(
+            &[
+                ((0, 0), 10),
+                ((5, 5), 20),
+                ((6, 5), 21),
+                ((5, 6), 22),
+                ((6, 6), 23),
+            ],
+            &[(10, 100), (20, 200), (21, 201), (22, 202), (23, 203)],
+            &[],
+        )
+        .with_strategy(AodGridStrategy::Clique);
+        let entries: HashMap<u64, u64> = [(10, 100)].into_iter().collect();
+
+        let grids = ctx.build_aod_grids(&entries);
+        // Only the mover's own 1×1 rectangle; no empty-region rectangle.
+        assert_eq!(grids.len(), 1);
+        assert_eq!(grids[0], vec![100]);
+    }
+
+    #[test]
+    fn clique_reversibility_rejects_filled_filler_destination() {
+        // Mover 10 at (0,0). Filler 13 at (1,1) has an occupied destination
+        // (stationary atom), so the 2×2 with mover 11/12 corners is invalid;
+        // the reversible sub-rectangle is 1×2 or 2×1, not 2×2.
+        let ctx = make_context(
+            &[((0, 0), 10), ((1, 0), 11), ((0, 1), 12), ((1, 1), 13)],
+            &[(10, 100), (11, 101), (12, 102), (13, 103)],
+            &[13], // src 13's destination is occupied (stationary)
+        )
+        .with_strategy(AodGridStrategy::Clique);
+        let entries: HashMap<u64, u64> = [(10, 100), (11, 101), (12, 102)].into_iter().collect();
+
+        let grids = ctx.build_aod_grids(&entries);
+        // No 4-lane rectangle (13 can't be a filler); every mover still covered.
+        assert!(!grids.iter().any(|g| g.len() == 4));
+        let covered: HashSet<u64> = grids.iter().flatten().copied().collect();
+        assert!([100, 101, 102].iter().all(|l| covered.contains(l)));
+    }
+
+    #[test]
+    fn clique_is_deterministic() {
+        let ctx = make_context(
+            &[((0, 0), 10), ((1, 0), 11), ((0, 1), 12), ((1, 1), 13)],
+            &[(10, 100), (11, 101), (12, 102), (13, 103)],
+            &[],
+        )
+        .with_strategy(AodGridStrategy::Clique);
+        let entries: HashMap<u64, u64> = [(10, 100), (11, 101), (12, 102), (13, 103)]
+            .into_iter()
+            .collect();
+        let a = ctx.build_aod_grids(&entries);
+        let b = ctx.build_aod_grids(&entries);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clique_covers_all_movers_via_decomposition() {
+        // Two separate movers whose induced 2×2 corners are blocked, forcing
+        // two 1×1 shots. Both movers must be covered across the returned grids.
+        let ctx = make_context_with_occupied(
+            &[((0, 0), 10), ((3, 3), 13), ((3, 0), 11), ((0, 3), 12)],
+            &[(10, 100), (13, 103), (11, 101), (12, 102)],
+            &[],
+            &[11, 12], // corner sources are spectators → 2×2 invalid
+        )
+        .with_strategy(AodGridStrategy::Clique);
+        let entries: HashMap<u64, u64> = [(10, 100), (13, 103)].into_iter().collect();
+
+        let grids = ctx.build_aod_grids(&entries);
+        let covered: HashSet<u64> = grids.iter().flatten().copied().collect();
+        assert!(covered.contains(&100) && covered.contains(&103));
     }
 }

--- a/crates/bloqade-lanes-search/src/ops/aod_grid.rs
+++ b/crates/bloqade-lanes-search/src/ops/aod_grid.rs
@@ -240,7 +240,11 @@ impl BusGridContext {
             };
 
             // Evaluate a clique (bitset over node indices) by the objective.
-            // Returns None if it covers zero input movers.
+            // Scoring is based on the EMITTED rectangle (the full xs × ys product
+            // of the clique's distinct tones), not the clique bitset size, because
+            // the product may contain valid positions that are non-adjacent to some
+            // clique members yet still covered by the emitted AOD shot.
+            // Returns without updating if the emitted rectangle covers zero movers.
             // Inlined into consider to avoid borrow-checker issues with closures.
             let mut best_key: Option<(usize, std::cmp::Reverse<usize>, u64)> = None;
             let mut best_clique: u64 = 0;
@@ -248,19 +252,32 @@ impl BusGridContext {
                 if clique == 0 {
                     return;
                 }
-                let mut movers_covered = 0usize;
+                // Derive distinct x/y tones of the clique.
+                let mut xs_set = BTreeSet::new();
+                let mut ys_set = BTreeSet::new();
                 let mut bits = clique;
                 while bits != 0 {
                     let idx = bits.trailing_zeros() as usize;
                     bits &= bits - 1;
-                    if is_mover(idx) {
-                        movers_covered += 1;
+                    let (x, y) = nodes[idx];
+                    xs_set.insert(x);
+                    ys_set.insert(y);
+                }
+                // Score on the full xs × ys product (the emitted rectangle).
+                let area = xs_set.len() * ys_set.len();
+                let mut movers_covered = 0usize;
+                for &x in &xs_set {
+                    for &y in &ys_set {
+                        if let Some(&src) = self.pos_to_src.get(&(x, y))
+                            && movers.contains(&src)
+                        {
+                            movers_covered += 1;
+                        }
                     }
                 }
                 if movers_covered == 0 {
                     return;
                 }
-                let area = clique.count_ones() as usize;
                 // Deterministic tie-break: the clique's raw bitset (lower node
                 // indices, which follow sorted node order, win).
                 let key = (movers_covered, std::cmp::Reverse(area), !clique);
@@ -389,8 +406,10 @@ impl BusGridContext {
             let mut clique = 1u64 << seed;
             let mut cand = adj[seed];
             while cand != 0 {
-                // Pick the candidate with the most connections to `cand`
-                // (deterministic: lowest index breaks ties).
+                // Pick the candidate with the most connections to `cand`.
+                // Tie-break: lowest index wins, because `trailing_zeros` iterates
+                // low-to-high and a strictly-greater `deg > best` comparison means
+                // the first (lowest-index) maximum is kept.
                 let mut bits = cand;
                 let mut pick = usize::MAX;
                 let mut best = -1i32;
@@ -911,18 +930,48 @@ mod tests {
 
     #[test]
     fn clique_is_deterministic() {
-        let ctx = make_context(
+        // Fix 4: prove order-independence structurally by building TWO contexts
+        // with positions/lanes inserted in different orders and asserting identical
+        // output after consistent per-grid normalization.
+        //
+        // Context A: positions and lanes in ascending src order.
+        let ctx_a = make_context(
             &[((0, 0), 10), ((1, 0), 11), ((0, 1), 12), ((1, 1), 13)],
             &[(10, 100), (11, 101), (12, 102), (13, 103)],
             &[],
         )
         .with_strategy(AodGridStrategy::Clique);
+
+        // Context B: positions and lanes in reversed src order (different HashMap
+        // insertion order, which affects HashMap iteration and bucket distribution).
+        let ctx_b = make_context(
+            &[((1, 1), 13), ((0, 1), 12), ((1, 0), 11), ((0, 0), 10)],
+            &[(13, 103), (12, 102), (11, 101), (10, 100)],
+            &[],
+        )
+        .with_strategy(AodGridStrategy::Clique);
+
         let entries: HashMap<u64, u64> = [(10, 100), (11, 101), (12, 102), (13, 103)]
             .into_iter()
             .collect();
-        let a = ctx.build_aod_grids(&entries);
-        let b = ctx.build_aod_grids(&entries);
-        assert_eq!(a, b);
+
+        let mut a = ctx_a.build_aod_grids(&entries);
+        let mut b = ctx_b.build_aod_grids(&entries);
+
+        // Normalize: sort lanes within each grid, then sort grids for comparison.
+        for g in &mut a {
+            g.sort();
+        }
+        for g in &mut b {
+            g.sort();
+        }
+        a.sort();
+        b.sort();
+
+        assert_eq!(
+            a, b,
+            "clique strategy must produce identical output regardless of insertion order"
+        );
     }
 
     #[test]
@@ -941,5 +990,152 @@ mod tests {
         let grids = ctx.build_aod_grids(&entries);
         let covered: HashSet<u64> = grids.iter().flatten().copied().collect();
         assert!(covered.contains(&100) && covered.contains(&103));
+    }
+
+    /// Fix 3: Build a candidate set exceeding MAX_EXACT_CLIQUE_NODES (>32 valid
+    /// positions) with AodGridStrategy::Clique and assert the result is valid:
+    /// non-empty, every emitted grid covers ≥1 mover, and all input movers are
+    /// covered across the returned grids. This exercises the `greedy_max_clique`
+    /// branch.
+    #[test]
+    fn clique_greedy_fallback_large_candidate_set() {
+        // Build a 7×6 = 42-position grid. All positions are movers. 42 > 32
+        // forces the greedy_max_clique fallback (MAX_EXACT_CLIQUE_NODES = 32).
+        let mut positions: Vec<((u64, u64), u64)> = Vec::new();
+        let mut lanes: Vec<(u64, u64)> = Vec::new();
+        let mut entries: HashMap<u64, u64> = HashMap::new();
+        let mut src = 1u64;
+        let mut lane_enc = 1001u64;
+
+        for x in 0u64..7 {
+            for y in 0u64..6 {
+                positions.push(((x, y), src));
+                lanes.push((src, lane_enc));
+                entries.insert(src, lane_enc);
+                src += 1;
+                lane_enc += 1;
+            }
+        }
+
+        let ctx = make_context(&positions, &lanes, &[]).with_strategy(AodGridStrategy::Clique);
+        let mover_lanes: HashSet<u64> = entries.values().copied().collect();
+
+        let grids = ctx.build_aod_grids(&entries);
+
+        // Must emit at least one grid.
+        assert!(
+            !grids.is_empty(),
+            "greedy fallback must produce at least one grid"
+        );
+
+        // Every emitted grid must cover ≥1 mover.
+        for grid in &grids {
+            let covers_mover = grid.iter().any(|l| mover_lanes.contains(l));
+            assert!(
+                covers_mover,
+                "every emitted grid must cover at least one mover; got {:?}",
+                grid
+            );
+        }
+
+        // All input movers must be covered across the returned grids.
+        let covered: HashSet<u64> = grids.iter().flatten().copied().collect();
+        for &l in &mover_lanes {
+            assert!(covered.contains(&l), "mover lane {} not covered", l);
+        }
+    }
+
+    /// Fix 1+2: Verify that the objective scoring uses the emitted rectangle's
+    /// product dimensions (xs.len() * ys.len()) rather than the clique bitset
+    /// count. We construct a scenario where two competing cliques have the same
+    /// number of nodes (clique.count_ones()) but different emitted-rectangle areas
+    /// (xs.len()*ys.len()), then assert the winner is selected by product-area.
+    ///
+    /// Scenario:
+    ///   - 6 movers laid out as two groups:
+    ///     Group A: (0,0),(1,0),(0,1),(1,1) — a fully-connected 2×2 with 4 movers.
+    ///     Group B: (5,0),(6,0),(7,0) — a 3×1 line with 3 movers.
+    ///   - The maximal clique for A has 4 nodes (all pairwise valid), area_product=4.
+    ///   - The maximal clique for B has 3 nodes, area_product=3.
+    ///   - Under EITHER scoring A wins (4 movers vs 3). The meaningful check is
+    ///     that A's emitted rectangle has area 4 (xs.len()*ys.len()=4), not that
+    ///     area is computed from node count in some other way.
+    ///
+    /// Note: The L-shape fixture (clique with fewer nodes than its xs×ys product)
+    /// is NOT constructible in this graph: for any 3-node L-shape {A,B,C} to be
+    /// fully connected, the edge between the two nodes that differ in BOTH x and y
+    /// requires is_valid_rect on their induced 2×2, which checks the 4th product
+    /// cell. If the 4th cell is valid, it is adjacent to all three and extends the
+    /// clique to 4 nodes, making the L-shape non-maximal. If the 4th cell is
+    /// invalid, the 2×2 edge doesn't exist and the L-shape isn't a clique. Hence
+    /// a strict L-shaped maximal clique cannot arise.
+    ///
+    /// Instead we verify: the winning rectangle's lane count equals xs.len()*ys.len()
+    /// and covers the correct set of movers.
+    #[test]
+    fn clique_objective_uses_product_area_not_bitset_count() {
+        // Group A: 2×2 = 4 movers at x∈{0,1}, y∈{0,1} (all valid, no collisions).
+        // Group B: 3×1 = 3 movers at x∈{5,6,7}, y∈{5} (disjoint in BOTH x and y).
+        // Groups share no x or y tones so no cross-group rectangle forms.
+        let ctx = make_context(
+            &[
+                ((0, 0), 10),
+                ((1, 0), 11),
+                ((0, 1), 12),
+                ((1, 1), 13), // group A
+                ((5, 5), 20),
+                ((6, 5), 21),
+                ((7, 5), 22), // group B (disjoint y)
+            ],
+            &[
+                (10, 100),
+                (11, 101),
+                (12, 102),
+                (13, 103),
+                (20, 200),
+                (21, 201),
+                (22, 202),
+            ],
+            &[],
+        )
+        .with_strategy(AodGridStrategy::Clique);
+
+        // All 7 are movers.
+        let entries: HashMap<u64, u64> = [
+            (10, 100),
+            (11, 101),
+            (12, 102),
+            (13, 103),
+            (20, 200),
+            (21, 201),
+            (22, 202),
+        ]
+        .into_iter()
+        .collect();
+
+        let grids = ctx.build_aod_grids(&entries);
+
+        // First emitted grid must be the 2×2 group A (4 movers > 3 movers).
+        assert!(!grids.is_empty());
+        let mut first = grids[0].clone();
+        first.sort();
+        assert_eq!(
+            first,
+            vec![100, 101, 102, 103],
+            "group A (4 movers, product area 4) must be selected first"
+        );
+
+        // Product area of first grid is xs.len()*ys.len() = 2*2 = 4, matching lane count.
+        assert_eq!(
+            grids[0].len(),
+            4,
+            "emitted rectangle lane count must equal xs.len()*ys.len()"
+        );
+
+        // All movers covered across all grids.
+        let covered: HashSet<u64> = grids.iter().flatten().copied().collect();
+        for l in [100u64, 101, 102, 103, 200, 201, 202] {
+            assert!(covered.contains(&l), "lane {} not covered", l);
+        }
     }
 }

--- a/crates/bloqade-lanes-search/src/ops/aod_grid.rs
+++ b/crates/bloqade-lanes-search/src/ops/aod_grid.rs
@@ -9,6 +9,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use bloqade_lanes_bytecode_core::arch::addr::{Direction, LaneAddr, MoveType};
 
 use crate::primitives::lane_index::LaneIndex;
+use crate::search::options::AodGridStrategy;
 
 /// A cluster represented by its X and Y coordinate sets.
 /// The rectangle covers the Cartesian product X × Y.
@@ -32,6 +33,8 @@ pub(crate) struct BusGridContext {
     src_to_pos: HashMap<u64, (u64, u64)>,
     /// Locations occupied by atoms or blocked locations in the current config.
     occupied_locs: HashSet<u64>,
+    /// Which grid-construction strategy `build_aod_grids` dispatches to.
+    strategy: AodGridStrategy,
 }
 
 impl BusGridContext {
@@ -82,7 +85,15 @@ impl BusGridContext {
             src_to_dst,
             src_to_pos,
             occupied_locs: occupied.clone(),
+            strategy: AodGridStrategy::default(),
         }
+    }
+
+    /// Select the grid-construction strategy (default [`AodGridStrategy::GreedyMerge`]).
+    #[allow(dead_code)]
+    pub(crate) fn with_strategy(mut self, strategy: AodGridStrategy) -> Self {
+        self.strategy = strategy;
+        self
     }
 
     /// Check if every position in the X × Y rectangle is valid.
@@ -142,12 +153,18 @@ impl BusGridContext {
 
     /// Build AOD-compatible rectangular grids from scored entry lanes.
     ///
-    /// `entries` maps `encoded_src → encoded_lane` for the scored/selected
-    /// moving atoms. Returned grids may also include empty filler lanes so each
-    /// lane set remains a complete AOD rectangle.
-    ///
-    /// Returns a list of lane sets, each forming a valid AOD rectangle.
+    /// Dispatches on [`BusGridContext::strategy`]. See
+    /// [`build_aod_grids_greedy`](Self::build_aod_grids_greedy) and
+    /// [`build_aod_grids_clique`](Self::build_aod_grids_clique).
     pub(crate) fn build_aod_grids(&self, entries: &HashMap<u64, u64>) -> Vec<Vec<u64>> {
+        match self.strategy {
+            AodGridStrategy::GreedyMerge => self.build_aod_grids_greedy(entries),
+            AodGridStrategy::Clique => self.build_aod_grids_clique(entries),
+        }
+    }
+
+    /// Greedy sequential clustering + iterative merge (original algorithm).
+    fn build_aod_grids_greedy(&self, entries: &HashMap<u64, u64>) -> Vec<Vec<u64>> {
         if entries.is_empty() {
             return Vec::new();
         }
@@ -163,6 +180,12 @@ impl BusGridContext {
             .map(|(xs, ys)| self.rect_to_lanes(xs, ys))
             .filter(|lanes| !lanes.is_empty())
             .collect()
+    }
+
+    /// Conflict-graph max-clique grid construction (implemented in Task 2).
+    fn build_aod_grids_clique(&self, entries: &HashMap<u64, u64>) -> Vec<Vec<u64>> {
+        // Placeholder until Task 2. Falls back to greedy so callers still work.
+        self.build_aod_grids_greedy(entries)
     }
 
     /// Form initial clusters via greedy sequential expansion.
@@ -332,6 +355,7 @@ mod tests {
             src_to_dst,
             src_to_pos,
             occupied_locs,
+            strategy: AodGridStrategy::default(),
         }
     }
 
@@ -567,5 +591,13 @@ mod tests {
         let mut sorted = grids[0].clone();
         sorted.sort();
         assert_eq!(sorted, vec![100, 101, 102, 103]);
+    }
+
+    #[test]
+    fn strategy_defaults_to_greedy_merge() {
+        let ctx = make_context(&[((0, 0), 10)], &[(10, 100)], &[]);
+        assert_eq!(ctx.strategy, AodGridStrategy::GreedyMerge);
+        let clique = ctx.with_strategy(AodGridStrategy::Clique);
+        assert_eq!(clique.strategy, AodGridStrategy::Clique);
     }
 }

--- a/crates/bloqade-lanes-search/src/ops/aod_grid.rs
+++ b/crates/bloqade-lanes-search/src/ops/aod_grid.rs
@@ -98,7 +98,6 @@ impl BusGridContext {
     }
 
     /// Select the grid-construction strategy (default [`AodGridStrategy::GreedyMerge`]).
-    #[allow(dead_code)]
     pub(crate) fn with_strategy(mut self, strategy: AodGridStrategy) -> Self {
         self.strategy = strategy;
         self
@@ -240,10 +239,10 @@ impl BusGridContext {
             };
 
             // Evaluate a clique (bitset over node indices) by the objective.
-            // Scoring is based on the EMITTED rectangle (the full xs × ys product
-            // of the clique's distinct tones), not the clique bitset size, because
-            // the product may contain valid positions that are non-adjacent to some
-            // clique members yet still covered by the emitted AOD shot.
+            // Score on the emitted rectangle (xs × ys) so area and movers_covered
+            // match exactly what rect_to_lanes emits. Every node in the clique
+            // already passed is_valid_rect, so the induced product is fully covered
+            // — no "extra" cells outside the clique can appear.
             // Returns without updating if the emitted rectangle covers zero movers.
             // Inlined into consider to avoid borrow-checker issues with closures.
             let mut best_key: Option<(usize, std::cmp::Reverse<usize>, u64)> = None;
@@ -288,6 +287,9 @@ impl BusGridContext {
             };
 
             if n <= Self::MAX_EXACT_CLIQUE_NODES {
+                // The n == 64 branch is never reached today (MAX_EXACT_CLIQUE_NODES = 32),
+                // but is kept defensively in case MAX_EXACT_CLIQUE_NODES is raised toward 64
+                // in the future; `1u64 << 64` would panic, so the guard must stay.
                 let full_p: u64 = if n == 64 { u64::MAX } else { (1u64 << n) - 1 };
                 Self::bron_kerbosch(&adj, 0, full_p, 0, &mut consider);
             } else {
@@ -310,6 +312,16 @@ impl BusGridContext {
                 ys.insert(y);
             }
             let lanes = self.rect_to_lanes(&xs, &ys);
+            // Soundness invariant: the emitted rectangle must be the full Cartesian
+            // product of the winning clique's x/y tone sets.
+            debug_assert!(
+                lanes.len() == xs.len() * ys.len(),
+                "rect_to_lanes emitted {} lanes but xs({}) × ys({}) = {}",
+                lanes.len(),
+                xs.len(),
+                ys.len(),
+                xs.len() * ys.len(),
+            );
             if lanes.is_empty() {
                 break;
             }
@@ -955,10 +967,25 @@ mod tests {
             .into_iter()
             .collect();
 
-        let mut a = ctx_a.build_aod_grids(&entries);
-        let mut b = ctx_b.build_aod_grids(&entries);
+        let raw_a = ctx_a.build_aod_grids(&entries);
+        let raw_b = ctx_b.build_aod_grids(&entries);
 
-        // Normalize: sort lanes within each grid, then sort grids for comparison.
+        // Strong check: sort only the OUTER vec (grid order may vary) but leave
+        // inner vecs unsorted, so intra-grid lane order is also verified to be
+        // identical between the two differently-inserted contexts.
+        let mut inner_a = raw_a.clone();
+        let mut inner_b = raw_b.clone();
+        inner_a.sort_by_key(|g| g.first().copied().unwrap_or(0));
+        inner_b.sort_by_key(|g| g.first().copied().unwrap_or(0));
+        assert_eq!(
+            inner_a, inner_b,
+            "clique strategy intra-grid lane order must be identical regardless of insertion order"
+        );
+
+        // Normalized check (sort lanes within each grid too): retained for
+        // completeness and to catch any set-level content divergence.
+        let mut a = raw_a;
+        let mut b = raw_b;
         for g in &mut a {
             g.sort();
         }

--- a/crates/bloqade-lanes-search/src/search/options.rs
+++ b/crates/bloqade-lanes-search/src/search/options.rs
@@ -137,6 +137,8 @@ pub struct EntropyOptions {
     /// A non-zero base seed starts the per-restart sequence at that value
     /// so every run is reproducible.
     pub seed: u64,
+    /// Strategy for AOD grid construction from selected movers.
+    pub aod_grid_strategy: AodGridStrategy,
 }
 
 impl Default for EntropyOptions {
@@ -147,6 +149,7 @@ impl Default for EntropyOptions {
             w_t: 0.05,
             collect_entropy_trace: false,
             seed: 0,
+            aod_grid_strategy: AodGridStrategy::default(),
         }
     }
 }

--- a/crates/bloqade-lanes-search/src/search/options.rs
+++ b/crates/bloqade-lanes-search/src/search/options.rs
@@ -40,6 +40,18 @@ pub enum Strategy {
     Entropy,
 }
 
+/// Strategy for turning selected mover lanes into valid AOD rectangles in
+/// [`BusGridContext`](crate::ops::aod_grid::BusGridContext).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AodGridStrategy {
+    /// Greedy sequential clustering + iterative rectangle merge (original).
+    #[default]
+    GreedyMerge,
+    /// Conflict-graph max-clique: pick the rectangle covering the most input
+    /// movers, completing it with filler/no-op lanes.
+    Clique,
+}
+
 /// Core search-tuning parameters shared by every solver entry point.
 ///
 /// Strategy-specific knobs live in [`EntropyOptions`] (entropy-search

--- a/crates/bloqade-lanes-search/src/search/restarts.rs
+++ b/crates/bloqade-lanes-search/src/search/restarts.rs
@@ -131,6 +131,7 @@ where
     let collect_entropy_trace = entropy.collect_entropy_trace;
     let w_t = entropy.w_t;
     let base_seed = entropy.seed;
+    let aod_grid_strategy = entropy.aod_grid_strategy;
 
     // Helper: run a single inner strategy with the given seed and budget.
     let run_inner = |inner: InnerStrategy, seed: u64, budget: Option<u32>| -> SolveResult {
@@ -153,6 +154,7 @@ where
                     max_goal_candidates,
                     lookahead: opts.lookahead,
                     w_t,
+                    aod_grid_strategy,
                     ..crate::drivers::entropy::EntropyParams::default()
                 };
                 let mut entropy_trace = if collect_entropy_trace {

--- a/crates/bloqade-lanes-search/tests/dsl_kernel_fallback.rs
+++ b/crates/bloqade-lanes-search/tests/dsl_kernel_fallback.rs
@@ -68,6 +68,7 @@ def step(graph, gs, ctx, lib):
         max_expansions: 100,
         timeout_s: Some(5.0),
         sandbox: SandboxConfig::default(),
+        ..PolicyOptions::default()
     };
 
     let result = solve_with_policy(

--- a/crates/bloqade-lanes-search/tests/dsl_kernel_insert_outcome.rs
+++ b/crates/bloqade-lanes-search/tests/dsl_kernel_insert_outcome.rs
@@ -83,6 +83,7 @@ def step(graph, gs, ctx, lib):
         max_expansions: 100,
         timeout_s: Some(5.0),
         sandbox: SandboxConfig::default(),
+        ..PolicyOptions::default()
     };
 
     let result = solve_with_policy(

--- a/crates/bloqade-lanes-search/tests/dsl_kernel_schema.rs
+++ b/crates/bloqade-lanes-search/tests/dsl_kernel_schema.rs
@@ -87,6 +87,7 @@ def step(graph, gs, ctx, lib):
         max_expansions: 100,
         timeout_s: Some(5.0),
         sandbox: SandboxConfig::default(),
+        ..PolicyOptions::default()
     };
 
     let result = solve_with_policy(
@@ -145,6 +146,7 @@ def step(graph, gs, ctx, lib):
         max_expansions: 100,
         timeout_s: Some(5.0),
         sandbox: SandboxConfig::default(),
+        ..PolicyOptions::default()
     };
 
     let result = solve_with_policy(

--- a/crates/bloqade-lanes-search/tests/dsl_params_override.rs
+++ b/crates/bloqade-lanes-search/tests/dsl_params_override.rs
@@ -73,6 +73,7 @@ fn run_with_params(
         max_expansions,
         timeout_s: Some(15.0),
         sandbox: SandboxConfig::default(),
+        ..PolicyOptions::default()
     };
     solve_with_policy(
         initial.iter().copied(),

--- a/crates/bloqade-lanes-search/tests/dsl_snapshot.rs
+++ b/crates/bloqade-lanes-search/tests/dsl_snapshot.rs
@@ -136,6 +136,7 @@ fn run_one(problem_path: &Path, expected_path: &Path, policy_path: &Path) -> Res
                 policy_params: mp.policy_params.clone(),
                 max_expansions: mp.budget.as_ref().map(|b| b.max_expansions).unwrap_or(5000),
                 timeout_s: Some(mp.budget.as_ref().map(|b| b.timeout_s).unwrap_or(10.0)),
+                ..PolicyOptions::default()
             };
             let mut obs = NoOpMoveObserver;
             let res = solve_with_policy(initial, target, blocked, index, opts, &mut obs)

--- a/docs/superpowers/plans/2026-07-01-aod-grid-clique-strategy.md
+++ b/docs/superpowers/plans/2026-07-01-aod-grid-clique-strategy.md
@@ -1,0 +1,625 @@
+# AOD Grid Clique Strategy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a selectable clique-based strategy to `BusGridContext` that turns a set of input mover lanes into valid AOD rectangles by modeling lanes as a conflict graph and extracting the clique that covers the most input movers.
+
+**Architecture:** A new `AodGridStrategy` enum selects between the existing greedy+merge builder and a new clique builder. `BusGridContext` gains a `strategy` field (default `GreedyMerge`, opt-in via a `with_strategy` builder so no existing call site breaks). The clique builder reuses the existing `is_valid_rect` as both the node predicate (valid 1×1) and edge predicate (valid 2×2), so a maximal clique is exactly a maximal valid rectangle. Bron–Kerbosch with pivoting enumerates maximal cliques (≤64 nodes via u64 bitsets; greedy fallback above a cap); the best is chosen by `(movers_covered desc, area asc, deterministic)`. The result is decomposed by pruning covered movers and rerunning.
+
+**Tech Stack:** Rust, `bloqade-lanes-search` crate, `ops/aod_grid.rs`, `search/options.rs`. No new dependencies (hand-rolled Bron–Kerbosch).
+
+## Global Constraints
+
+- Existing `build_aod_grids` return type stays `Vec<Vec<u64>>`; each element is one AOD-rectangle lane set.
+- Default behavior is unchanged: `BusGridContext::new` yields `AodGridStrategy::GreedyMerge`.
+- All output must be deterministic (sorted iteration, deterministic tie-breaks) — the search depends on reproducibility.
+- Coordinates are `f64::to_bits()` (`u64`); positions are `(x_bits, y_bits)`.
+- `movers` are identified by `entries.keys()` (encoded source locations).
+- Run Rust tests with `cargo test -p bloqade-lanes-search`. Lint with `cargo clippy -p bloqade-lanes-search --all-targets -- -D warnings` and `cargo fmt`.
+
+---
+
+## Task 1: `AodGridStrategy` enum + `BusGridContext` dispatch
+
+**Files:**
+- Modify: `crates/bloqade-lanes-search/src/search/options.rs` (add enum, after the `Strategy` enum ~line 41)
+- Modify: `crates/bloqade-lanes-search/src/ops/aod_grid.rs` (add field, builder, dispatch; rename current body)
+
+**Interfaces:**
+- Produces: `pub enum AodGridStrategy { GreedyMerge, Clique }` (`Default = GreedyMerge`); `BusGridContext::with_strategy(self, AodGridStrategy) -> BusGridContext`; `BusGridContext::build_aod_grids(&self, &HashMap<u64,u64>) -> Vec<Vec<u64>>` (unchanged signature, now dispatches); private `build_aod_grids_greedy` (renamed existing body).
+
+- [ ] **Step 1: Add the enum**
+
+In `crates/bloqade-lanes-search/src/search/options.rs`, after the `Strategy` enum (after line 41), add:
+
+```rust
+/// Strategy for turning selected mover lanes into valid AOD rectangles in
+/// [`BusGridContext`](crate::ops::aod_grid::BusGridContext).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AodGridStrategy {
+    /// Greedy sequential clustering + iterative rectangle merge (original).
+    #[default]
+    GreedyMerge,
+    /// Conflict-graph max-clique: pick the rectangle covering the most input
+    /// movers, completing it with filler/no-op lanes.
+    Clique,
+}
+```
+
+- [ ] **Step 2: Add the field, builder, and dispatch in `aod_grid.rs`**
+
+Add the import at the top of `crates/bloqade-lanes-search/src/ops/aod_grid.rs` (after the existing `use` block, line 11):
+
+```rust
+use crate::search::options::AodGridStrategy;
+```
+
+Add a field to `BusGridContext` (inside the struct, after `occupied_locs`, line 34):
+
+```rust
+    /// Which grid-construction strategy `build_aod_grids` dispatches to.
+    strategy: AodGridStrategy,
+```
+
+In `BusGridContext::new`, set the default in the returned struct literal (in the `Self { ... }` block, add after `occupied_locs: occupied.clone(),`):
+
+```rust
+            strategy: AodGridStrategy::default(),
+```
+
+Add the builder immediately after `new` (before `is_valid_rect`):
+
+```rust
+    /// Select the grid-construction strategy (default [`AodGridStrategy::GreedyMerge`]).
+    pub(crate) fn with_strategy(mut self, strategy: AodGridStrategy) -> Self {
+        self.strategy = strategy;
+        self
+    }
+```
+
+Rename the current `build_aod_grids` method body to `build_aod_grids_greedy` and add a dispatching `build_aod_grids`. Replace the existing method signature line
+`pub(crate) fn build_aod_grids(&self, entries: &HashMap<u64, u64>) -> Vec<Vec<u64>> {`
+with:
+
+```rust
+    /// Build AOD-compatible rectangular grids from scored entry lanes.
+    ///
+    /// Dispatches on [`BusGridContext::strategy`]. See
+    /// [`build_aod_grids_greedy`](Self::build_aod_grids_greedy) and
+    /// [`build_aod_grids_clique`](Self::build_aod_grids_clique).
+    pub(crate) fn build_aod_grids(&self, entries: &HashMap<u64, u64>) -> Vec<Vec<u64>> {
+        match self.strategy {
+            AodGridStrategy::GreedyMerge => self.build_aod_grids_greedy(entries),
+            AodGridStrategy::Clique => self.build_aod_grids_clique(entries),
+        }
+    }
+
+    /// Greedy sequential clustering + iterative merge (original algorithm).
+    fn build_aod_grids_greedy(&self, entries: &HashMap<u64, u64>) -> Vec<Vec<u64>> {
+```
+
+(The rest of the original method body — the `if entries.is_empty()` block through the `.collect()` — stays as the body of `build_aod_grids_greedy`.)
+
+- [ ] **Step 3: Add a temporary stub for the clique method so it compiles**
+
+Add (will be implemented in Task 2):
+
+```rust
+    /// Conflict-graph max-clique grid construction (implemented in Task 2).
+    fn build_aod_grids_clique(&self, entries: &HashMap<u64, u64>) -> Vec<Vec<u64>> {
+        // Placeholder until Task 2. Falls back to greedy so callers still work.
+        self.build_aod_grids_greedy(entries)
+    }
+```
+
+- [ ] **Step 4: Add a test that the strategy field is honored**
+
+Add to the `tests` module in `aod_grid.rs`:
+
+```rust
+    #[test]
+    fn strategy_defaults_to_greedy_merge() {
+        let ctx = make_context(&[((0, 0), 10)], &[(10, 100)], &[]);
+        assert_eq!(ctx.strategy, AodGridStrategy::GreedyMerge);
+        let clique = ctx.with_strategy(AodGridStrategy::Clique);
+        assert_eq!(clique.strategy, AodGridStrategy::Clique);
+    }
+```
+
+- [ ] **Step 5: Build and run tests**
+
+Run: `cargo test -p bloqade-lanes-search aod_grid`
+Expected: PASS — all existing 8 grid tests still pass (greedy path unchanged), plus `strategy_defaults_to_greedy_merge`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/bloqade-lanes-search/src/search/options.rs crates/bloqade-lanes-search/src/ops/aod_grid.rs
+git commit -m "feat(search): add AodGridStrategy enum + BusGridContext dispatch"
+```
+
+---
+
+## Task 2: Clique grid construction
+
+**Files:**
+- Modify: `crates/bloqade-lanes-search/src/ops/aod_grid.rs` (replace the Task-1 stub `build_aod_grids_clique`; add helpers + tests)
+
+**Interfaces:**
+- Consumes: `is_valid_rect(&self, &BTreeSet<u64>, &BTreeSet<u64>, &HashSet<u64>) -> bool`; `rect_to_lanes(&self, &BTreeSet<u64>, &BTreeSet<u64>) -> Vec<u64>`; `self.src_to_pos: HashMap<u64,(u64,u64)>`; `self.pos_to_src: HashMap<(u64,u64),u64>`.
+- Produces: `build_aod_grids_clique(&self, &HashMap<u64,u64>) -> Vec<Vec<u64>>`; module-private helpers `clique_candidate_nodes`, `bron_kerbosch`, `greedy_max_clique`.
+
+- [ ] **Step 1: Write the failing test (clique finds one complete rectangle)**
+
+Add to the `tests` module:
+
+```rust
+    #[test]
+    fn clique_builds_single_complete_rectangle() {
+        // 2×2 grid, 3 movers + 1 empty filler (13). Clique strategy should
+        // return one complete rectangle of all four lanes.
+        let ctx = make_context(
+            &[((0, 0), 10), ((1, 0), 11), ((0, 1), 12), ((1, 1), 13)],
+            &[(10, 100), (11, 101), (12, 102), (13, 103)],
+            &[],
+        )
+        .with_strategy(AodGridStrategy::Clique);
+        let entries: HashMap<u64, u64> = [(10, 100), (11, 101), (12, 102)].into_iter().collect();
+
+        let grids = ctx.build_aod_grids(&entries);
+        assert_eq!(grids.len(), 1);
+        let mut sorted = grids[0].clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![100, 101, 102, 103]);
+    }
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cargo test -p bloqade-lanes-search clique_builds_single_complete_rectangle`
+Expected: FAIL (stub falls back to greedy which would also pass here — so ALSO add the discriminating test in Step 3 before implementing; run both after implementing).
+
+- [ ] **Step 3: Write the discriminating test (clique beats greedy split)**
+
+Add to the `tests` module:
+
+```rust
+    #[test]
+    fn clique_recovers_rectangle_greedy_would_split() {
+        // Movers at (0,0),(1,1) with valid corners (1,0),(0,1) as empty fillers.
+        // Both strategies must yield one 2×2 rectangle; this locks in that the
+        // clique path completes the rectangle from the movers' product.
+        let ctx = make_context(
+            &[((0, 0), 10), ((1, 1), 13), ((1, 0), 11), ((0, 1), 12)],
+            &[(10, 100), (13, 103), (11, 101), (12, 102)],
+            &[],
+        )
+        .with_strategy(AodGridStrategy::Clique);
+        let entries: HashMap<u64, u64> = [(10, 100), (13, 103)].into_iter().collect();
+
+        let grids = ctx.build_aod_grids(&entries);
+        assert_eq!(grids.len(), 1);
+        let mut sorted = grids[0].clone();
+        sorted.sort();
+        assert_eq!(sorted, vec![100, 101, 102, 103]);
+    }
+
+    #[test]
+    fn clique_emits_only_mover_covering_rectangles() {
+        // One mover at (0,0). A disjoint empty 2×2 region at x∈{5,6}, y∈{5,6}
+        // is a valid rectangle but covers no mover — it must never be emitted.
+        let ctx = make_context(
+            &[
+                ((0, 0), 10),
+                ((5, 5), 20),
+                ((6, 5), 21),
+                ((5, 6), 22),
+                ((6, 6), 23),
+            ],
+            &[(10, 100), (20, 200), (21, 201), (22, 202), (23, 203)],
+            &[],
+        )
+        .with_strategy(AodGridStrategy::Clique);
+        let entries: HashMap<u64, u64> = [(10, 100)].into_iter().collect();
+
+        let grids = ctx.build_aod_grids(&entries);
+        // Only the mover's own 1×1 rectangle; no empty-region rectangle.
+        assert_eq!(grids.len(), 1);
+        assert_eq!(grids[0], vec![100]);
+    }
+
+    #[test]
+    fn clique_reversibility_rejects_filled_filler_destination() {
+        // Mover 10 at (0,0). Filler 13 at (1,1) has an occupied destination
+        // (stationary atom), so the 2×2 with mover 11/12 corners is invalid;
+        // the reversible sub-rectangle is 1×2 or 2×1, not 2×2.
+        let ctx = make_context(
+            &[((0, 0), 10), ((1, 0), 11), ((0, 1), 12), ((1, 1), 13)],
+            &[(10, 100), (11, 101), (12, 102), (13, 103)],
+            &[13], // src 13's destination is occupied (stationary)
+        )
+        .with_strategy(AodGridStrategy::Clique);
+        let entries: HashMap<u64, u64> = [(10, 100), (11, 101), (12, 102)].into_iter().collect();
+
+        let grids = ctx.build_aod_grids(&entries);
+        // No 4-lane rectangle (13 can't be a filler); every mover still covered.
+        assert!(!grids.iter().any(|g| g.len() == 4));
+        let covered: HashSet<u64> = grids.iter().flatten().copied().collect();
+        assert!([100, 101, 102].iter().all(|l| covered.contains(l)));
+    }
+```
+
+- [ ] **Step 4: Implement `build_aod_grids_clique` and helpers**
+
+Replace the Task-1 stub `build_aod_grids_clique` with:
+
+```rust
+    /// Maximum nodes for exact Bron–Kerbosch; above this, use the greedy
+    /// fallback. Bounded by the u64 adjacency bitset (≤64) and enumeration cost.
+    const MAX_EXACT_CLIQUE_NODES: usize = 32;
+
+    /// Conflict-graph max-clique grid construction.
+    ///
+    /// Candidate nodes are the valid positions in the input movers' induced
+    /// Cartesian product; two nodes are adjacent iff their induced 2×2 rectangle
+    /// is valid (so a maximal clique = a maximal valid rectangle). Each round
+    /// emits the rectangle covering the most input movers (tie-break: smaller
+    /// area, then deterministic), then prunes those movers and repeats.
+    fn build_aod_grids_clique(&self, entries: &HashMap<u64, u64>) -> Vec<Vec<u64>> {
+        if entries.is_empty() {
+            return Vec::new();
+        }
+        let mut remaining: HashSet<u64> = entries.keys().copied().collect();
+        let mut out: Vec<Vec<u64>> = Vec::new();
+
+        while !remaining.is_empty() {
+            // Candidate universe: positions in X × Y of the remaining movers.
+            let nodes = self.clique_candidate_nodes(&remaining);
+            if nodes.is_empty() {
+                break;
+            }
+            let movers: &HashSet<u64> = &remaining;
+
+            // Adjacency bitsets: edge iff the 2×2 {A,B} rectangle is valid.
+            let n = nodes.len();
+            let mut adj = vec![0u64; n];
+            for i in 0..n {
+                for j in (i + 1)..n {
+                    let (xi, yi) = nodes[i];
+                    let (xj, yj) = nodes[j];
+                    let xs: BTreeSet<u64> = [xi, xj].into_iter().collect();
+                    let ys: BTreeSet<u64> = [yi, yj].into_iter().collect();
+                    if self.is_valid_rect(&xs, &ys, movers) {
+                        adj[i] |= 1u64 << j;
+                        adj[j] |= 1u64 << i;
+                    }
+                }
+            }
+
+            // Evaluate a clique (bitset over node indices) by the objective.
+            // Returns None if it covers zero input movers.
+            let is_mover = |idx: usize| -> bool {
+                self.pos_to_src
+                    .get(&nodes[idx])
+                    .is_some_and(|src| movers.contains(src))
+            };
+            let eval = |clique: u64| -> Option<(usize, std::cmp::Reverse<usize>, u64)> {
+                if clique == 0 {
+                    return None;
+                }
+                let mut movers_covered = 0usize;
+                let mut bits = clique;
+                while bits != 0 {
+                    let idx = bits.trailing_zeros() as usize;
+                    bits &= bits - 1;
+                    if is_mover(idx) {
+                        movers_covered += 1;
+                    }
+                }
+                if movers_covered == 0 {
+                    return None;
+                }
+                let area = clique.count_ones() as usize; // clique == full rectangle
+                // Deterministic tie-break: the clique's raw bitset (lower node
+                // indices, which follow sorted node order, win).
+                Some((movers_covered, std::cmp::Reverse(area), !clique))
+            };
+
+            // Find the best maximal clique.
+            let mut best_key: Option<(usize, std::cmp::Reverse<usize>, u64)> = None;
+            let mut best_clique: u64 = 0;
+            let mut consider = |clique: u64| {
+                if let Some(key) = eval(clique)
+                    && best_key.as_ref().is_none_or(|b| key > *b)
+                {
+                    best_key = Some(key);
+                    best_clique = clique;
+                }
+            };
+
+            if n <= Self::MAX_EXACT_CLIQUE_NODES {
+                let full_p: u64 = if n == 64 { u64::MAX } else { (1u64 << n) - 1 };
+                Self::bron_kerbosch(&adj, 0, full_p, 0, &mut consider);
+            } else {
+                Self::greedy_max_clique(&adj, n, &is_mover, &mut consider);
+            }
+
+            if best_clique == 0 {
+                break; // no mover-covering clique (shouldn't happen while movers remain)
+            }
+
+            // Tone sets of the winning clique → complete rectangle.
+            let mut xs = BTreeSet::new();
+            let mut ys = BTreeSet::new();
+            let mut bits = best_clique;
+            while bits != 0 {
+                let idx = bits.trailing_zeros() as usize;
+                bits &= bits - 1;
+                let (x, y) = nodes[idx];
+                xs.insert(x);
+                ys.insert(y);
+            }
+            let lanes = self.rect_to_lanes(&xs, &ys);
+            if lanes.is_empty() {
+                break;
+            }
+
+            // Prune covered movers (sources inside the rectangle).
+            for &x in &xs {
+                for &y in &ys {
+                    if let Some(&src) = self.pos_to_src.get(&(x, y)) {
+                        remaining.remove(&src);
+                    }
+                }
+            }
+            out.push(lanes);
+        }
+
+        out
+    }
+
+    /// Valid positions in the movers' induced X × Y product (each a valid 1×1).
+    /// Sorted for determinism. Capped at 64 nodes (u64 bitset); excess dropped
+    /// deterministically (the greedy fallback handles large sets, and >64 valid
+    /// positions is not expected per bus per step).
+    fn clique_candidate_nodes(&self, movers: &HashSet<u64>) -> Vec<(u64, u64)> {
+        let mut xs = BTreeSet::new();
+        let mut ys = BTreeSet::new();
+        for &src in movers {
+            if let Some(&(x, y)) = self.src_to_pos.get(&src) {
+                xs.insert(x);
+                ys.insert(y);
+            }
+        }
+        let mut nodes = Vec::new();
+        for &x in &xs {
+            for &y in &ys {
+                let px: BTreeSet<u64> = [x].into_iter().collect();
+                let py: BTreeSet<u64> = [y].into_iter().collect();
+                if self.is_valid_rect(&px, &py, movers) {
+                    nodes.push((x, y));
+                    if nodes.len() == 64 {
+                        return nodes;
+                    }
+                }
+            }
+        }
+        nodes
+    }
+
+    /// Bron–Kerbosch with pivoting over a u64 adjacency bitset (≤64 nodes).
+    /// Invokes `visit` on each maximal clique (as a node-index bitset).
+    fn bron_kerbosch(
+        adj: &[u64],
+        r: u64,
+        p: u64,
+        x: u64,
+        visit: &mut impl FnMut(u64),
+    ) {
+        if p == 0 && x == 0 {
+            visit(r);
+            return;
+        }
+        // Pivot u ∈ P∪X maximizing |P ∩ adj[u]|.
+        let mut pux = p | x;
+        let mut pivot = 0usize;
+        let mut best = -1i32;
+        while pux != 0 {
+            let u = pux.trailing_zeros() as usize;
+            pux &= pux - 1;
+            let cnt = (p & adj[u]).count_ones() as i32;
+            if cnt > best {
+                best = cnt;
+                pivot = u;
+            }
+        }
+        let mut p = p;
+        let mut x = x;
+        let mut cand = p & !adj[pivot];
+        while cand != 0 {
+            let v = cand.trailing_zeros() as usize;
+            let vbit = 1u64 << v;
+            cand &= cand - 1;
+            Self::bron_kerbosch(adj, r | vbit, p & adj[v], x & adj[v], visit);
+            p &= !vbit;
+            x |= vbit;
+        }
+    }
+
+    /// Greedy maximal-clique fallback for large node sets. Seeds from each mover
+    /// node, extends by highest-degree compatible node, and reports each grown
+    /// clique to `visit`. Deterministic (sorted seeds/candidates).
+    fn greedy_max_clique(
+        adj: &[u64],
+        n: usize,
+        is_mover: &impl Fn(usize) -> bool,
+        visit: &mut impl FnMut(u64),
+    ) {
+        for seed in 0..n {
+            if !is_mover(seed) {
+                continue;
+            }
+            let mut clique = 1u64 << seed;
+            let mut cand = adj[seed];
+            while cand != 0 {
+                // Pick the candidate with the most connections to `cand`
+                // (deterministic: lowest index breaks ties).
+                let mut bits = cand;
+                let mut pick = usize::MAX;
+                let mut best = -1i32;
+                while bits != 0 {
+                    let v = bits.trailing_zeros() as usize;
+                    bits &= bits - 1;
+                    let deg = (adj[v] & cand).count_ones() as i32;
+                    if deg > best {
+                        best = deg;
+                        pick = v;
+                    }
+                }
+                if pick == usize::MAX {
+                    break;
+                }
+                clique |= 1u64 << pick;
+                cand &= adj[pick];
+            }
+            visit(clique);
+        }
+    }
+```
+
+- [ ] **Step 5: Run the clique tests**
+
+Run: `cargo test -p bloqade-lanes-search clique`
+Expected: PASS — `clique_builds_single_complete_rectangle`, `clique_recovers_rectangle_greedy_would_split`, `clique_emits_only_mover_covering_rectangles`, `clique_reversibility_rejects_filled_filler_destination`.
+
+- [ ] **Step 6: Add determinism + fallback tests**
+
+```rust
+    #[test]
+    fn clique_is_deterministic() {
+        let ctx = make_context(
+            &[((0, 0), 10), ((1, 0), 11), ((0, 1), 12), ((1, 1), 13)],
+            &[(10, 100), (11, 101), (12, 102), (13, 103)],
+            &[],
+        )
+        .with_strategy(AodGridStrategy::Clique);
+        let entries: HashMap<u64, u64> =
+            [(10, 100), (11, 101), (12, 102), (13, 103)].into_iter().collect();
+        let a = ctx.build_aod_grids(&entries);
+        let b = ctx.build_aod_grids(&entries);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn clique_covers_all_movers_via_decomposition() {
+        // Two separate movers whose induced 2×2 corners are blocked, forcing
+        // two 1×1 shots. Both movers must be covered across the returned grids.
+        let ctx = make_context_with_occupied(
+            &[((0, 0), 10), ((3, 3), 13), ((3, 0), 11), ((0, 3), 12)],
+            &[(10, 100), (13, 103), (11, 101), (12, 102)],
+            &[],
+            &[11, 12], // corner sources are spectators → 2×2 invalid
+        )
+        .with_strategy(AodGridStrategy::Clique);
+        let entries: HashMap<u64, u64> = [(10, 100), (13, 103)].into_iter().collect();
+
+        let grids = ctx.build_aod_grids(&entries);
+        let covered: HashSet<u64> = grids.iter().flatten().copied().collect();
+        assert!(covered.contains(&100) && covered.contains(&103));
+    }
+```
+
+- [ ] **Step 7: Run all aod_grid tests + clippy + fmt**
+
+Run: `cargo test -p bloqade-lanes-search aod_grid`
+Expected: PASS (all greedy + clique tests).
+Run: `cargo clippy -p bloqade-lanes-search --all-targets -- -D warnings`
+Expected: clean.
+Run: `cargo fmt -p bloqade-lanes-search`
+Expected: no diff (or apply).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/bloqade-lanes-search/src/ops/aod_grid.rs
+git commit -m "feat(search): clique-based AOD grid construction strategy"
+```
+
+---
+
+## Task 3: Wire the strategy through config to call sites
+
+**Files:**
+- Modify: `crates/bloqade-lanes-search/src/search/options.rs` (add `aod_grid_strategy` to `EntropyOptions`)
+- Modify: `crates/bloqade-lanes-search/src/drivers/entropy.rs` (3 sites: lines ~417, ~962, ~2451)
+- Modify: `crates/bloqade-lanes-search/src/generators/greedy.rs` (line ~93)
+- Modify: `crates/bloqade-lanes-search/src/generators/heuristic.rs` (line ~554)
+- Modify: `crates/bloqade-lanes-search/src/dsl/pipeline.rs` (line ~112)
+
+**Interfaces:**
+- Consumes: `AodGridStrategy` (Task 1), `BusGridContext::with_strategy` (Task 1).
+- Produces: `EntropyOptions.aod_grid_strategy: AodGridStrategy`.
+
+- [ ] **Step 1: Add the config field**
+
+In `crates/bloqade-lanes-search/src/search/options.rs`, add to `EntropyOptions` (in the struct, and set its default in the `Default`/constructor for `EntropyOptions`):
+
+```rust
+    /// Strategy for AOD grid construction from selected movers.
+    pub aod_grid_strategy: AodGridStrategy,
+```
+
+Add `aod_grid_strategy: AodGridStrategy::default(),` to the `EntropyOptions` default initializer. (`AodGridStrategy` is in the same module.)
+
+- [ ] **Step 2: Thread into the 3 entropy call sites**
+
+At each `let grid_ctx = BusGridContext::new(...);` in `drivers/entropy.rs` (lines ~417, ~962, ~2451), append `.with_strategy(<opts>.aod_grid_strategy)`, where `<opts>` is the `EntropyOptions` in scope at that site (the entropy driver already carries its options — locate the `EntropyOptions` binding in each function and read `.aod_grid_strategy`). Example for line ~417:
+
+```rust
+let grid_ctx = BusGridContext::new(ctx.index, mt, bus_id, None, dir, occupied)
+    .with_strategy(opts.aod_grid_strategy);
+```
+
+Verify the exact `EntropyOptions` variable name in each of the three functions before editing; if a function does not already have the options in scope, thread it in from its caller (the entropy driver constructs from `EntropyOptions`).
+
+- [ ] **Step 3: Thread into greedy / heuristic / dsl generators**
+
+These generators are not entropy-specific. For each, plumb the strategy from the generator's own configuration:
+
+- `generators/greedy.rs` (~line 93): append `.with_strategy(self.aod_grid_strategy)` and add an `aod_grid_strategy: AodGridStrategy` field to the greedy generator struct (default via its constructor).
+- `generators/heuristic.rs` (~line 554): same pattern — add the field to `HeuristicGenerator` and append `.with_strategy(self.aod_grid_strategy)`.
+- `dsl/pipeline.rs` (~line 112): the DSL pipeline builds the context directly; read the strategy from the pipeline's config struct (add an `aod_grid_strategy` field there) and append `.with_strategy(...)`.
+
+For each struct that gains the field, default it to `AodGridStrategy::default()` so existing constructors and tests are unaffected.
+
+- [ ] **Step 4: Build + full crate tests + lint**
+
+Run: `cargo test -p bloqade-lanes-search`
+Expected: PASS (no behavior change — everything defaults to `GreedyMerge`).
+Run: `cargo clippy -p bloqade-lanes-search --all-targets -- -D warnings` and `cargo fmt -p bloqade-lanes-search`
+Expected: clean.
+
+- [ ] **Step 5: Add an end-to-end wiring test**
+
+Add a test (in `drivers/entropy.rs` tests or a suitable integration test) that constructs `EntropyOptions { aod_grid_strategy: AodGridStrategy::Clique, ..Default::default() }`, runs the entropy path on a small config with a known multi-mover bus, and asserts a valid moveset is produced (grids non-empty, movers covered). Mirror an existing entropy test's setup for the fixture.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/bloqade-lanes-search/src/search/options.rs \
+        crates/bloqade-lanes-search/src/drivers/entropy.rs \
+        crates/bloqade-lanes-search/src/generators/greedy.rs \
+        crates/bloqade-lanes-search/src/generators/heuristic.rs \
+        crates/bloqade-lanes-search/src/dsl/pipeline.rs
+git commit -m "feat(search): thread AodGridStrategy through config to grid call sites"
+```
+
+---
+
+## Notes for the Implementer
+
+- **Why reuse `is_valid_rect` for edges:** a node is a valid 1×1 rectangle; an edge A–B is a valid 2×2 rectangle `{xₐ,x_b}×{yₐ,y_b}`. Because every cell of a clique's full `X×Y` product is a corner of some node pair, all-edges-valid ⟹ the full rectangle is valid — so a maximal clique is exactly a maximal valid rectangle. This also inherits the mover / rect-mover / reversibility handling already in `is_valid_rect` with no duplication.
+- **Objective:** `(movers_covered desc, area asc, deterministic)` with `movers_covered ≥ 1`. `area == clique.count_ones()` because a maximal clique equals its full rectangle.
+- **`is_none_or` / `is_some_and`:** stable since Rust 1.82 / 1.70; this crate is edition 2024, so they are available.
+- **Bitset limit:** ≤64 nodes (u64). `clique_candidate_nodes` caps at 64; the exact/greedy split is at `MAX_EXACT_CLIQUE_NODES = 32`. Both are deterministic. If profiling shows large per-bus candidate sets, raising the cap or adding a maximal-clique-count guard is a follow-up.
+- **Determinism:** `BTreeSet` iteration + sorted node vector + `!clique` tie-break keep output stable regardless of `HashMap` iteration order.

--- a/docs/superpowers/specs/2026-07-01-aod-grid-clique-strategy-design.md
+++ b/docs/superpowers/specs/2026-07-01-aod-grid-clique-strategy-design.md
@@ -1,0 +1,196 @@
+# AOD Grid Clique Strategy Design
+
+**Goal:** Add a second, selectable strategy for turning an arbitrary set of
+input mover lanes into valid AOD rectangles in
+`crates/bloqade-lanes-search/src/ops/aod_grid.rs`. The new strategy models the
+problem as a **conflict graph over lanes** and extracts **cliques** (each a valid
+AOD rectangle), maximizing the number of input movers covered per shot while
+completing each rectangle with filler/no-op lanes for full AOD utilization. The
+existing greedy-init + merge strategy stays as the default.
+
+**Non-goals:** Changing the rectangle/AOD validity model itself; changing the
+`Vec<Vec<u64>>` return contract; multi-bus solving (still per bus group).
+
+**Tech stack:** Rust (`bloqade-lanes-search` crate), `BusGridContext` in
+`ops/aod_grid.rs`, `search/options.rs` (existing `Strategy` enum + option
+bundles), hand-rolled Bron–Kerbosch (no `petgraph`/graph dep in this crate).
+
+---
+
+## Background
+
+`BusGridContext` is built per bus group `(MoveType, bus_id, Direction)` from ALL
+lanes on that bus, plus the set of `occupied` locations (atoms / blocked). Its
+`build_aod_grids(entries)` takes `entries: HashMap<encoded_src, encoded_lane>`
+(the selected movers) and returns `Vec<Vec<u64>>` — a list of valid AOD
+rectangles (lane sets). Crossed AODs illuminate the Cartesian product of the
+selected X-tones × Y-tones, so a valid shot is a **rectangle**: every position
+in `X × Y` must be present and safe. "Rectangle" means the product of two
+coordinate **sets** — the coordinates need not be contiguous.
+
+The current strategy builds rectangles greedily then iteratively merges
+compatible ones. Consumers (`drivers/entropy.rs` ×3, `generators/greedy.rs`,
+`generators/heuristic.rs`, `dsl/pipeline.rs`) iterate the returned grids, score
+each, and select the best.
+
+### Validity & reversibility
+
+A rectangle cell (a lane `src → dst`) is valid iff moving it is **reversible**:
+
+- A **mover** cell: `src` holds an atom we intend to move; valid iff `dst` is
+  unoccupied *or* occupied by another mover inside this rectangle.
+- A **filler** (no-op) cell: `src` is empty; valid iff `dst` is **also** empty.
+  An empty-source / filled-destination cell is invalid even though the forward
+  move collides with nothing — because the *reverse* move would drag the
+  destination atom, which we never intended to move.
+
+This is the logic in today's `is_valid_rect`; it is preserved.
+
+### Key insight (why cliques model rectangles)
+
+Model each candidate lane as a graph node and connect two lanes
+`A = (xₐ,yₐ)` and `B = (x_b,y_b)` with a **non-conflict edge** iff both induced
+corners `(xₐ, y_b)` and `(x_b, yₐ)` are present as valid cells. Then **any clique
+induces a fully valid rectangle**: every cell `(xᵢ, yⱼ)` of the clique's
+`X × Y` product is a corner of the pair `(i, j)`, and diagonal cells `(xᵢ, yᵢ)`
+are the nodes themselves — so all-pairs-valid ⟹ all-cells-valid. This makes the
+pairwise conflict graph a sound encoding of the (global) rectangle constraint.
+
+---
+
+## Section 1 — Strategy enum + wiring
+
+- Add `AodGridStrategy { GreedyMerge, Clique }` to `search/options.rs`, next to
+  the existing `Strategy` enum. `#[derive(..., Default)]` with
+  `#[default] GreedyMerge` so current behavior is unchanged.
+- Store the selected strategy as a field on `BusGridContext`, set in
+  `BusGridContext::new(...)` (all six construction sites already call it). The
+  public `build_aod_grids(&entries)` signature is **unchanged**; internally it
+  dispatches to the greedy path or the new clique path based on the field.
+- Thread the enum from the option bundles (e.g. `EntropyOptions`, and the
+  greedy/heuristic/dsl generator configs) down to each `BusGridContext::new`
+  call. This is the configurable wiring: flip one config value to select the
+  strategy everywhere it is plumbed.
+
+**Touch points:** `search/options.rs` (new enum + option-bundle field),
+`ops/aod_grid.rs` (field + dispatch + new method), and the 6 `BusGridContext::new`
+call sites (pass the strategy through from their config). Call sites that don't
+yet plumb a config keep the `Default` (`GreedyMerge`).
+
+---
+
+## Section 2 — Clique algorithm (`build_aod_grids_clique`)
+
+Operates on the same `BusGridContext` data. Given `entries` (input movers):
+
+1. **Candidate universe = the movers' induced Cartesian product.**
+   `X = { distinct x-tone of each input mover }`,
+   `Y = { distinct y-tone of each input mover }`. Candidate positions are the
+   full product `X × Y`. This bounds the problem to the movers' tone span (no
+   growth beyond it).
+2. **Nodes.** For each position in `X × Y`, add a node for its lane iff the cell
+   is **reversibility-valid** (mover cell with free/rect-mover destination, or
+   filler cell with empty source *and* empty destination). Positions with a
+   spectator source, a blocked destination, or no lane produce no node.
+3. **Edges (non-conflict).** Connect nodes `A`, `B` iff their induced corners
+   `(xₐ,y_b)` and `(x_b,yₐ)` are both present as valid nodes.
+4. **Select the winning clique.** Objective, in order:
+   1. maximize the number of **input movers** covered by the clique's rectangle;
+   2. tie-break: **smaller** rectangle area `|X_clique| × |Y_clique|` (don't
+      inflate with unnecessary no-op tones);
+   3. tie-break: deterministic (sorted lane/src encoding).
+   Every emitted shot must cover **≥ 1 input mover** — a clique covering zero
+   input movers can never win, so mover-less rectangles never dominate.
+   Solver: exact **Bron–Kerbosch with pivoting** (hand-rolled), evaluating
+   maximal cliques by the objective; above a node-count cap
+   (const, e.g. 32) fall back to a greedy degeneracy-order heuristic to bound
+   worst-case runtime.
+5. **Emit the complete rectangle.** `rect_to_lanes` over the winning clique's
+   `X × Y` → all lanes at those positions, **including filler/no-op lanes** (full
+   AOD utilization: the shot is a complete rectangle, not a sparse subset).
+6. **Decompose.** Remove the covered input movers, recompute the candidate
+   product from the **remaining** movers, and rerun steps 1–5 until no input
+   movers remain. Returns `Vec<Vec<u64>>` — same contract as the greedy path;
+   consumers still score each grid and pick the best.
+
+---
+
+## Section 3 — Determinism, fallback, refactor, edge cases
+
+- **Determinism:** sorted node ordering, deterministic pivot selection, and the
+  encoding-order final tie-break keep output reproducible (the search relies on
+  this).
+- **Fallback:** node-count cap → greedy degeneracy-order clique heuristic;
+  `log`/comment notes the cap so silent truncation is visible.
+- **Refactor:** extract the per-cell validity check out of `is_valid_rect` into
+  a shared helper (e.g. `is_valid_cell(src, dst, movers, rect_movers)`) used by
+  both the greedy path (unchanged behavior) and the clique edge predicate.
+- **Edge cases:** empty `entries` → empty `Vec` (as today); a mover that
+  conflicts with every other candidate → its own 1×1 rectangle; a mover whose
+  own cell is invalid (destination blocked) → excluded (cannot be placed this
+  shot), consistent with the greedy path.
+
+---
+
+## Section 4 — Testing
+
+Rust unit tests in `ops/aod_grid.rs`, mirroring the existing helpers
+(`make_context*`):
+
+- **Behavioral parity where expected:** all-movers 2×2, sparse color-code
+  rectangle, spectator/reversibility rejection, empty-filler inclusion — assert
+  the clique strategy produces valid complete rectangles.
+- **Clique beats greedy:** a configuration where the clique strategy finds a
+  larger single valid rectangle than greedy-init+merge would.
+- **Mover-less domination guard:** a large valid empty region adjacent to a few
+  movers — assert emitted shots always contain ≥1 mover and are not the empty
+  rectangle.
+- **Tie-break:** equal-mover cliques of different areas → smaller area chosen.
+- **Fallback path:** synthetic node set above the cap → still returns valid
+  rectangles (heuristic).
+- **Determinism:** identical output across repeated runs / shuffled input order.
+- **Existing 8 greedy tests stay green** under `GreedyMerge` (unchanged).
+
+---
+
+## File Layout
+
+| File | Status | Responsibility |
+|------|--------|----------------|
+| `crates/bloqade-lanes-search/src/search/options.rs` | EDIT | Add `AodGridStrategy` enum; add field to the option bundle(s) that reach grid construction |
+| `crates/bloqade-lanes-search/src/ops/aod_grid.rs` | EDIT | Add strategy field to `BusGridContext`; dispatch in `build_aod_grids`; add `build_aod_grids_clique`; extract `is_valid_cell`; hand-rolled Bron–Kerbosch; new tests |
+| `crates/bloqade-lanes-search/src/drivers/entropy.rs` | EDIT | Pass strategy into the 3 `BusGridContext::new` calls from config |
+| `crates/bloqade-lanes-search/src/generators/greedy.rs` | EDIT | Pass strategy into `BusGridContext::new` |
+| `crates/bloqade-lanes-search/src/generators/heuristic.rs` | EDIT | Pass strategy into `BusGridContext::new` |
+| `crates/bloqade-lanes-search/src/dsl/pipeline.rs` | EDIT | Pass strategy into `BusGridContext::new` |
+
+---
+
+## Objective, stated precisely
+
+For a candidate clique `C` with induced tone sets `X_C`, `Y_C`:
+
+```
+key(C) = ( movers_covered(C),        // maximize
+          -(|X_C| * |Y_C|),          // then maximize (i.e. prefer smaller area)
+           deterministic_tiebreak )   // then maximize (stable)
+```
+
+pick `argmax key(C)` subject to `movers_covered(C) >= 1`.
+
+**"Utilization" vs. "smaller area" — not a contradiction.** Utilization means the
+emitted shot is a *complete* rectangle: every valid cell of the winning clique's
+`X × Y` is driven, including no-op filler lanes (step 5). The smaller-area
+tie-break only chooses *between cliques that cover the same movers* — it avoids
+padding the rectangle with extra tones the movers don't already span. We complete
+the rectangle we pick; we don't grow it just to add no-ops.
+
+---
+
+## Follow-Ups (Out of Scope)
+
+- Wiring the enum through the Python/PyO3 surface or the DSL config, if callers
+  want to select it from Python.
+- Multi-bus / cross-group AOD scheduling.
+- Weighting the clique objective by mover *score* (fidelity/priority) rather than
+  raw count.


### PR DESCRIPTION
## Summary

Adds a second, **selectable** strategy for building AOD-compatible rectangles from a set of mover lanes in `bloqade-lanes-search` (`ops/aod_grid.rs`): a **conflict-graph / max-clique** approach alongside the existing greedy+merge builder. Default behavior is unchanged (`AodGridStrategy::GreedyMerge`).

## Approach

Candidate nodes are the valid positions in the input movers' induced Cartesian product `X × Y`. A node is a valid 1×1 rectangle and an edge A–B is a valid 2×2 rectangle — both decided by reusing the existing `is_valid_rect`, so **a maximal clique is exactly a maximal valid rectangle** (every product cell is a corner of some node pair ⇒ all-pairs-valid ⇒ full rectangle valid). The strategy:

- selects the clique maximizing `(movers_covered desc, area asc, deterministic)`, scored on the **emitted product** `X_C × Y_C` (not the clique bitset), requiring ≥1 input mover per shot (no no-op-only rectangles);
- emits the **complete** rectangle via `rect_to_lanes` — filler/no-op lanes included, for full AOD utilization;
- decomposes by pruning covered movers and rerunning until none remain.

Solver: hand-rolled **Bron–Kerbosch** with pivoting (u64 adjacency bitset, ≤64 nodes), with a deterministic **greedy fallback** above `MAX_EXACT_CLIQUE_NODES = 32`. Output is deterministic (BTreeSet tone sets, sorted nodes, stable tie-break) — independent of `HashMap` iteration order.

Reversibility is preserved from the existing model: a filler lane needs **both** endpoints free (an empty-source / filled-destination move is invalid because its *reverse* would drag an unintended atom).

An `AodGridStrategy { GreedyMerge, Clique }` enum is threaded through config to all 6 `BusGridContext::new` sites. The **entropy path is user-selectable end-to-end** via `EntropyOptions.aod_grid_strategy`; the greedy/heuristic generators and DSL pipeline carry the field (defaulting to `GreedyMerge`) with builders ready to wire — see Follow-ups.

## Design & plan

- Spec: `docs/superpowers/specs/2026-07-01-aod-grid-clique-strategy-design.md`
- Plan: `docs/superpowers/plans/2026-07-01-aod-grid-clique-strategy.md`

## Test plan

- [x] `cargo test -p bloqade-lanes-search` — 309 unit + integration pass, 0 failures
- [x] `cargo clippy -p bloqade-lanes-search --all-targets -- -D warnings` — clean
- [x] `cargo check --workspace --all-targets` — all 3 crates compile
- [x] Clique unit tests: complete-rectangle, clique-beats-greedy-split, **mover-less-domination guard**, reversibility rejection, determinism (order-independent), decomposition coverage, greedy-fallback (>32 nodes)
- [x] End-to-end wiring test exercising `AodGridStrategy::Clique` through the entropy path (asserts real movement, non-vacuous)

## Follow-ups (out of scope)

- Wire the greedy/heuristic generators and DSL pipeline strategy from a user-facing config (builders/fields exist, default `GreedyMerge`).
- Expose the selector through the Python/PyO3 / DSL surface.
- Weight the objective by mover *score* rather than raw count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
