### PR TITLE
feat(arch): add ZoneBuilder.from_positions classmethod

### DIFF
--- a/python/bloqade/lanes/arch/build/imperative.py
+++ b/python/bloqade/lanes/arch/build/imperative.py
@@ -203,6 +203,46 @@ class ZoneBuilder:
         self._entangling_pairs: list[tuple[int, int]] = []
         self._blockade_radius_nm: int | None = None
 
+    @classmethod
+    def from_positions(
+        cls,
+        name: str,
+        x_coordinates: Sequence[float | int],
+        y_coordinates: Sequence[float | int],
+        word_shape: tuple[int, int],
+        *,
+        x_clearance: float,
+        y_clearance: float,
+    ) -> ZoneBuilder:
+        """Build a zone from explicit x/y coordinate arrays.
+
+        Convenience constructor that builds the coordinate grid from
+        ``x_coordinates`` and ``y_coordinates`` (via ``Grid.from_positions``)
+        and forwards the remaining arguments to the default constructor.
+
+        Args:
+            name: Human-readable zone name (stored in Rust Zone).
+            x_coordinates: X-coordinates of the grid points (at least one).
+                Every position must be representable at 1 nm precision.
+            y_coordinates: Y-coordinates of the grid points (at least one).
+            word_shape: (num_x_sites, num_y_sites) — uniform shape for
+                all words in this zone.
+            x_clearance: Minimum x-axis clearance (> 0, µm) from grid lines
+                that path waypoints must maintain.
+            y_clearance: Same as ``x_clearance``, applied to the y-axis.
+
+        Returns:
+            ZoneBuilder: The constructed zone.
+        """
+        grid = _RustGrid.from_positions(list(x_coordinates), list(y_coordinates))
+        return cls(
+            name,
+            grid,
+            word_shape,
+            x_clearance=x_clearance,
+            y_clearance=y_clearance,
+        )
+
     @property
     def name(self) -> str:
         """Zone name."""

--- a/python/tests/arch/test_arch_builder.py
+++ b/python/tests/arch/test_arch_builder.py
@@ -76,6 +76,64 @@ class TestAODValidation:
         _validate_aod_rectangle([(0, 0), (0, 1), (0, 2)], "test")
 
 
+# ── ZoneBuilder: from_positions ──
+
+
+class TestZoneBuilderFromPositions:
+    def test_builds_equivalent_to_default_constructor(self):
+        xs = [0.0, 1.0, 2.0, 3.0]
+        ys = [0.0, 1.0]
+        zone = ZoneBuilder.from_positions(
+            "gate",
+            xs,
+            ys,
+            word_shape=(2, 1),
+            x_clearance=_DEFAULT_CL,
+            y_clearance=_DEFAULT_CL,
+        )
+        assert isinstance(zone, ZoneBuilder)
+        assert zone.name == "gate"
+        assert zone.word_shape == (2, 1)
+        assert zone.x_clearance == _DEFAULT_CL
+        assert zone.y_clearance == _DEFAULT_CL
+        assert list(zone._grid.x_positions) == xs
+        assert list(zone._grid.y_positions) == ys
+
+    def test_accepts_int_coordinates(self):
+        zone = ZoneBuilder.from_positions(
+            "gate",
+            [0, 1, 2, 3],
+            [0, 1],
+            word_shape=(2, 1),
+            x_clearance=_DEFAULT_CL,
+            y_clearance=_DEFAULT_CL,
+        )
+        assert list(zone._grid.x_positions) == [0.0, 1.0, 2.0, 3.0]
+        assert list(zone._grid.y_positions) == [0.0, 1.0]
+
+    def test_result_is_usable(self):
+        zone = ZoneBuilder.from_positions(
+            "gate",
+            [0.0, 1.0, 2.0, 3.0],
+            [0.0, 1.0],
+            word_shape=(2, 1),
+            x_clearance=_DEFAULT_CL,
+            y_clearance=_DEFAULT_CL,
+        )
+        assert zone.add_word(x_sites=slice(0, 2), y_sites=slice(0, 1)) == 0
+
+    def test_invalid_clearance_raises(self):
+        with pytest.raises(ValueError, match="x_clearance must be positive"):
+            ZoneBuilder.from_positions(
+                "gate",
+                [0.0, 1.0],
+                [0.0],
+                word_shape=(2, 1),
+                x_clearance=0.0,
+                y_clearance=_DEFAULT_CL,
+            )
+
+
 # ── ZoneBuilder: add_word ──
 
 


### PR DESCRIPTION
## Summary

Adds a `ZoneBuilder.from_positions` classmethod in `bloqade.lanes.arch.build.imperative` that constructs a `ZoneBuilder` directly from explicit `x_coordinates` / `y_coordinates` sequences instead of a pre-built `Grid`.

Internally it builds the grid via `Grid.from_positions(...)` and forwards the remaining arguments (`name`, `word_shape`, `x_clearance`, `y_clearance`) to the default constructor.

## Test plan

- New `TestZoneBuilderFromPositions` class in `python/tests/arch/test_arch_builder.py` covering:
  - equivalence with the default constructor (name, word_shape, clearances, grid positions)
  - `int` coordinates accepted (`Sequence[float | int]`)
  - the returned builder is usable (`add_word` succeeds)
  - invalid clearance still raises through the default constructor
- `uv run pytest python/tests/arch/test_arch_builder.py` → 101 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)