### PR TITLE
fix(lanes): preserve measurement order via EndMeasure.qubits (replace layout permute)

### DIFF
--- a/python/bloqade/lanes/analysis/placement/strategy.py
+++ b/python/bloqade/lanes/analysis/placement/strategy.py
@@ -69,10 +69,13 @@ class PlacementStrategyABC(abc.ABC):
     ) -> AtomState:
         """Place a terminal measurement of all ``qubits``.
 
-        Builds an ``ExecuteMeasure`` whose ``layout``/``zone_maps`` are ordered
-        by the measurement order ``qubits`` so each emitted measurement result
-        lines up with the location of the qubit it measures (``qubits`` is a
-        permutation once StaticPlacement blocks are merged).
+        ``layout`` stays canonical (indexed by qubit id) — it must not be
+        permuted, since reordering it would relabel qubits. The measurement
+        order is carried by ``place.EndMeasure.qubits`` and applied when the
+        measurement is lowered (see ``place2move.InsertMeasure``), which indexes
+        this canonical layout by ``qubits`` so each result reads the location of
+        the qubit it measures (``qubits`` is a permutation once StaticPlacement
+        blocks are merged).
 
         A ``UserMoved`` state is accepted here: a user-directed move that ends
         at a measurement is committed — the atoms stay at their moved layout and
@@ -88,9 +91,9 @@ class PlacementStrategyABC(abc.ABC):
             return AtomState.bottom()  # all qubits must be measured
         return ExecuteMeasure(
             occupied=state.occupied,
-            layout=tuple(state.layout[i] for i in qubits),
-            move_count=tuple(state.move_count[i] for i in qubits),
-            zone_maps=tuple(ZoneAddress(state.layout[i].zone_id) for i in qubits),
+            layout=state.layout,
+            move_count=state.move_count,
+            zone_maps=tuple(ZoneAddress(loc.zone_id) for loc in state.layout),
         )
 
     def _strip_user_moved(self, state: AtomState) -> AtomState:

--- a/python/bloqade/lanes/rewrite/place2move.py
+++ b/python/bloqade/lanes/rewrite/place2move.py
@@ -255,14 +255,17 @@ class InsertMeasure(RewriteRule):
             )
         ).insert_before(node)
 
-        for result, zone_address, loc_addr in zip(
-            node.results[1:], atom_state.zone_maps, atom_state.layout, strict=True
-        ):
+        # ``node.qubits`` gives the qubit id measured at each result position
+        # (the squin measurement order, remapped to block-local ids by
+        # MergeStaticPlacement). Index the canonical ``layout``/``zone_maps``
+        # (both qubit-id ordered) by it so each result reads the location of the
+        # qubit it actually measures, without permuting the layout upstream.
+        for result, qid in zip(node.results[1:], node.qubits, strict=True):
             (
                 get_item_stmt := move.GetFutureResult(
                     future_stmt.result,
-                    zone_address=zone_address,
-                    location_address=loc_addr,
+                    zone_address=atom_state.zone_maps[qid],
+                    location_address=atom_state.layout[qid],
                 )
             ).insert_before(node)
 

--- a/python/tests/pipeline/test_measure_permutation.py
+++ b/python/tests/pipeline/test_measure_permutation.py
@@ -1,0 +1,76 @@
+"""Regression test: physical compilation must preserve terminal-measurement order.
+
+Under ``always_merge`` the CZ and measurement ``StaticPlacement`` blocks merge and
+qubit indices are renumbered to block-local positions. The lowered readout must
+still pair each returned measurement result with the qubit measured at that
+position — that coupling is carried by ``place.EndMeasure.qubits`` and applied in
+``place2move.InsertMeasure`` against the canonical (qubit-id-indexed) layout.
+
+This guards the bug where a non-identity measurement order produced a permuted
+readout (each logical qubit read the wrong physical patch).
+"""
+
+import pytest
+from bloqade.pyqrack.device import StackMemorySimulator
+from kirin.dialects import ilist
+
+from bloqade import squin
+from bloqade.lanes.arch.gemini.physical import get_arch_spec
+from bloqade.lanes.heuristics.physical import make_physical_placement_strategy
+from bloqade.lanes.pipeline import PhysicalPipeline
+from bloqade.lanes.transform import MoveToSquinPhysical
+
+# Distinct per-qubit bits so any misordered readout changes the result vector.
+_BITS = (0, 1, 1, 0)
+
+
+def _build_kernel(perm: tuple[int, int, int, int]):
+    """Deterministic |b0 b1 b2 b3> prep, three overlapping CZ layers, then a
+    terminal measurement of all four qubits in ``perm`` order."""
+    one_bits = [i for i, b in enumerate(_BITS) if b]
+
+    @squin.kernel
+    def circuit():
+        q = squin.qalloc(4)
+        for i in one_bits:
+            squin.x(q[i])
+        # Overlapping CZ layers force the place pass to merge the CZ and measure
+        # StaticPlacement blocks and renumber qubit indices block-locally. CZ on
+        # a computational-basis state only adds phase, so outcomes stay
+        # deterministic.
+        squin.cz(q[0], q[1])
+        squin.cz(q[1], q[2])
+        squin.cz(q[3], q[2])
+        return squin.broadcast.measure(
+            ilist.IList([q[perm[0]], q[perm[1]], q[perm[2]], q[perm[3]]])
+        )
+
+    return circuit
+
+
+@pytest.mark.parametrize("return_moves", [False, True])
+@pytest.mark.parametrize(
+    "perm",
+    [(0, 1, 2, 3), (3, 2, 1, 0), (0, 3, 2, 1), (1, 3, 0, 2)],
+    ids=["identity", "reversed", "counter_example", "arbitrary"],
+)
+def test_physical_roundtrip_preserves_measurement_order(
+    perm: tuple[int, int, int, int], return_moves: bool
+):
+    arch = get_arch_spec()
+    strategy = make_physical_placement_strategy(
+        return_moves=return_moves, search_budget=None, move_solutions_per_layer=100
+    )
+    move_kernel = PhysicalPipeline(placement_strategy=strategy).emit(
+        _build_kernel(perm)
+    )
+    compiled = MoveToSquinPhysical(arch).emit(move_kernel)
+
+    sim = StackMemorySimulator()
+    # Results are MeasurementResultValue (an IntEnum), so they compare equal to
+    # the plain-int expected bits element-wise.
+    expected = [_BITS[p] for p in perm]
+    # Ground truth: the uncompiled kernel yields results in measurement order.
+    assert list(sim.run(_build_kernel(perm))) == expected
+    # The physical round-trip (squin -> move -> squin) must preserve that order.
+    assert list(sim.run(compiled)) == expected


### PR DESCRIPTION
Targets `feat-user-movement-dialect` (#683).

## What

Replaces the layout-permute measurement-order fix (`646350e`, `e7894ad`) with a version that keeps `ExecuteMeasure.layout` canonical.

- `measure_placements` (base ABC): `layout`/`move_count`/`zone_maps` stay in canonical **qubit-id order** instead of being permuted by the measurement `qubits`. `UserMoved` handling is unchanged.
- `place2move.InsertMeasure`: indexes the canonical `layout`/`zone_maps` by `place.EndMeasure.qubits` (the measurement order, already remapped to block-local ids by `MergeStaticPlacement`), so each result reads the location of the qubit it actually measures.

## Why

`layout` is the canonical **qubit-id → location** map. Ordering it by the measurement `qubits` silently *relabels* qubits — it only appeared correct because measurement is terminal, so nothing downstream read the relabeled layout. The measurement-order coupling already exists in `EndMeasure.qubits`; applying it at the readout (rather than permuting `layout`) is the semantically correct fix, needs no new field/dataflow, and leaves `MergeStaticPlacement` as a simple positional zip.

## Tests

- New `test_measure_permutation.py`: deterministic kernel + overlapping CZ layers (forces StaticPlacement merge + block-local renumbering) measured in permuted order; asserts the squin→move→squin round-trip preserves order (4 permutations × `return_moves`). **Verified to fail without the `InsertMeasure` fix and pass with it.**
- `feat-user-movement-dialect`'s movement-dialect suite (movement_kernel / move_to / UserMoved / permute) stays green (300 passed); pipeline/rewrite/heuristics/validation green (447 passed); lint + pyright clean.

Mirrors the fix landing on `main` via #788 (which supersedes the same permute approach), ported onto this branch's hoisted `measure_placements` structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)