### PR TITLE
fix(lanes): merge all StaticPlacement so no-return placement threads state across CZ layers

### DIFF
--- a/python/bloqade/lanes/analysis/placement/strategy.py
+++ b/python/bloqade/lanes/analysis/placement/strategy.py
@@ -139,17 +139,15 @@ class SingleZonePlacementStrategyABC(PlacementStrategyABC):
         if len(qubits) != len(state.layout):
             return AtomState.bottom()
 
-        # Order layout/zone_maps/move_count by the measurement order ``qubits``
-        # so each emitted measurement result lines up with the location of the
-        # qubit it measures. ``qubits`` is identity for un-merged blocks but a
-        # permutation once StaticPlacement blocks are merged (always_merge),
-        # which remaps qubit indices; reading state.layout positionally would
-        # then pair a result with the wrong patch.
+        # ``layout`` stays canonical (indexed by qubit id). The measurement
+        # order is carried by ``place.EndMeasure.qubits`` and applied when the
+        # measurement is lowered (see ``place2move.InsertMeasure``), so we do
+        # not permute the layout here (that would relabel qubits).
         return ExecuteMeasure(
             occupied=state.occupied,
-            layout=tuple(state.layout[i] for i in qubits),
-            move_count=tuple(state.move_count[i] for i in qubits),
-            zone_maps=tuple(ZoneAddress(state.layout[i].zone_id) for i in qubits),
+            layout=state.layout,
+            move_count=state.move_count,
+            zone_maps=tuple(ZoneAddress(loc.zone_id) for loc in state.layout),
         )
 
 

--- a/python/bloqade/lanes/analysis/placement/strategy.py
+++ b/python/bloqade/lanes/analysis/placement/strategy.py
@@ -139,11 +139,17 @@ class SingleZonePlacementStrategyABC(PlacementStrategyABC):
         if len(qubits) != len(state.layout):
             return AtomState.bottom()
 
+        # Order layout/zone_maps/move_count by the measurement order ``qubits``
+        # so each emitted measurement result lines up with the location of the
+        # qubit it measures. ``qubits`` is identity for un-merged blocks but a
+        # permutation once StaticPlacement blocks are merged (always_merge),
+        # which remaps qubit indices; reading state.layout positionally would
+        # then pair a result with the wrong patch.
         return ExecuteMeasure(
             occupied=state.occupied,
-            layout=state.layout,
-            move_count=state.move_count,
-            zone_maps=tuple(ZoneAddress(loc.zone_id) for loc in state.layout),
+            layout=tuple(state.layout[i] for i in qubits),
+            move_count=tuple(state.move_count[i] for i in qubits),
+            zone_maps=tuple(ZoneAddress(state.layout[i].zone_id) for i in qubits),
         )
 
 

--- a/python/bloqade/lanes/heuristics/logical/placement.py
+++ b/python/bloqade/lanes/heuristics/logical/placement.py
@@ -724,15 +724,13 @@ class LogicalPlacementStrategyNoHome(LogicalPlacementMethods, PlacementStrategyA
         if len(qubits) != len(state.layout):
             return AtomState.bottom()
 
-        # Order layout/zone_maps/move_count by the measurement order ``qubits``
-        # so each emitted measurement result lines up with the location of the
-        # qubit it measures. ``qubits`` is identity for un-merged blocks but a
-        # permutation once StaticPlacement blocks are merged (always_merge),
-        # which remaps qubit indices; reading state.layout positionally would
-        # then pair a result with the wrong patch.
+        # ``layout`` stays canonical (indexed by qubit id). The measurement
+        # order is carried by ``place.EndMeasure.qubits`` and applied when the
+        # measurement is lowered (see ``place2move.InsertMeasure``), so we do
+        # not permute the layout here (that would relabel qubits).
         return ExecuteMeasure(
             occupied=state.occupied,
-            layout=tuple(state.layout[i] for i in qubits),
-            move_count=tuple(state.move_count[i] for i in qubits),
-            zone_maps=tuple(ZoneAddress(state.layout[i].zone_id) for i in qubits),
+            layout=state.layout,
+            move_count=state.move_count,
+            zone_maps=tuple(ZoneAddress(loc.zone_id) for loc in state.layout),
         )

--- a/python/bloqade/lanes/heuristics/logical/placement.py
+++ b/python/bloqade/lanes/heuristics/logical/placement.py
@@ -724,9 +724,15 @@ class LogicalPlacementStrategyNoHome(LogicalPlacementMethods, PlacementStrategyA
         if len(qubits) != len(state.layout):
             return AtomState.bottom()
 
+        # Order layout/zone_maps/move_count by the measurement order ``qubits``
+        # so each emitted measurement result lines up with the location of the
+        # qubit it measures. ``qubits`` is identity for un-merged blocks but a
+        # permutation once StaticPlacement blocks are merged (always_merge),
+        # which remaps qubit indices; reading state.layout positionally would
+        # then pair a result with the wrong patch.
         return ExecuteMeasure(
             occupied=state.occupied,
-            layout=state.layout,
-            move_count=state.move_count,
-            zone_maps=tuple(ZoneAddress(loc.zone_id) for loc in state.layout),
+            layout=tuple(state.layout[i] for i in qubits),
+            move_count=tuple(state.move_count[i] for i in qubits),
+            zone_maps=tuple(ZoneAddress(state.layout[i].zone_id) for i in qubits),
         )

--- a/python/bloqade/lanes/heuristics/physical/_no_return_base.py
+++ b/python/bloqade/lanes/heuristics/physical/_no_return_base.py
@@ -222,15 +222,13 @@ class NoReturnStrategyBase(PlacementStrategyABC):
             return state
         if len(qubits) != len(state.layout):
             return AtomState.bottom()
-        # Order layout/zone_maps/move_count by the measurement order ``qubits``
-        # so each emitted measurement result lines up with the location of the
-        # qubit it measures. ``qubits`` is identity for un-merged blocks but a
-        # permutation once StaticPlacement blocks are merged (always_merge),
-        # which remaps qubit indices; reading state.layout positionally would
-        # then pair a result with the wrong patch.
+        # ``layout`` stays canonical (indexed by qubit id). The measurement
+        # order is carried by ``place.EndMeasure.qubits`` and applied when the
+        # measurement is lowered (see ``place2move.InsertMeasure``), so we do
+        # not permute the layout here (that would relabel qubits).
         return ExecuteMeasure(
             occupied=state.occupied,
-            layout=tuple(state.layout[i] for i in qubits),
-            move_count=tuple(state.move_count[i] for i in qubits),
-            zone_maps=tuple(ZoneAddress(state.layout[i].zone_id) for i in qubits),
+            layout=state.layout,
+            move_count=state.move_count,
+            zone_maps=tuple(ZoneAddress(loc.zone_id) for loc in state.layout),
         )

--- a/python/bloqade/lanes/heuristics/physical/_no_return_base.py
+++ b/python/bloqade/lanes/heuristics/physical/_no_return_base.py
@@ -222,9 +222,15 @@ class NoReturnStrategyBase(PlacementStrategyABC):
             return state
         if len(qubits) != len(state.layout):
             return AtomState.bottom()
+        # Order layout/zone_maps/move_count by the measurement order ``qubits``
+        # so each emitted measurement result lines up with the location of the
+        # qubit it measures. ``qubits`` is identity for un-merged blocks but a
+        # permutation once StaticPlacement blocks are merged (always_merge),
+        # which remaps qubit indices; reading state.layout positionally would
+        # then pair a result with the wrong patch.
         return ExecuteMeasure(
             occupied=state.occupied,
-            layout=state.layout,
-            move_count=state.move_count,
-            zone_maps=tuple(ZoneAddress(loc.zone_id) for loc in state.layout),
+            layout=tuple(state.layout[i] for i in qubits),
+            move_count=tuple(state.move_count[i] for i in qubits),
+            zone_maps=tuple(ZoneAddress(state.layout[i].zone_id) for i in qubits),
         )

--- a/python/bloqade/lanes/passes.py
+++ b/python/bloqade/lanes/passes.py
@@ -10,8 +10,7 @@ from bloqade.lanes.rewrite import circuit2place
 from bloqade.lanes.rewrite.circuit2place import (
     HoistNewQubitsUp,
     MergeStaticPlacement,
-    gate_only_merge,
-    sq_only_merge,
+    always_merge,
 )
 from bloqade.lanes.rewrite.fuse_gates import FuseAdjacentGates
 from bloqade.lanes.rewrite.remove_debug import RemoveDebugStatements
@@ -32,10 +31,14 @@ from bloqade.lanes.rewrite.transversal import (
 
 @dataclass
 class SequentialPlacePass(passes.Pass):
-    """Preserve gate order; merge only adjacent single-qubit-gate placements (R, Rz).
+    """Merge all adjacent StaticPlacement blocks, preserving original gate order.
 
-    CZ placements remain isolated, preserving the original program order.
-    This is the default behavior.
+    Merging CZ placements into a single region (rather than leaving each CZ
+    isolated) is required for correctness: the placement analysis threads the
+    atom layout through the merged region, so each CZ layer is placed from the
+    *current* (possibly displaced) layout. Isolated CZ blocks were each placed
+    from the initial home layout, which is only valid when return moves restore
+    home between layers. This is the default place-dialect optimization pass.
     """
 
     name: ClassVar[str] = "sequential_place"
@@ -46,13 +49,13 @@ class SequentialPlacePass(passes.Pass):
             rewrite.Walk(circuit2place.HoistConstants()).rewrite(mt.code)
         )
         result = result.join(
-            rewrite.Fixpoint(rewrite.Walk(MergeStaticPlacement(sq_only_merge))).rewrite(
+            rewrite.Fixpoint(rewrite.Walk(MergeStaticPlacement(always_merge))).rewrite(
                 mt.code
             )
         )
         result = result.join(rewrite.Walk(HoistNewQubitsUp()).rewrite(mt.code))
         result = result.join(
-            rewrite.Fixpoint(rewrite.Walk(MergeStaticPlacement(sq_only_merge))).rewrite(
+            rewrite.Fixpoint(rewrite.Walk(MergeStaticPlacement(always_merge))).rewrite(
                 mt.code
             )
         )
@@ -81,15 +84,15 @@ class ASAPPlacePass(passes.Pass):
             rewrite.Walk(circuit2place.HoistConstants()).rewrite(mt.code)
         )
         result = result.join(
-            rewrite.Fixpoint(
-                rewrite.Walk(MergeStaticPlacement(gate_only_merge))
-            ).rewrite(mt.code)
+            rewrite.Fixpoint(rewrite.Walk(MergeStaticPlacement(always_merge))).rewrite(
+                mt.code
+            )
         )
         result = result.join(rewrite.Walk(HoistNewQubitsUp()).rewrite(mt.code))
         result = result.join(
-            rewrite.Fixpoint(
-                rewrite.Walk(MergeStaticPlacement(gate_only_merge))
-            ).rewrite(mt.code)
+            rewrite.Fixpoint(rewrite.Walk(MergeStaticPlacement(always_merge))).rewrite(
+                mt.code
+            )
         )
         result = result.join(
             rewrite.Walk(ReorderStaticPlacement(asap_reorder_policy)).rewrite(mt.code)
@@ -122,15 +125,15 @@ class ALAPPlacePass(passes.Pass):
             rewrite.Walk(circuit2place.HoistConstants()).rewrite(mt.code)
         )
         result = result.join(
-            rewrite.Fixpoint(
-                rewrite.Walk(MergeStaticPlacement(gate_only_merge))
-            ).rewrite(mt.code)
+            rewrite.Fixpoint(rewrite.Walk(MergeStaticPlacement(always_merge))).rewrite(
+                mt.code
+            )
         )
         result = result.join(rewrite.Walk(HoistNewQubitsUp()).rewrite(mt.code))
         result = result.join(
-            rewrite.Fixpoint(
-                rewrite.Walk(MergeStaticPlacement(gate_only_merge))
-            ).rewrite(mt.code)
+            rewrite.Fixpoint(rewrite.Walk(MergeStaticPlacement(always_merge))).rewrite(
+                mt.code
+            )
         )
         result = result.join(
             rewrite.Walk(ReorderStaticPlacement(alap_reorder_policy)).rewrite(mt.code)

--- a/python/bloqade/lanes/rewrite/place2move.py
+++ b/python/bloqade/lanes/rewrite/place2move.py
@@ -235,14 +235,17 @@ class InsertMeasure(RewriteRule):
             )
         ).insert_before(node)
 
-        for result, zone_address, loc_addr in zip(
-            node.results[1:], atom_state.zone_maps, atom_state.layout, strict=True
-        ):
+        # ``node.qubits`` gives the qubit id measured at each result position
+        # (the squin measurement order, remapped to block-local ids by
+        # MergeStaticPlacement). Index the canonical ``layout``/``zone_maps``
+        # (both qubit-id ordered) by it so each result reads the location of the
+        # qubit it actually measures, without permuting the layout upstream.
+        for result, qid in zip(node.results[1:], node.qubits, strict=True):
             (
                 get_item_stmt := move.GetFutureResult(
                     future_stmt.result,
-                    zone_address=zone_address,
-                    location_address=loc_addr,
+                    zone_address=atom_state.zone_maps[qid],
+                    location_address=atom_state.layout[qid],
                 )
             ).insert_before(node)
 

--- a/python/tests/pipeline/test_measure_permutation.py
+++ b/python/tests/pipeline/test_measure_permutation.py
@@ -1,0 +1,76 @@
+"""Regression test: physical compilation must preserve terminal-measurement order.
+
+Under ``always_merge`` the CZ and measurement ``StaticPlacement`` blocks merge and
+qubit indices are renumbered to block-local positions. The lowered readout must
+still pair each returned measurement result with the qubit measured at that
+position — that coupling is carried by ``place.EndMeasure.qubits`` and applied in
+``place2move.InsertMeasure`` against the canonical (qubit-id-indexed) layout.
+
+This guards the bug where a non-identity measurement order produced a permuted
+readout (each logical qubit read the wrong physical patch).
+"""
+
+import pytest
+from bloqade.pyqrack.device import StackMemorySimulator
+from kirin.dialects import ilist
+
+from bloqade import squin
+from bloqade.lanes.arch.gemini.physical import get_arch_spec
+from bloqade.lanes.heuristics.physical import make_physical_placement_strategy
+from bloqade.lanes.pipeline import PhysicalPipeline
+from bloqade.lanes.transform import MoveToSquinPhysical
+
+# Distinct per-qubit bits so any misordered readout changes the result vector.
+_BITS = (0, 1, 1, 0)
+
+
+def _build_kernel(perm: tuple[int, int, int, int]):
+    """Deterministic |b0 b1 b2 b3> prep, three overlapping CZ layers, then a
+    terminal measurement of all four qubits in ``perm`` order."""
+    one_bits = [i for i, b in enumerate(_BITS) if b]
+
+    @squin.kernel
+    def circuit():
+        q = squin.qalloc(4)
+        for i in one_bits:
+            squin.x(q[i])
+        # Overlapping CZ layers force the place pass to merge the CZ and measure
+        # StaticPlacement blocks and renumber qubit indices block-locally. CZ on
+        # a computational-basis state only adds phase, so outcomes stay
+        # deterministic.
+        squin.cz(q[0], q[1])
+        squin.cz(q[1], q[2])
+        squin.cz(q[3], q[2])
+        return squin.broadcast.measure(
+            ilist.IList([q[perm[0]], q[perm[1]], q[perm[2]], q[perm[3]]])
+        )
+
+    return circuit
+
+
+@pytest.mark.parametrize("return_moves", [False, True])
+@pytest.mark.parametrize(
+    "perm",
+    [(0, 1, 2, 3), (3, 2, 1, 0), (0, 3, 2, 1), (1, 3, 0, 2)],
+    ids=["identity", "reversed", "counter_example", "arbitrary"],
+)
+def test_physical_roundtrip_preserves_measurement_order(
+    perm: tuple[int, int, int, int], return_moves: bool
+):
+    arch = get_arch_spec()
+    strategy = make_physical_placement_strategy(
+        return_moves=return_moves, search_budget=None, move_solutions_per_layer=100
+    )
+    move_kernel = PhysicalPipeline(placement_strategy=strategy).emit(
+        _build_kernel(perm)
+    )
+    compiled = MoveToSquinPhysical(arch).emit(move_kernel)
+
+    sim = StackMemorySimulator()
+    # Results are MeasurementResultValue (an IntEnum), so they compare equal to
+    # the plain-int expected bits element-wise.
+    expected = [_BITS[p] for p in perm]
+    # Ground truth: the uncompiled kernel yields results in measurement order.
+    assert list(sim.run(_build_kernel(perm))) == expected
+    # The physical round-trip (squin -> move -> squin) must preserve that order.
+    assert list(sim.run(compiled)) == expected

--- a/python/tests/test_validation_squin_kernels.py
+++ b/python/tests/test_validation_squin_kernels.py
@@ -10,7 +10,7 @@ from bloqade.lanes.dialects import move
 from bloqade.lanes.heuristics.physical.layout import (
     PhysicalLayoutHeuristicGraphPartitionCenterOut,
 )
-from bloqade.lanes.heuristics.physical.placement import PhysicalPlacementStrategy
+from bloqade.lanes.heuristics.physical.movement import make_physical_placement_strategy
 from bloqade.lanes.upstream import squin_to_move
 from bloqade.lanes.validation.address import Validation
 
@@ -27,7 +27,7 @@ def _compile_physical_move(kernel):
     return squin_to_move(
         kernel,
         PhysicalLayoutHeuristicGraphPartitionCenterOut(),
-        PhysicalPlacementStrategy(),
+        make_physical_placement_strategy(),
         logical_initialize=False,
         no_raise=False,
     )

--- a/python/tests/visualize/entropy_tree/test_tracer.py
+++ b/python/tests/visualize/entropy_tree/test_tracer.py
@@ -43,7 +43,16 @@ def test_decode_config_returns_qid_mapping():
 
 
 @pytest.mark.slow
-def test_build_entropy_trace_exposes_spectator_qubits_as_blocked_locations():
+def test_build_entropy_trace_targets_all_qubits_without_spectator_blocking():
+    """With ``block_spectators`` off (the default), every qubit in the block is
+    part of the CZ solve, so the traced target covers all qubits and no
+    spectators are exposed as blocked locations.
+
+    Spectator scoping (participants-only target, spectators blocked) is opt-in
+    via ``RustPlacementTraversal.block_spectators``; ``build_entropy_trace`` does
+    not enable it, so the trace reflects the unscoped default.
+    """
+
     @squin.kernel(typeinfer=True, fold=True)
     def spectator_kernel():
         q = squin.qalloc(4)
@@ -59,7 +68,7 @@ def test_build_entropy_trace_exposes_spectator_qubits_as_blocked_locations():
         max_goal_candidates=3,
     )
 
-    assert len(bundle.traced_target) == 2
-    assert len(bundle.blocked_locations) == 2
-    assert set(bundle.blocked_locations).isdisjoint(bundle.traced_target.values())
-    assert all(loc in bundle.location_to_global_qid for loc in bundle.blocked_locations)
+    # All four qubits are routed (the two CZ participants plus the two
+    # spectators), and nothing is blocked under the default.
+    assert len(bundle.traced_target) == 4
+    assert len(bundle.blocked_locations) == 0


### PR DESCRIPTION
## Problem

Compiling a physical squin kernel with a placement strategy that has **no return moves** (`make_physical_placement_strategy(return_moves=False)`) produced a circuit that is **not equivalent** to the source — statevector overlap ~0. Compilation succeeded silently.

## Root cause (two coupled issues)

1. **State not threaded across CZ layers.** `SequentialPlacePass` merged only single-qubit `StaticPlacement` blocks (`sq_only_merge`), leaving each CZ layer isolated and placed from the *home* layout — correct only when return moves restore home. Without return moves the atoms stay displaced, so a later CZ layer's moves (computed relative to home) source empty sites, no-op, and every CZ layer resolves to the same home pairing → scrambled output.

2. **Measurement readout permuted after merge.** Once all `StaticPlacement` blocks merge (`always_merge`), qubit indices are renumbered block-locally, so a non-identity terminal-measurement order became a permutation. The readout paired result *j* with `layout[j]` positionally, so each logical qubit read the wrong physical patch.

## Fix

- **`passes.py`** — merge **all** adjacent `StaticPlacement` blocks (`always_merge`) so the placement analysis threads the current (possibly displaced) layout across CZ layers.
- **`place2move.py` `InsertMeasure`** — index the **canonical** `layout`/`zone_maps` (qubit-id ordered) by `place.EndMeasure.qubits` (the measurement order, already remapped block-locally by the merge). Each result reads the location of the qubit it actually measures.
- `measure_placements` stays canonical in every strategy — `layout` is the canonical qubit-id→location map and is never relabeled. `MergeStaticPlacement` stays a simple positional zip.
- Test updates from `always_merge`: kernel catalog compiles via `make_physical_placement_strategy()`; entropy-tracer spectator test reflects that a merged block routes all qubits.

## Tests

- **New regression** `test_measure_permutation.py`: deterministic kernel + overlapping CZ layers + permuted terminal measurement; asserts the squin→move→squin round-trip preserves measurement order (4 permutations × `return_moves`). Verified to fail without the `InsertMeasure` fix and pass with it.
- Original repro + minimal repros equivalent for both `return_moves`.
- **Full suite: 1518 passed / 0 failures**; steane transversal regression passes; lint/pyright clean.

## Dependency

Depends on #793 (`build(deps): uv sync --upgrade`), which clears a stale `bloqade-circuit`/`stim` mismatch (`'Circuit' object has no attribute 'is_clifford'`) that otherwise fails the device/decoding/steane simulator tests. Merge #793 first (or into the same base) so this PR's CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)