### PR TITLE
Unify logical and physical measurement annotation helpers

### DIFF
--- a/docs/superpowers/plans/2026-07-14-unified-measurement-annotations.md
+++ b/docs/superpowers/plans/2026-07-14-unified-measurement-annotations.md
@@ -1,0 +1,153 @@
+# Unified Measurement Annotations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace duplicated logical and physical annotation implementations with one level-aware API while retaining compatibility imports and behavior.
+
+**Architecture:** A new `bloqade.gemini.measurement_annotations` module owns matrix validation, address-based qubit discovery, measurement resolution, and shared detector/observable emission. Logical and physical setup remain explicit branches selected by `level`; `logical_mvp` re-exports the unified function and the physical module keeps a thin legacy wrapper.
+
+**Tech Stack:** Python 3.10+, Kirin IR, Bloqade SQuIn/Gemini dialects, pytest, uv.
+
+---
+
+### Task 1: Add the unified level-aware API
+
+**Files:**
+- Create: `python/bloqade/gemini/measurement_annotations.py`
+- Modify: `python/bloqade/lanes/logical_mvp.py`
+- Modify: `python/bloqade/gemini/device/physical_simulator.py`
+- Test: `python/tests/test_cudaq_integration.py`
+- Test: `python/tests/gemini/test_physical_simulator.py`
+
+- [ ] **Step 1: Write failing unified-API tests**
+
+Add tests that call both the canonical
+`bloqade.gemini.measurement_annotations` API and the existing `logical_mvp`
+re-export with `level="physical"`. Require an invalid level, empty matrix, and
+ragged matrix to raise `ValueError`; require detector/observable matrices with
+unequal row counts to raise `ValueError`; and verify `[[]]` remains a valid
+zero-column matrix.
+
+- [ ] **Step 2: Run the new tests and verify RED**
+
+Run:
+
+```bash
+uv run pytest \
+  python/tests/test_cudaq_integration.py -k "annotation_matrix or annotation_level" \
+  python/tests/gemini/test_physical_simulator.py::test_unified_append_measurements_and_annotations_supports_physical_level \
+  -q
+```
+
+Expected: failures because the current logical function has no `level`
+parameter and does not consistently validate both matrices.
+
+- [ ] **Step 3: Implement the shared module**
+
+Move `_find_qubit_ssas`, `_find_return_stmt`, `_insert_before`, and matrix
+validation into `measurement_annotations.py`. Implement
+`append_measurements_and_annotations(..., level="logical")` with:
+
+- logical setup that finds/creates `TerminalLogicalMeasurement` and resolves
+  global matrix rows through nested results;
+- physical setup that unrolls, validates physical block size, requires one
+  `qubit.Measure`, and resolves flat measurement results;
+- one shared loop for `SetDetector` and `SetObservable` emission.
+
+Keep `append_measurements_and_annotations_physical` as a delegating wrapper.
+Re-export the shared function and private compatibility helpers from the old
+modules, removing their duplicate bodies and now-unused imports.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run the command from Step 2. Expected: all selected tests pass.
+
+- [ ] **Step 5: Run both affected test modules**
+
+Run:
+
+```bash
+uv run pytest python/tests/test_cudaq_integration.py python/tests/gemini/test_physical_simulator.py -q
+```
+
+Expected: all tests pass.
+
+### Task 2: Route `PhysicalSimulator.task` through the unified API
+
+**Files:**
+- Modify: `python/bloqade/gemini/device/physical_simulator.py`
+- Test: `python/tests/gemini/test_physical_simulator.py`
+
+- [ ] **Step 1: Update the task-delegation test first**
+
+Patch the module's `append_measurements_and_annotations` binding, call
+`PhysicalSimulator.task`, and assert it receives the kernel, matrices, and
+`level="physical"`.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+uv run pytest python/tests/gemini/test_physical_simulator.py::test_physical_simulator_task_passes_placement_strategy -q
+```
+
+Expected: failure because `task()` still invokes the legacy physical wrapper.
+
+- [ ] **Step 3: Change the production call**
+
+Have `PhysicalSimulator.task` call the unified function with
+`level="physical"`; leave the old wrapper available only for compatibility.
+
+- [ ] **Step 4: Run the affected test modules**
+
+Run:
+
+```bash
+uv run pytest python/tests/test_cudaq_integration.py python/tests/gemini/test_physical_simulator.py -q
+```
+
+Expected: all tests pass.
+
+### Task 3: Format and verify the refactor
+
+**Files:**
+- Modify only files changed by Tasks 1-2 if formatters require it.
+
+- [ ] **Step 1: Run Python formatting and static checks**
+
+Run:
+
+```bash
+uv run isort python/bloqade/gemini/measurement_annotations.py python/bloqade/lanes/logical_mvp.py python/bloqade/gemini/device/physical_simulator.py python/tests/test_cudaq_integration.py python/tests/gemini/test_physical_simulator.py
+uv run black python/bloqade/gemini/measurement_annotations.py python/bloqade/lanes/logical_mvp.py python/bloqade/gemini/device/physical_simulator.py python/tests/test_cudaq_integration.py python/tests/gemini/test_physical_simulator.py
+uv run ruff check python/bloqade/gemini/measurement_annotations.py python/bloqade/lanes/logical_mvp.py python/bloqade/gemini/device/physical_simulator.py python/tests/test_cudaq_integration.py python/tests/gemini/test_physical_simulator.py
+uv run pyright python/bloqade/gemini/measurement_annotations.py python/bloqade/lanes/logical_mvp.py python/bloqade/gemini/device/physical_simulator.py
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 2: Run the full Python test suite**
+
+Run:
+
+```bash
+just test-python
+```
+
+Expected: all Python tests pass.
+
+- [ ] **Step 3: Review the final diff and commit**
+
+Confirm only the shared module, compatibility modules, tests, and planning
+documentation changed. Commit with:
+
+```bash
+git add python/bloqade/gemini/measurement_annotations.py \
+  python/bloqade/lanes/logical_mvp.py \
+  python/bloqade/gemini/device/physical_simulator.py \
+  python/tests/test_cudaq_integration.py \
+  python/tests/gemini/test_physical_simulator.py \
+  docs/superpowers/plans/2026-07-14-unified-measurement-annotations.md
+git commit -m "refactor(python): unify measurement annotation helpers"
+```

--- a/docs/superpowers/specs/2026-07-14-unified-measurement-annotations-design.md
+++ b/docs/superpowers/specs/2026-07-14-unified-measurement-annotations-design.md
@@ -1,0 +1,81 @@
+# Unified Measurement Annotations
+
+**Status:** approved (design)
+**Date:** 2026-07-14
+
+## Goal
+
+Replace the duplicated logical and physical measurement-annotation implementations
+with one public `append_measurements_and_annotations` API while preserving the two
+existing matrix-layout contracts and existing callers.
+
+## Public API
+
+Add the shared implementation in `bloqade.gemini.measurement_annotations`:
+
+```python
+def append_measurements_and_annotations(
+    mt: ir.Method,
+    m2dets: list[list[int]] | None,
+    m2obs: list[list[int]] | None,
+    *,
+    level: Literal["logical", "physical"] = "logical",
+) -> None: ...
+```
+
+The default remains `"logical"` so imports from `bloqade.lanes.logical_mvp` stay
+source-compatible. `append_measurements_and_annotations_physical` remains as a
+thin compatibility wrapper and delegates with `level="physical"`.
+
+## Behavior
+
+Both levels validate that at least one matrix is present, matrices have at least
+one row and are rectangular, and detector/observable matrices have equal row
+counts when both are supplied. Zero-column matrices such as `[[]]` remain valid.
+
+Logical mode:
+
+- Treats the rows as one global measurement map across all logical qubits.
+- Finds or creates `TerminalLogicalMeasurement`.
+- Resolves a matrix row through the nested logical-qubit/physical-measurement
+  result.
+- Emits detector coordinates `(0, detector_index)`.
+
+Physical mode:
+
+- Aggressively unrolls the kernel before resolving allocations.
+- Treats the rows as a per-logical-block map and repeats annotations once per
+  physical-qubit block.
+- Requires exactly one physical `qubit.Measure` statement and indexes its flat
+  result.
+- Emits detector coordinates `(logical_block_index, detector_index)`.
+- Leaves the kernel's existing return value unchanged.
+
+After each mode prepares its measurement resolver, a shared emitter creates all
+`SetDetector` and `SetObservable` statements. Address-based qubit discovery and
+IR insertion helpers also live in the shared module. The old modules continue to
+expose `_find_qubit_ssas`; `logical_mvp` also continues to expose
+`_find_return_stmt`, matching existing test and consumer imports.
+
+## Errors and Compatibility
+
+Invalid levels raise `ValueError`. Existing level-specific allocation and
+measurement errors retain their current messages where practical. No deprecation
+warning is emitted by the physical compatibility wrapper, avoiding new runtime
+noise while callers migrate.
+
+## Testing
+
+- Exercise physical behavior through the unified API.
+- Verify the legacy physical wrapper delegates correctly.
+- Retain logical annotation-count, terminal-measurement, allocation, and return
+  tests.
+- Retain physical block repetition, divisibility, `new_at`, post-processing, and
+  return-preservation tests.
+- Add validation coverage for an invalid `level` and mismatched matrix row counts.
+
+## Non-goals
+
+- Changing the meaning or orientation of either matrix format.
+- Automatically inferring logical versus physical mode from kernel contents.
+- Changing detector or observable post-processing semantics.

--- a/python/bloqade/gemini/device/physical_simulator.py
+++ b/python/bloqade/gemini/device/physical_simulator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
-from functools import cache, cached_property
+from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     Generic,
@@ -12,14 +12,13 @@ from typing import (
 )
 
 import numpy as np
-from bloqade.analysis.address import AddressAnalysis, AddressQubit
 from bloqade.analysis.fidelity import FidelityAnalysis
-from bloqade.decoders.dialects.annotate.stmts import SetDetector, SetObservable
-from bloqade.rewrite.passes import AggressiveUnroll
 from kirin import ir, passes, rewrite
-from kirin.dialects import func, ilist, py
 
-from bloqade import qubit
+from bloqade.gemini.measurement_annotations import (
+    _find_qubit_ssas as _find_qubit_ssas,
+    append_measurements_and_annotations,
+)
 
 from .simulator import DetectorResult, Result
 
@@ -33,7 +32,6 @@ if TYPE_CHECKING:
 
 RetType = TypeVar("RetType")
 PhysicalResult = Result
-_S = TypeVar("_S", bound=ir.Statement)
 
 
 def _default_noise_model() -> "NoiseModelABC":
@@ -60,137 +58,13 @@ def _tsim():
     return tsim
 
 
-def _find_qubit_ssas(mt: ir.Method) -> list[ir.SSAValue]:
-    """Return one physical-qubit SSA value per concrete qubit address."""
-    address_analysis = AddressAnalysis(mt.dialects)
-    frame, _ = address_analysis.run(mt)
-    qubits_by_address: dict[int, ir.SSAValue] = {}
-
-    for stmt in mt.callable_region.walk():
-        for result in stmt.results:
-            address = frame.get(result)
-            if isinstance(address, AddressQubit):
-                qubits_by_address.setdefault(address.data, result)
-
-    return [
-        qubits_by_address[address] for address in range(address_analysis.qubit_count)
-    ]
-
-
-def _find_return_stmt(mt: ir.Method) -> func.Return:
-    """Find the final return statement in a single-block kernel."""
-    block = mt.callable_region.blocks[0]
-    last = block.last_stmt
-    assert isinstance(last, func.Return), f"Expected func.Return, got {type(last)}"
-    return last
-
-
-def _insert_before(stmt: _S, anchor: ir.Statement) -> _S:
-    """Insert stmt before anchor and return stmt for chaining."""
-    stmt.insert_before(anchor)
-    return stmt
-
-
-def _validate_m2_matrix(matrix: list[list[int]], name: str) -> int:
-    if len(matrix) == 0:
-        raise ValueError(f"{name} must have at least one row")
-    width = len(matrix[0])
-    if any(len(row) != width for row in matrix):
-        raise ValueError(f"{name} rows must all have the same length")
-    return len(matrix)
-
-
 def append_measurements_and_annotations_physical(
     mt: ir.Method,
     m2dets: list[list[int]] | None,
     m2obs: list[list[int]] | None,
 ) -> None:
-    """Append physical detector/observable annotations from per-block matrices.
-
-    The method is mutated in-place. The supplied matrices are interpreted as
-    measurement-to-detector/observable maps for one logical block laid out in a
-    flat physical measurement list. If the kernel measures multiple such blocks,
-    the matrices are repeated block-by-block. The original return value is
-    preserved.
-    """
-    if m2dets is None and m2obs is None:
-        raise ValueError("At least one of m2dets or m2obs must be provided")
-
-    AggressiveUnroll(mt.dialects, no_raise=True).fixpoint(mt)
-
-    physical_qubits_per_logical_qubit: int | None = None
-    if m2dets is not None:
-        physical_qubits_per_logical_qubit = _validate_m2_matrix(m2dets, "m2dets")
-    if m2obs is not None:
-        m2obs_rows = _validate_m2_matrix(m2obs, "m2obs")
-        if (
-            physical_qubits_per_logical_qubit is not None
-            and physical_qubits_per_logical_qubit != m2obs_rows
-        ):
-            raise ValueError("m2dets and m2obs must have the same number of rows")
-        physical_qubits_per_logical_qubit = m2obs_rows
-    assert physical_qubits_per_logical_qubit is not None
-
-    num_physical_qubits = len(_find_qubit_ssas(mt))
-    if num_physical_qubits == 0:
-        raise ValueError("No physical qubit allocations found in the kernel")
-
-    num_logical_qubits, remainder = divmod(
-        num_physical_qubits, physical_qubits_per_logical_qubit
-    )
-    if remainder != 0:
-        raise ValueError(
-            "The number of physical qubits must be divisible by the number of "
-            "physical qubits per logical qubit"
-        )
-
-    measure_stmts = [
-        stmt
-        for stmt in mt.callable_region.walk()
-        if isinstance(stmt, qubit.stmts.Measure)
-    ]
-    if len(measure_stmts) != 1:
-        raise ValueError("Expected exactly one physical qubit.Measure statement")
-    measure_stmt = measure_stmts[0]
-    return_stmt = _find_return_stmt(mt)
-
-    @cache
-    def _get_physical_measurement(q_idx: int, m_idx: int) -> ir.SSAValue:
-        flat_idx = q_idx * physical_qubits_per_logical_qubit + m_idx
-        (idx := py.Constant(flat_idx)).insert_before(return_stmt)
-        (getitem := py.GetItem(measure_stmt.result, idx.result)).insert_before(
-            return_stmt
-        )
-        return getitem.result
-
-    if m2dets is not None:
-        for q_idx in range(num_logical_qubits):
-            for j in range(len(m2dets[0])):
-                meas_ssas = [
-                    _get_physical_measurement(q_idx, m_idx)
-                    for m_idx, row in enumerate(m2dets)
-                    if row[j]
-                ]
-                meas_list = _insert_before(ilist.New(meas_ssas), return_stmt)
-                coord_0 = _insert_before(py.Constant(float(q_idx)), return_stmt)
-                coord_1 = _insert_before(py.Constant(float(j)), return_stmt)
-                coords = _insert_before(
-                    ilist.New([coord_0.result, coord_1.result]), return_stmt
-                )
-                _insert_before(
-                    SetDetector(meas_list.result, coords.result), return_stmt
-                )
-
-    if m2obs is not None:
-        for q_idx in range(num_logical_qubits):
-            for j in range(len(m2obs[0])):
-                meas_ssas = [
-                    _get_physical_measurement(q_idx, m_idx)
-                    for m_idx, row in enumerate(m2obs)
-                    if row[j]
-                ]
-                meas_list = _insert_before(ilist.New(meas_ssas), return_stmt)
-                _insert_before(SetObservable(meas_list.result), return_stmt)
+    """Compatibility wrapper for physical measurement annotations."""
+    append_measurements_and_annotations(mt, m2dets, m2obs, level="physical")
 
 
 @dataclass(frozen=True)
@@ -443,7 +317,9 @@ class PhysicalSimulator:
         from bloqade.lanes.pipeline import PhysicalPipeline
 
         if m2dets is not None or m2obs is not None:
-            append_measurements_and_annotations_physical(physical_kernel, m2dets, m2obs)
+            append_measurements_and_annotations(
+                physical_kernel, m2dets, m2obs, level="physical"
+            )
 
         if place_opt_type is None:
             place_opt_type = SequentialPlacePass

--- a/python/bloqade/gemini/measurement_annotations.py
+++ b/python/bloqade/gemini/measurement_annotations.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from functools import cache
+from typing import Callable, Literal, TypeVar
+
+from bloqade.analysis.address import AddressAnalysis, AddressQubit
+from bloqade.decoders.dialects.annotate.stmts import SetDetector, SetObservable
+from bloqade.rewrite.passes import AggressiveUnroll
+from kirin import ir
+from kirin.dialects import func, ilist, py
+
+from bloqade import qubit
+from bloqade.gemini.logical.dialects.operations.stmts import (
+    TerminalLogicalMeasurement,
+)
+
+MeasurementLevel = Literal["logical", "physical"]
+MeasurementResolver = Callable[[int, int], ir.SSAValue]
+_S = TypeVar("_S", bound=ir.Statement)
+
+
+def _find_qubit_ssas(mt: ir.Method) -> list[ir.SSAValue]:
+    """Return one qubit SSA value per concrete qubit address."""
+    address_analysis = AddressAnalysis(mt.dialects)
+    frame, _ = address_analysis.run(mt)
+    qubits_by_address: dict[int, ir.SSAValue] = {}
+
+    for stmt in mt.callable_region.walk():
+        for result in stmt.results:
+            address = frame.get(result)
+            if isinstance(address, AddressQubit):
+                qubits_by_address.setdefault(address.data, result)
+
+    return [
+        qubits_by_address[address] for address in range(address_analysis.qubit_count)
+    ]
+
+
+def _find_return_stmt(mt: ir.Method) -> func.Return:
+    """Find the final return statement in a single-block kernel."""
+    block = mt.callable_region.blocks[0]
+    last = block.last_stmt
+    assert isinstance(last, func.Return), f"Expected func.Return, got {type(last)}"
+    return last
+
+
+def _insert_before(stmt: _S, anchor: ir.Statement) -> _S:
+    """Insert ``stmt`` before ``anchor`` and return it for chaining."""
+    stmt.insert_before(anchor)
+    return stmt
+
+
+def _validate_m2_matrix(matrix: list[list[int]], name: str) -> int:
+    if len(matrix) == 0:
+        raise ValueError(f"{name} must have at least one row")
+    width = len(matrix[0])
+    if any(len(row) != width for row in matrix):
+        raise ValueError(f"{name} rows must all have the same length")
+    return len(matrix)
+
+
+def _validate_m2_matrices(
+    m2dets: list[list[int]] | None,
+    m2obs: list[list[int]] | None,
+) -> int:
+    if m2dets is None and m2obs is None:
+        raise ValueError("At least one of m2dets or m2obs must be provided")
+
+    num_rows: int | None = None
+    if m2dets is not None:
+        num_rows = _validate_m2_matrix(m2dets, "m2dets")
+    if m2obs is not None:
+        m2obs_rows = _validate_m2_matrix(m2obs, "m2obs")
+        if num_rows is not None and num_rows != m2obs_rows:
+            raise ValueError("m2dets and m2obs must have the same number of rows")
+        num_rows = m2obs_rows
+
+    assert num_rows is not None
+    return num_rows
+
+
+def _prepare_logical_measurements(
+    mt: ir.Method,
+    num_total_measurements: int,
+) -> tuple[int, MeasurementResolver, func.Return]:
+    qubit_ssas = _find_qubit_ssas(mt)
+    num_qubits = len(qubit_ssas)
+    if num_qubits == 0:
+        raise ValueError("No qubit allocations found in the kernel")
+
+    measurements_per_qubit, remainder = divmod(num_total_measurements, num_qubits)
+    if remainder != 0:
+        raise ValueError("Incompatible shape of m2dets or m2obs")
+
+    return_stmt = _find_return_stmt(mt)
+    terminal_measurement = next(
+        (
+            stmt
+            for stmt in mt.callable_region.walk()
+            if isinstance(stmt, TerminalLogicalMeasurement)
+        ),
+        None,
+    )
+    if terminal_measurement is None:
+        qubit_list = _insert_before(ilist.New(qubit_ssas), return_stmt)
+        terminal_measurement = _insert_before(
+            TerminalLogicalMeasurement(qubit_list.result), return_stmt
+        )
+
+    @cache
+    def get_logical_measurement(qubit_index: int) -> ir.SSAValue:
+        index = _insert_before(py.Constant(qubit_index), return_stmt)
+        item = _insert_before(
+            py.GetItem(terminal_measurement.result, index.result), return_stmt
+        )
+        return item.result
+
+    @cache
+    def resolve_measurement(_group_index: int, row_index: int) -> ir.SSAValue:
+        qubit_index, measurement_index = divmod(row_index, measurements_per_qubit)
+        index = _insert_before(py.Constant(measurement_index), return_stmt)
+        item = _insert_before(
+            py.GetItem(get_logical_measurement(qubit_index), index.result),
+            return_stmt,
+        )
+        return item.result
+
+    return 1, resolve_measurement, return_stmt
+
+
+def _prepare_physical_measurements(
+    mt: ir.Method,
+    physical_qubits_per_logical_qubit: int,
+) -> tuple[int, MeasurementResolver, func.Return]:
+    AggressiveUnroll(mt.dialects, no_raise=True).fixpoint(mt)
+
+    num_physical_qubits = len(_find_qubit_ssas(mt))
+    if num_physical_qubits == 0:
+        raise ValueError("No physical qubit allocations found in the kernel")
+
+    num_logical_qubits, remainder = divmod(
+        num_physical_qubits, physical_qubits_per_logical_qubit
+    )
+    if remainder != 0:
+        raise ValueError(
+            "The number of physical qubits must be divisible by the number of "
+            "physical qubits per logical qubit"
+        )
+
+    measure_stmts = [
+        stmt
+        for stmt in mt.callable_region.walk()
+        if isinstance(stmt, qubit.stmts.Measure)
+    ]
+    if len(measure_stmts) != 1:
+        raise ValueError("Expected exactly one physical qubit.Measure statement")
+    measure_stmt = measure_stmts[0]
+    return_stmt = _find_return_stmt(mt)
+
+    @cache
+    def resolve_measurement(group_index: int, row_index: int) -> ir.SSAValue:
+        flat_index = group_index * physical_qubits_per_logical_qubit + row_index
+        index = _insert_before(py.Constant(flat_index), return_stmt)
+        item = _insert_before(
+            py.GetItem(measure_stmt.result, index.result), return_stmt
+        )
+        return item.result
+
+    return num_logical_qubits, resolve_measurement, return_stmt
+
+
+def _append_annotations(
+    matrix: list[list[int]],
+    *,
+    num_groups: int,
+    resolve_measurement: MeasurementResolver,
+    return_stmt: func.Return,
+    level: MeasurementLevel,
+    detector: bool,
+) -> None:
+    for group_index in range(num_groups):
+        for annotation_index in range(len(matrix[0])):
+            measurements = [
+                resolve_measurement(group_index, row_index)
+                for row_index, row in enumerate(matrix)
+                if row[annotation_index]
+            ]
+            measurement_list = _insert_before(ilist.New(measurements), return_stmt)
+
+            if detector:
+                coordinate_group = group_index if level == "physical" else 0
+                coord_0 = _insert_before(
+                    py.Constant(float(coordinate_group)), return_stmt
+                )
+                coord_1 = _insert_before(
+                    py.Constant(float(annotation_index)), return_stmt
+                )
+                coords = _insert_before(
+                    ilist.New([coord_0.result, coord_1.result]), return_stmt
+                )
+                _insert_before(
+                    SetDetector(measurement_list.result, coords.result), return_stmt
+                )
+            else:
+                _insert_before(SetObservable(measurement_list.result), return_stmt)
+
+
+def append_measurements_and_annotations(
+    mt: ir.Method,
+    m2dets: list[list[int]] | None,
+    m2obs: list[list[int]] | None,
+    *,
+    level: MeasurementLevel = "logical",
+) -> None:
+    """Append measurement-backed detector and observable annotations.
+
+    Logical matrices describe the complete flattened measurement output.
+    Physical matrices describe one logical block and are repeated for every
+    physical-qubit block in the kernel. The method is mutated in-place and its
+    existing return value is preserved.
+    """
+    if level not in ("logical", "physical"):
+        raise ValueError(f"Unknown measurement annotation level: {level!r}")
+
+    num_matrix_rows = _validate_m2_matrices(m2dets, m2obs)
+    if level == "logical":
+        num_groups, resolver, return_stmt = _prepare_logical_measurements(
+            mt, num_matrix_rows
+        )
+    else:
+        num_groups, resolver, return_stmt = _prepare_physical_measurements(
+            mt, num_matrix_rows
+        )
+
+    if m2dets is not None:
+        _append_annotations(
+            m2dets,
+            num_groups=num_groups,
+            resolve_measurement=resolver,
+            return_stmt=return_stmt,
+            level=level,
+            detector=True,
+        )
+    if m2obs is not None:
+        _append_annotations(
+            m2obs,
+            num_groups=num_groups,
+            resolve_measurement=resolver,
+            return_stmt=return_stmt,
+            level=level,
+            detector=False,
+        )

--- a/python/bloqade/lanes/logical_mvp.py
+++ b/python/bloqade/lanes/logical_mvp.py
@@ -1,22 +1,20 @@
 import io
-from functools import cache
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable
 
-from bloqade.analysis.address import AddressAnalysis, AddressQubit
 from bloqade.analysis.validation.simple_nocloning import FlatKernelNoCloningValidation
-from bloqade.decoders.dialects.annotate.stmts import SetDetector, SetObservable
 from bloqade.stim.emit.stim_str import EmitStimMain
 from bloqade.stim.upstream.from_squin import squin_to_stim
 from kirin import ir
-from kirin.dialects import func, ilist, py
 from kirin.validation import ValidationSuite
 
-from bloqade.gemini.logical.dialects.operations.stmts import (
-    TerminalLogicalMeasurement,
-)
 from bloqade.gemini.logical.validation.clifford.analysis import GeminiLogicalValidation
 from bloqade.gemini.logical.validation.measurement.analysis import (
     GeminiTerminalMeasurementValidation,
+)
+from bloqade.gemini.measurement_annotations import (
+    _find_qubit_ssas as _find_qubit_ssas,
+    _find_return_stmt as _find_return_stmt,
+    append_measurements_and_annotations,
 )
 from bloqade.lanes import visualize
 from bloqade.lanes.analysis import atom, placement
@@ -212,140 +210,6 @@ def compile_to_stim_program(
     emit.initialize()
     emit.run(node=noise_kernel)
     return buf.getvalue().strip()
-
-
-_S = TypeVar("_S", bound=ir.Statement)
-
-
-def _find_qubit_ssas(mt: ir.Method) -> list[ir.SSAValue]:
-    """Return one qubit SSA value per concrete qubit address.
-
-    ``qalloc`` calls must be aggressively unrolled so each allocation has a
-    corresponding SSA value in ``mt``.
-    """
-    address_analysis = AddressAnalysis(mt.dialects)
-    frame, _ = address_analysis.run(mt)
-    qubits_by_address: dict[int, ir.SSAValue] = {}
-
-    for stmt in mt.callable_region.walk():
-        for result in stmt.results:
-            address = frame.get(result)
-            if isinstance(address, AddressQubit):
-                qubits_by_address.setdefault(address.data, result)
-
-    return [
-        qubits_by_address[address] for address in range(address_analysis.qubit_count)
-    ]
-
-
-def _find_return_stmt(mt: ir.Method) -> func.Return:
-    """Find the func.Return statement at the end of the function body."""
-    block = mt.callable_region.blocks[0]
-    last = block.last_stmt
-    assert isinstance(last, func.Return), f"Expected func.Return, got {type(last)}"
-    return last
-
-
-def _insert_before(stmt: _S, anchor: ir.Statement) -> _S:
-    """Insert stmt before anchor and return stmt for chaining."""
-    stmt.insert_before(anchor)
-    return stmt
-
-
-def append_measurements_and_annotations(
-    mt: ir.Method,
-    m2dets: list[list[int]] | None,
-    m2obs: list[list[int]] | None,
-) -> None:
-    """Append terminal measurement, detector, and observable IR statements to a squin kernel.
-
-    The method is mutated in-place.
-
-    Args:
-        mt: A squin ``ir.Method`` whose body returns ``None``.
-        m2dets: Binary matrix of shape ``(num_total_meas, num_detectors)``.
-            Each column defines a detector by its non-zero row indices.
-        m2obs: Binary matrix of shape ``(num_total_meas, num_observables)``.
-            Each column defines an observable by its non-zero row indices.
-    """
-
-    if m2dets is None and m2obs is None:
-        raise ValueError("At least one of m2dets or m2obs must be provided")
-
-    qubit_ssas = _find_qubit_ssas(mt)
-    num_qubits = len(qubit_ssas)
-    if num_qubits == 0:
-        raise ValueError("No qubit allocations found in the kernel")
-
-    m2 = m2dets if m2dets is not None else m2obs
-    assert m2 is not None
-    num_total_meas = len(m2)
-    meas_per_qubit = num_total_meas // num_qubits
-    assert (
-        meas_per_qubit * num_qubits == num_total_meas
-    ), "Incompatible shape of m2dets or m2obs"
-
-    return_stmt = _find_return_stmt(mt)
-
-    # insert TerminalLogicalMeasurement if not present
-    terminal_measurement = next(
-        (
-            s
-            for s in mt.callable_region.walk()
-            if isinstance(s, TerminalLogicalMeasurement)
-        ),
-        None,
-    )
-    if terminal_measurement is not None:
-        term_meas = terminal_measurement
-    else:
-        qlist_stmt = _insert_before(ilist.New(qubit_ssas), return_stmt)
-        term_meas = _insert_before(
-            TerminalLogicalMeasurement(qlist_stmt.result), return_stmt
-        )
-
-    @cache
-    def _get_logical_measurement(q_idx: int) -> ir.SSAValue:
-        (idx := py.Constant(q_idx)).insert_before(return_stmt)
-        (getitem := py.GetItem(term_meas.result, idx.result)).insert_before(return_stmt)
-        return getitem.result
-
-    @cache
-    def _get_physical_measurement(q_idx: int, m_idx: int) -> ir.SSAValue:
-        (idx := py.Constant(m_idx)).insert_before(return_stmt)
-        (
-            getitem := py.GetItem(_get_logical_measurement(q_idx), idx.result)
-        ).insert_before(return_stmt)
-        return getitem.result
-
-    # insert detectors
-    if m2dets is not None:
-        for j in range(len(m2dets[0])):
-            indices = [i for i, row in enumerate(m2dets) if row[j]]
-            meas_ssas = [
-                _get_physical_measurement(*divmod(idx, meas_per_qubit))
-                for idx in indices
-            ]
-            meas_list = _insert_before(ilist.New(meas_ssas), return_stmt)
-
-            coord_0 = _insert_before(py.Constant(0.0), return_stmt)
-            coord_1 = _insert_before(py.Constant(float(j)), return_stmt)
-            coords = _insert_before(
-                ilist.New([coord_0.result, coord_1.result]), return_stmt
-            )
-
-            _insert_before(SetDetector(meas_list.result, coords.result), return_stmt)
-
-    # insert observables
-    if m2obs is not None:
-        for j in range(len(m2obs[0])):
-            indices = [i for i, row in enumerate(m2obs) if row[j]]
-            meas_ssas = [
-                _get_physical_measurement(*divmod(idx, meas_per_qubit))
-                for idx in indices
-            ]
-            meas_list = _insert_before(ilist.New(meas_ssas), return_stmt)
-            _insert_before(SetObservable(meas_list.result), return_stmt)
 
 
 def compile_task(

--- a/python/tests/gemini/test_physical_simulator.py
+++ b/python/tests/gemini/test_physical_simulator.py
@@ -19,6 +19,7 @@ from bloqade.gemini.device.physical_simulator import (
 )
 from bloqade.lanes.analysis import atom
 from bloqade.lanes.arch.gemini.physical import get_arch_spec
+from bloqade.lanes.logical_mvp import append_measurements_and_annotations
 from bloqade.lanes.pipeline import PhysicalPipeline
 
 
@@ -97,17 +98,25 @@ def test_physical_simulator_task_passes_placement_strategy(monkeypatch):
             captured["post_processing_kernel"] = kernel
             return "post_processing"
 
-    def fake_append_measurements_and_annotations_physical(kernel, m2dets, m2obs):
+    def fake_append_measurements_and_annotations(
+        kernel, m2dets, m2obs, *, level="logical"
+    ):
         captured["annotated_kernel"] = kernel
         captured["m2dets"] = m2dets
         captured["m2obs"] = m2obs
+        captured["level"] = level
 
     monkeypatch.setattr(pipeline_module, "PhysicalPipeline", FakePhysicalPipeline)
     monkeypatch.setattr(atom, "AtomInterpreter", FakeAtomInterpreter)
     monkeypatch.setattr(
         physical_simulator_module,
+        "append_measurements_and_annotations",
+        fake_append_measurements_and_annotations,
+    )
+    monkeypatch.setattr(
+        physical_simulator_module,
         "append_measurements_and_annotations_physical",
-        fake_append_measurements_and_annotations_physical,
+        MagicMock(side_effect=AssertionError("legacy wrapper called")),
     )
 
     kernel = MagicMock()
@@ -126,6 +135,7 @@ def test_physical_simulator_task_passes_placement_strategy(monkeypatch):
     assert captured["annotated_kernel"] is kernel
     assert captured["m2dets"] is m2dets
     assert captured["m2obs"] is m2obs
+    assert captured["level"] == "physical"
     assert captured["kernel"] is kernel
     assert captured["no_raise"] is False
     assert captured["atom_dialects"] == "dialects"
@@ -165,6 +175,54 @@ def test_append_measurements_and_annotations_physical_preserves_kernel_return():
     assert list(return_values[0]) == raw_shots[0]
     assert list(post_processing.emit_detectors(raw_shots)) == [[True, True]]
     assert list(post_processing.emit_observables(raw_shots)) == [[True, False]]
+
+
+def test_unified_append_measurements_and_annotations_supports_physical_level():
+    @squin.kernel
+    def kernel():
+        reg = squin.qalloc(4)
+        squin.broadcast.measure(reg)
+
+    append_measurements_and_annotations(
+        kernel,
+        m2dets=[[1], [1]],
+        m2obs=[[1], [0]],
+        level="physical",
+    )
+
+    assert sum(isinstance(s, SetDetector) for s in kernel.callable_region.walk()) == 2
+    assert sum(isinstance(s, SetObservable) for s in kernel.callable_region.walk()) == 2
+
+
+def test_legacy_physical_annotation_helper_delegates(monkeypatch):
+    captured = {}
+
+    def fake_append_measurements_and_annotations(
+        kernel, m2dets, m2obs, *, level="logical"
+    ):
+        captured["kernel"] = kernel
+        captured["m2dets"] = m2dets
+        captured["m2obs"] = m2obs
+        captured["level"] = level
+
+    monkeypatch.setattr(
+        physical_simulator_module,
+        "append_measurements_and_annotations",
+        fake_append_measurements_and_annotations,
+        raising=False,
+    )
+    kernel = MagicMock()
+    m2dets = [[1]]
+    m2obs = [[1]]
+
+    append_measurements_and_annotations_physical(kernel, m2dets, m2obs)
+
+    assert captured == {
+        "kernel": kernel,
+        "m2dets": m2dets,
+        "m2obs": m2obs,
+        "level": "physical",
+    }
 
 
 def test_append_measurements_and_annotations_physical_validates_block_size():

--- a/python/tests/test_cudaq_integration.py
+++ b/python/tests/test_cudaq_integration.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import importlib
+
 import pytest
 from bloqade.decoders.dialects.annotate.stmts import SetDetector, SetObservable
 from kirin.dialects import func
@@ -67,6 +69,52 @@ def test_find_return_stmt():
 def test_raises_when_both_matrices_none():
     with pytest.raises(ValueError, match="At least one"):
         append_measurements_and_annotations(_make_kernel(1), None, None)
+
+
+def test_canonical_measurement_annotation_import():
+    module = importlib.import_module("bloqade.gemini.measurement_annotations")
+
+    assert (
+        module.append_measurements_and_annotations
+        is append_measurements_and_annotations
+    )
+
+
+def test_rejects_unknown_annotation_level():
+    with pytest.raises(ValueError, match="Unknown measurement annotation level"):
+        append_measurements_and_annotations(
+            _make_kernel(1),
+            DETS,
+            OBS,
+            level="unknown",  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    "matrix, match",
+    [
+        ([], "at least one row"),
+        ([[1], [1, 0]], "same length"),
+    ],
+    ids=["empty", "ragged"],
+)
+def test_rejects_invalid_annotation_matrix(matrix: list[list[int]], match: str):
+    with pytest.raises(ValueError, match=match):
+        append_measurements_and_annotations(_make_kernel(1), matrix, None)
+
+
+def test_rejects_annotation_matrices_with_different_row_counts():
+    with pytest.raises(ValueError, match="same number of rows"):
+        append_measurements_and_annotations(_make_kernel(1), DETS, [[1]])
+
+
+def test_accepts_zero_column_annotation_matrix():
+    mt = _make_kernel(1)
+
+    append_measurements_and_annotations(mt, [[]], None)
+
+    assert _count_stmts(mt, TerminalLogicalMeasurement) == 1
+    assert _count_stmts(mt, SetDetector) == 0
 
 
 def test_raises_when_no_qubits():


### PR DESCRIPTION
# Unify logical and physical measurement annotation helpers

## Summary

- Add a shared `append_measurements_and_annotations` implementation for logical
  and physical SQuIn kernels.
- Select the measurement layout explicitly with `level="logical"` or
  `level="physical"`.
- Preserve the existing logical default and
  `append_measurements_and_annotations_physical` compatibility wrapper.
- Centralize matrix validation, qubit discovery, measurement resolution, and
  detector/observable emission.

## Motivation

Logical compilation and physical simulation previously maintained separate
measurement-annotation helpers with substantial duplicated IR construction.
The allocation handling is common to both paths: `qalloc` ultimately produces
addressable qubit SSA values in either kernel type. The meaningful difference is
the measurement result layout:

- Logical kernels use `TerminalLogicalMeasurement`, whose result is nested by
  logical qubit.
- Physical kernels use one flat `qubit.Measure` result and interpret the input
  matrices as a per-logical-block mapping.

This change keeps those layout-specific steps explicit while sharing the rest of
the implementation.

## API

```python
append_measurements_and_annotations(
    kernel,
    m2dets,
    m2obs,
    level="logical",  # or "physical"
)
```

`level` defaults to `"logical"`, so existing logical callers remain compatible.
Existing physical callers can continue using:

```python
append_measurements_and_annotations_physical(kernel, m2dets, m2obs)
```

The compatibility wrapper delegates to the unified API with
`level="physical"`. `PhysicalSimulator.task` now calls the unified API directly.

## Implementation details

- Move shared functionality into
  `bloqade.gemini.measurement_annotations`.
- Use `AddressAnalysis` to discover concrete qubit SSA values produced by both
  ordinary `qubit.New` allocations and pinned `NewAt` allocations.
- Keep logical measurement resolution nested and physical measurement resolution
  flat.
- Preserve detector coordinates:
  - logical: `(0, detector_index)`;
  - physical: `(logical_block_index, detector_index)`.
- Preserve arbitrary physical-kernel return values by inserting annotations
  before the existing `func.Return`.
- Continue accepting valid zero-column matrices such as `[[]]`.
- Raise `ValueError` for missing, empty, ragged, or row-count-mismatched matrices
  and for unknown annotation levels.

## Compatibility

- No change to logical matrix semantics: rows describe the globally flattened
  measurement output.
- No change to physical matrix semantics: rows describe one logical block and
  annotations repeat for each block.
- The old physical helper remains available as a compatibility wrapper.
- Existing private helper imports used by tests remain re-exported from their
  original modules.

## Testing

- Added coverage for:
  - canonical and compatibility imports;
  - logical and physical dispatch;
  - physical compatibility-wrapper delegation;
  - detector and observable counts;
  - physical block repetition and return-value preservation;
  - empty, ragged, mismatched-row, zero-column, and invalid-level inputs;
  - ordinary and pinned (`NewAt`) allocations.
- Focused tests: `30 passed`.
- Full Python suite: `1554 passed, 17 skipped`.
- Ruff: passed.
- Pyright: `0 errors, 0 warnings`.
- Pre-commit checks: passed.
