### PR TITLE
Use AddressAnalysis for _find_qubit_ssas

### DIFF
--- a/python/bloqade/gemini/device/physical_simulator.py
+++ b/python/bloqade/gemini/device/physical_simulator.py
@@ -12,13 +12,14 @@ from typing import (
 )
 
 import numpy as np
+from bloqade.analysis.address import AddressAnalysis, AddressQubit
 from bloqade.analysis.fidelity import FidelityAnalysis
 from bloqade.decoders.dialects.annotate.stmts import SetDetector, SetObservable
 from bloqade.rewrite.passes import AggressiveUnroll
-from kirin import ir, passes, rewrite, types
+from kirin import ir, passes, rewrite
 from kirin.dialects import func, ilist, py
 
-from bloqade import qubit, types as bloqade_types
+from bloqade import qubit
 
 from .simulator import DetectorResult, Result
 
@@ -60,15 +61,20 @@ def _tsim():
 
 
 def _find_qubit_ssas(mt: ir.Method) -> list[ir.SSAValue]:
-    """Walk the IR and collect SSA values for physical qubit allocations."""
-    qubits: list[ir.SSAValue] = []
+    """Return one physical-qubit SSA value per concrete qubit address."""
+    address_analysis = AddressAnalysis(mt.dialects)
+    frame, _ = address_analysis.run(mt)
+    qubits_by_address: dict[int, ir.SSAValue] = {}
+
     for stmt in mt.callable_region.walk():
         for result in stmt.results:
-            if result.type.is_subseteq(
-                bloqade_types.QubitType
-            ) and not result.type.is_subseteq(types.Bottom):
-                qubits.append(result)
-    return qubits
+            address = frame.get(result)
+            if isinstance(address, AddressQubit):
+                qubits_by_address.setdefault(address.data, result)
+
+    return [
+        qubits_by_address[address] for address in range(address_analysis.qubit_count)
+    ]
 
 
 def _find_return_stmt(mt: ir.Method) -> func.Return:

--- a/python/bloqade/lanes/logical_mvp.py
+++ b/python/bloqade/lanes/logical_mvp.py
@@ -2,6 +2,7 @@ import io
 from functools import cache
 from typing import Any, Callable, TypeVar
 
+from bloqade.analysis.address import AddressAnalysis, AddressQubit
 from bloqade.analysis.validation.simple_nocloning import FlatKernelNoCloningValidation
 from bloqade.decoders.dialects.annotate.stmts import SetDetector, SetObservable
 from bloqade.stim.emit.stim_str import EmitStimMain
@@ -10,7 +11,6 @@ from kirin import ir
 from kirin.dialects import func, ilist, py
 from kirin.validation import ValidationSuite
 
-from bloqade import qubit
 from bloqade.gemini.logical.dialects.operations.stmts import (
     TerminalLogicalMeasurement,
 )
@@ -218,11 +218,23 @@ _S = TypeVar("_S", bound=ir.Statement)
 
 
 def _find_qubit_ssas(mt: ir.Method) -> list[ir.SSAValue]:
-    """Walk the squin IR and collect SSA values for all qubit allocations."""
+    """Return one qubit SSA value per concrete qubit address.
+
+    ``qalloc`` calls must be aggressively unrolled so each allocation has a
+    corresponding SSA value in ``mt``.
+    """
+    address_analysis = AddressAnalysis(mt.dialects)
+    frame, _ = address_analysis.run(mt)
+    qubits_by_address: dict[int, ir.SSAValue] = {}
+
+    for stmt in mt.callable_region.walk():
+        for result in stmt.results:
+            address = frame.get(result)
+            if isinstance(address, AddressQubit):
+                qubits_by_address.setdefault(address.data, result)
+
     return [
-        stmt.result
-        for stmt in mt.callable_region.walk()
-        if isinstance(stmt, qubit.stmts.New)
+        qubits_by_address[address] for address in range(address_analysis.qubit_count)
     ]
 
 

--- a/python/tests/gemini/test_physical_simulator.py
+++ b/python/tests/gemini/test_physical_simulator.py
@@ -5,7 +5,7 @@ import pytest
 from bloqade.decoders.dialects.annotate.stmts import SetDetector, SetObservable
 from kirin import ir, types
 from kirin.decl import info, statement
-from kirin.dialects import func, ilist
+from kirin.dialects import func, ilist, ssacfg
 
 import bloqade.gemini.device.physical_simulator as physical_simulator_module
 from bloqade import squin, types as bloqade_types
@@ -210,22 +210,17 @@ def test_append_measurements_and_annotations_physical_accepts_new_at_allocations
     )
 
 
-def test_find_qubit_ssas_collects_any_qubit_typed_statement_result():
+def test_find_qubit_ssas_ignores_qubit_typed_results_without_addresses():
     test_dialect = ir.Dialect("test.qubit_alloc")
 
     @statement(dialect=test_dialect)
     class CustomQubitAlloc(ir.Statement):
         result: ir.ResultValue = info.result(bloqade_types.QubitType)
 
-    @statement(dialect=test_dialect)
-    class BottomTypedStatement(ir.Statement):
-        result: ir.ResultValue = info.result(types.Bottom)
-
     block = ir.Block(argtypes=(types.MethodType,))
     alloc = CustomQubitAlloc()
-    bottom = BottomTypedStatement()
     none_stmt = func.ConstantNone()
-    for stmt in (alloc, bottom, none_stmt, func.Return(none_stmt.result)):
+    for stmt in (alloc, none_stmt, func.Return(none_stmt.result)):
         block.stmts.append(stmt)
 
     function = func.Function(
@@ -235,10 +230,10 @@ def test_find_qubit_ssas_collects_any_qubit_typed_statement_result():
         body=ir.Region(blocks=block),
     )
     method = ir.Method(
-        dialects=ir.DialectGroup([func.dialect, test_dialect]),
+        dialects=ir.DialectGroup([func.dialect, ssacfg.dialect, test_dialect]),
         code=function,
         sym_name="custom_alloc",
         arg_names=[],
     )
 
-    assert _find_qubit_ssas(method) == [alloc.result]
+    assert _find_qubit_ssas(method) == []

--- a/python/tests/test_cudaq_integration.py
+++ b/python/tests/test_cudaq_integration.py
@@ -6,6 +6,7 @@ from kirin.dialects import func
 
 from bloqade import qubit, squin
 from bloqade.gemini import logical as gemini_logical
+from bloqade.gemini.common.dialects.qubit import new_at
 from bloqade.gemini.logical.dialects.operations.stmts import (
     TerminalLogicalMeasurement,
 )
@@ -45,6 +46,15 @@ def test_find_qubit_ssas_no_qubits():
         return 42
 
     assert len(_find_qubit_ssas(kernel)) == 0
+
+
+def test_find_qubit_ssas_includes_new_at_allocations():
+    @gemini_logical.kernel(aggressive_unroll=True)
+    def kernel():
+        new_at(0, 0, 0)
+        qubit.qalloc(2)
+
+    assert len(_find_qubit_ssas(kernel)) == 3
 
 
 def test_find_return_stmt():


### PR DESCRIPTION
closes https://github.com/QuEraComputing/bloqade-lanes/issues/803

# Use Address Analysis for Qubit SSA Discovery

## Summary

Replace the type- and statement-class-based implementations of
`_find_qubit_ssas` with `AddressAnalysis` in both the physical simulator and
logical compiler paths.

The helpers now return one representative SSA value for each concrete qubit
allocation address, in allocation-address order.

## Motivation

The previous implementations inferred allocations from IR surface structure:

- The physical helper collected every result typed as `QubitType`.
- The logical helper collected only `qubit.New` statements.

Neither rule represents the intended invariant: count each allocated qubit
once, even when that qubit has multiple SSA aliases. The logical rule also
missed Gemini `new_at(...)` allocations entirely.

`AddressAnalysis` already models the allocation semantics of both
`qubit.new()` and Gemini `new_at(...)`, while propagating concrete addresses
through lists, constant indexing, aliases, helper calls, and supported control
flow.

## Changes

- Run `AddressAnalysis` in both `_find_qubit_ssas` helpers.
- Collect the first SSA value associated with each `AddressQubit` address.
- Return those values ordered by address (`0, 1, ..., qubit_count - 1`), which
  corresponds to allocation order.
- Document that `qalloc` must be aggressively unrolled before an SSA-returning
  helper can recover its individual allocation results from the caller IR.
- Add regression coverage that verifies logical `new_at(...)` allocations are
  included.
- Update physical coverage so arbitrary `QubitType`-producing statements with
  no concrete address-analysis handler are not treated as allocations.

## Behavioral Notes

This intentionally changes the interpretation of aliases. For example,
multiple SSA values referring to `reg[0]` now contribute one allocation rather
than multiple qubits.

`AddressAnalysis.qubit_count` can count allocations in an unexpanded
`qalloc(3)` call by analyzing the helper body. However, the SSA-returning
helpers require aggressive unrolling: before unrolling, the caller contains a
single register SSA rather than the three individual `qubit.new()` result
SSAs.

The physical annotation path already aggressively unrolls before calling its
helper. Logical kernels using `qalloc` must likewise be aggressively unrolled,
as they were for the previous helper to find `qubit.New` statements.

## Tests

- `uv run pytest python/tests/gemini/test_physical_simulator.py`
- `uv run pytest python/tests/test_cudaq_integration.py`
- `uv run ruff check python/bloqade/gemini/device/physical_simulator.py python/bloqade/lanes/logical_mvp.py python/tests/gemini/test_physical_simulator.py python/tests/test_cudaq_integration.py`
- `uv run black --check python/bloqade/gemini/device/physical_simulator.py python/bloqade/lanes/logical_mvp.py python/tests/gemini/test_physical_simulator.py python/tests/test_cudaq_integration.py`
- `uv run pyright python/bloqade/gemini/device/physical_simulator.py python/bloqade/lanes/logical_mvp.py python/tests/gemini/test_physical_simulator.py python/tests/test_cudaq_integration.py`

## Compatibility

No public API changes. The private helpers now provide canonical allocation
semantics instead of returning arbitrary qubit-typed SSA aliases.
