### PR TITLE
feat(python): add MoveToStackMove transformation

### DIFF
--- a/python/bloqade/lanes/transform.py
+++ b/python/bloqade/lanes/transform.py
@@ -185,11 +185,11 @@ class MoveToStackMove:
        each SSA value used at most once, defining statements in stack order).
 
     ``RewriteMoveToStackMove`` only lowers the subset of ``move`` statements
-    the bytecode path supports, so after dropping ``move`` from the dialect
-    group ``emit`` runs ``statements_outside_dialect_group`` and raises if any
-    statement is left outside the group — Kirin's ``verify()`` does not check
-    dialect-group membership, so an unlowered statement would otherwise slip
-    through and fail lazily inside ``dump_program``.
+    the bytecode path supports. When ``no_raise`` is ``False``, ``emit`` runs
+    ``statements_outside_dialect_group`` after dropping ``move`` from the group
+    and raises if any statement is left outside it — Kirin's ``verify()`` does
+    not check dialect-group membership, so an unlowered statement would
+    otherwise slip through and fail lazily inside ``dump_program``.
 
     ``emit_bytecode`` runs ``emit`` and encodes the result to a bytecode
     ``Program`` via ``dump_program``.
@@ -218,18 +218,21 @@ class MoveToStackMove:
         # Drop the now-unused move dialect from the group.
         out = out.similar(out.dialects.discard(move.dialect))
 
-        # Fail fast: RewriteMoveToStackMove passes through any move statement it
-        # doesn't handle, and verify() does not police dialect-group membership,
-        # so an unlowered statement would otherwise surface as a confusing
-        # EncodingError deep inside dump_program.
-        leftover = statements_outside_dialect_group(out)
-        if leftover:
-            kinds = sorted({type(stmt).__name__ for stmt in leftover})
-            raise ValueError(
-                "MoveToStackMove left statements outside the stack_move dialect "
-                f"group: {', '.join(kinds)}; RewriteMoveToStackMove does not "
-                "lower them, so the kernel cannot be emitted as stack_move IR"
-            )
+        if not no_raise:
+            # RewriteMoveToStackMove passes through any move statement it does
+            # not handle, and verify() does not police dialect-group membership,
+            # so an unlowered statement would otherwise surface as a confusing
+            # EncodingError deep inside dump_program. Fail fast with a precise
+            # error naming the offending statement kinds.
+            leftover = statements_outside_dialect_group(out)
+            if leftover:
+                kinds = sorted({type(stmt).__name__ for stmt in leftover})
+                raise ValueError(
+                    "MoveToStackMove left statements outside the stack_move "
+                    f"dialect group: {', '.join(kinds)}; RewriteMoveToStackMove "
+                    "does not lower them, so the kernel cannot be emitted as "
+                    "stack_move IR"
+                )
 
         # Canonicalize into stack-consistent form, ready for dump_program.
         stackify(out)

--- a/python/bloqade/lanes/transform.py
+++ b/python/bloqade/lanes/transform.py
@@ -23,6 +23,7 @@ from bloqade.lanes.rewrite.move2squin import (
 )
 from bloqade.lanes.rewrite.move2stack_move import RewriteMoveToStackMove
 from bloqade.lanes.rewrite.stackify import stackify
+from bloqade.lanes.utils import statements_outside_dialect_group
 
 InitKernel = LogicalInitKernel | None
 
@@ -181,7 +182,14 @@ class MoveToStackMove:
     2. DCE + CSE to a fixpoint — the cleanup the encoder pipeline expects
        before stackification (see ``stackify``'s docstring).
     3. ``stackify`` — normalise into stack-consistent form (single block,
-       each SSA value used exactly once, defining statements in stack order).
+       each SSA value used at most once, defining statements in stack order).
+
+    ``RewriteMoveToStackMove`` only lowers the subset of ``move`` statements
+    the bytecode path supports, so after dropping ``move`` from the dialect
+    group ``emit`` runs ``statements_outside_dialect_group`` and raises if any
+    statement is left outside the group — Kirin's ``verify()`` does not check
+    dialect-group membership, so an unlowered statement would otherwise slip
+    through and fail lazily inside ``dump_program``.
 
     ``emit_bytecode`` runs ``emit`` and encodes the result to a bytecode
     ``Program`` via ``dump_program``.
@@ -209,6 +217,19 @@ class MoveToStackMove:
 
         # Drop the now-unused move dialect from the group.
         out = out.similar(out.dialects.discard(move.dialect))
+
+        # Fail fast: RewriteMoveToStackMove passes through any move statement it
+        # doesn't handle, and verify() does not police dialect-group membership,
+        # so an unlowered statement would otherwise surface as a confusing
+        # EncodingError deep inside dump_program.
+        leftover = statements_outside_dialect_group(out)
+        if leftover:
+            kinds = sorted({type(stmt).__name__ for stmt in leftover})
+            raise ValueError(
+                "MoveToStackMove left statements outside the stack_move dialect "
+                f"group: {', '.join(kinds)}; RewriteMoveToStackMove does not "
+                "lower them, so the kernel cannot be emitted as stack_move IR"
+            )
 
         # Canonicalize into stack-consistent form, ready for dump_program.
         stackify(out)

--- a/python/bloqade/lanes/transform.py
+++ b/python/bloqade/lanes/transform.py
@@ -10,7 +10,9 @@ from kirin.passes import TypeInfer
 from bloqade import squin
 from bloqade.lanes.analysis import atom
 from bloqade.lanes.arch.spec import ArchSpec
-from bloqade.lanes.dialects import move
+from bloqade.lanes.bytecode import Program
+from bloqade.lanes.bytecode.encode import dump_program
+from bloqade.lanes.dialects import move, stack_move
 from bloqade.lanes.rewrite import move2squin
 from bloqade.lanes.rewrite.move2squin import (
     LogicalInitKernel as LogicalInitKernel,
@@ -19,6 +21,8 @@ from bloqade.lanes.rewrite.move2squin import (
     SimpleLogicalNoiseModel as SimpleLogicalNoiseModel,
     SimpleNoiseModel as SimpleNoiseModel,
 )
+from bloqade.lanes.rewrite.move2stack_move import RewriteMoveToStackMove
+from bloqade.lanes.rewrite.stackify import stackify
 
 InitKernel = LogicalInitKernel | None
 
@@ -162,3 +166,62 @@ class MoveToSquinPhysical(MoveToSquinBase):
 
     def _get_initialize_noise_kernel(self) -> InitKernel:
         return None
+
+
+@dataclass
+class MoveToStackMove:
+    """Lower a ``move``-dialect kernel to a canonicalized ``stack_move`` kernel.
+
+    ``emit`` runs the full move → stack_move lowering pipeline, producing an
+    ``ir.Method`` that is stack-consistent and ready for bytecode emission:
+
+    1. ``RewriteMoveToStackMove`` — in-place move → stack_move rewrite
+       (strips Load/Store state threading, materialises address attributes
+       as ``Const*`` SSA values, rebuilds Measure/AwaitMeasure/GetItem).
+    2. DCE + CSE to a fixpoint — the cleanup the encoder pipeline expects
+       before stackification (see ``stackify``'s docstring).
+    3. ``stackify`` — normalise into stack-consistent form (single block,
+       each SSA value used exactly once, defining statements in stack order).
+
+    ``emit_bytecode`` runs ``emit`` and encodes the result to a bytecode
+    ``Program`` via ``dump_program``.
+    """
+
+    arch_spec: ArchSpec
+
+    def emit(self, main: ir.Method, no_raise: bool = True) -> ir.Method:
+        # Copy into a dialect group that includes stack_move so the rewritten
+        # statements are legal members of the method's dialects.
+        out = main.similar(main.dialects.union([stack_move.dialect]))
+
+        # move → stack_move (single pass; the rule deletes the move statements).
+        rewrite.Walk(RewriteMoveToStackMove(arch_spec=self.arch_spec)).rewrite(out.code)
+
+        # DCE + CSE, matching the cleanup the real pipeline runs before stackify.
+        rewrite.Fixpoint(
+            rewrite.Walk(
+                rewrite.Chain(
+                    rewrite.DeadCodeElimination(),
+                    rewrite.CommonSubexpressionElimination(),
+                )
+            )
+        ).rewrite(out.code)
+
+        # Drop the now-unused move dialect from the group.
+        out = out.similar(out.dialects.discard(move.dialect))
+
+        # Canonicalize into stack-consistent form, ready for dump_program.
+        stackify(out)
+
+        if not no_raise:
+            out.verify()
+
+        return out
+
+    def emit_bytecode(
+        self,
+        main: ir.Method,
+        version: tuple[int, int] = (1, 0),
+        no_raise: bool = True,
+    ) -> Program:
+        return dump_program(self.emit(main, no_raise=no_raise), version=version)

--- a/python/bloqade/lanes/utils.py
+++ b/python/bloqade/lanes/utils.py
@@ -32,6 +32,37 @@ def no_none_elements_tuple(xs: tuple[T | None, ...]) -> TypeGuard[tuple[T, ...]]
     return all(x is not None for x in xs)
 
 
+def statements_outside_dialect_group(method: ir.Method) -> list[ir.Statement]:
+    """Return every statement in *method* whose dialect is not in its group.
+
+    Kirin's ``Method.verify()`` checks per-statement structure but never
+    validates that each statement's dialect is a member of the method's
+    declared ``DialectGroup``. An out-of-group statement therefore passes
+    ``verify()`` cleanly and only surfaces lazily — as an ``InterpreterError``
+    at interpretation/emit time (see ``kirin.interp.abc``), far from its cause.
+
+    Use this after a lowering pass that is expected to leave no statements from
+    the source dialect behind (e.g. ``move`` after ``RewriteMoveToStackMove``)
+    to fail fast with a precise, local error instead.
+
+    Statements with no dialect (``stmt.dialect is None``, e.g. dialect-agnostic
+    base statements) are ignored.
+
+    Args:
+        method: The kernel to scan.
+
+    Returns:
+        The offending statements, in walk order. Empty if every statement's
+        dialect is a member of ``method.dialects``.
+    """
+    dialects = method.dialects
+    return [
+        stmt
+        for stmt in method.code.walk()
+        if stmt.dialect is not None and stmt.dialect not in dialects
+    ]
+
+
 def check_circuit(
     squin_method: ir.Method[[], None],
     other_squin_method: ir.Method[[], None],

--- a/python/tests/test_transform_move_to_stack_move.py
+++ b/python/tests/test_transform_move_to_stack_move.py
@@ -1,0 +1,117 @@
+"""Tests for the MoveToStackMove transformation.
+
+Builds a ``move``-dialect kernel by running the inverse rewrite
+(``RewriteStackMoveToMove``) on a hand-authored ``stack_move`` block, then
+drives it through ``MoveToStackMove.emit`` / ``emit_bytecode`` and checks the
+result is a canonicalized, bytecode-ready ``stack_move`` kernel.
+"""
+
+from kirin import ir, types
+from kirin.dialects import func, py
+from kirin.rewrite import Walk
+
+from bloqade.lanes.arch.gemini.logical import get_arch_spec
+from bloqade.lanes.bytecode.decode import load_program
+from bloqade.lanes.bytecode.encoding import LocationAddress
+from bloqade.lanes.dialects import move, stack_move
+from bloqade.lanes.rewrite.stack_move2move import RewriteStackMoveToMove
+from bloqade.lanes.transform import MoveToStackMove
+
+_ARCH = get_arch_spec()
+
+
+def _move_kernel() -> ir.Method:
+    """Build a small move-dialect ir.Method: InitialFill + LocalRz on one loc.
+
+    Constructs the target ``stack_move`` IR, then runs the inverse rewrite so
+    the resulting method holds equivalent ``move``-dialect statements (with
+    Load/Store state threading) ready to feed into ``MoveToStackMove``.
+    """
+    a0 = LocationAddress(0, 0, 0)
+    cf = stack_move.ConstFloat(value=0.5)
+    cl = stack_move.ConstLoc(value=a0)
+    initial_fill = stack_move.InitialFill(locations=(cl.result,))
+    lrz = stack_move.LocalRz(rotation_angle=cf.result, locations=(cl.result,))
+    none_stmt = func.ConstantNone()
+    ret = func.Return(none_stmt.result)
+
+    block = ir.Block(argtypes=(types.MethodType,))
+    for s in [cf, cl, initial_fill, lrz, none_stmt, ret]:
+        block.stmts.append(s)
+
+    function = func.Function(
+        sym_name="main",
+        signature=func.Signature((), types.Any),
+        slots=(),
+        body=ir.Region(blocks=block),
+    )
+    dialects = ir.DialectGroup(
+        [stack_move.dialect, move.dialect, func.dialect, py.dialect]
+    )
+    method = ir.Method(dialects=dialects, code=function, sym_name="main", arg_names=[])
+
+    Walk(RewriteStackMoveToMove(arch_spec=_ARCH)).rewrite(method.code)
+    return method
+
+
+def _stmts(method: ir.Method) -> list[ir.Statement]:
+    return list(method.callable_region.blocks[0].stmts)
+
+
+def test_emit_lowers_move_to_stack_move():
+    """emit() removes all move statements and produces stack_move equivalents."""
+    method = _move_kernel()
+    # sanity: the input is genuinely a move-dialect kernel
+    assert any(isinstance(s, move.Fill) for s in _stmts(method))
+
+    out = MoveToStackMove(arch_spec=_ARCH).emit(method)
+    stmts = _stmts(out)
+
+    assert not any(s.dialect is move.dialect for s in stmts)
+    assert any(isinstance(s, stack_move.InitialFill) for s in stmts)
+    assert any(isinstance(s, stack_move.LocalRz) for s in stmts)
+
+
+def test_emit_is_stack_consistent():
+    """Every SSA value in the emitted kernel is used at most once (stackified)."""
+    out = MoveToStackMove(arch_spec=_ARCH).emit(_move_kernel())
+    for stmt in _stmts(out):
+        for result in stmt.results:
+            assert len(result.uses) <= 1
+
+
+def test_emit_does_not_mutate_input():
+    """emit() operates on a copy; the input move kernel is untouched."""
+    method = _move_kernel()
+    before = [type(s).__name__ for s in _stmts(method)]
+    MoveToStackMove(arch_spec=_ARCH).emit(method)
+    after = [type(s).__name__ for s in _stmts(method)]
+    assert before == after
+
+
+def test_emit_no_raise_false_verifies():
+    """emit(no_raise=False) runs verify() without raising on valid IR."""
+    out = MoveToStackMove(arch_spec=_ARCH).emit(_move_kernel(), no_raise=False)
+    assert any(isinstance(s, stack_move.InitialFill) for s in _stmts(out))
+
+
+def test_emit_bytecode_round_trips():
+    """emit_bytecode() produces a Program that load_program can decode."""
+    xform = MoveToStackMove(arch_spec=_ARCH)
+    prog = xform.emit_bytecode(_move_kernel())
+    assert len(prog.instructions) > 0
+    assert prog.version == (1, 0)
+
+    decoded = load_program(prog)
+    assert any(
+        isinstance(s, stack_move.InitialFill)
+        for s in decoded.callable_region.blocks[0].stmts
+    )
+
+
+def test_emit_bytecode_version_passthrough():
+    """emit_bytecode() forwards the requested version onto the Program."""
+    prog = MoveToStackMove(arch_spec=_ARCH).emit_bytecode(
+        _move_kernel(), version=(2, 3)
+    )
+    assert prog.version == (2, 3)

--- a/python/tests/test_transform_move_to_stack_move.py
+++ b/python/tests/test_transform_move_to_stack_move.py
@@ -137,8 +137,8 @@ def _move_kernel_with_unlowered_stmt() -> ir.Method:
 
 
 def test_emit_fails_fast_on_unlowered_move_stmt():
-    """emit() raises (even with no_raise=True) when a move statement is not
-    lowered, naming the offending statement kind rather than failing later."""
+    """emit(no_raise=False) raises when a move statement is not lowered, naming
+    the offending statement kind rather than failing later in dump_program."""
     method = _move_kernel_with_unlowered_stmt()
     with pytest.raises(ValueError, match="ConstZone"):
-        MoveToStackMove(arch_spec=_ARCH).emit(method, no_raise=True)
+        MoveToStackMove(arch_spec=_ARCH).emit(method, no_raise=False)

--- a/python/tests/test_transform_move_to_stack_move.py
+++ b/python/tests/test_transform_move_to_stack_move.py
@@ -6,13 +6,14 @@ drives it through ``MoveToStackMove.emit`` / ``emit_bytecode`` and checks the
 result is a canonicalized, bytecode-ready ``stack_move`` kernel.
 """
 
+import pytest
 from kirin import ir, types
 from kirin.dialects import func, py
 from kirin.rewrite import Walk
 
 from bloqade.lanes.arch.gemini.logical import get_arch_spec
 from bloqade.lanes.bytecode.decode import load_program
-from bloqade.lanes.bytecode.encoding import LocationAddress
+from bloqade.lanes.bytecode.encoding import LocationAddress, ZoneAddress
 from bloqade.lanes.dialects import move, stack_move
 from bloqade.lanes.rewrite.stack_move2move import RewriteStackMoveToMove
 from bloqade.lanes.transform import MoveToStackMove
@@ -115,3 +116,29 @@ def test_emit_bytecode_version_passthrough():
         _move_kernel(), version=(2, 3)
     )
     assert prog.version == (2, 3)
+
+
+def _move_kernel_with_unlowered_stmt() -> ir.Method:
+    """A move kernel containing move.ConstZone, which RewriteMoveToStackMove
+    does not lower (it passes through unchanged)."""
+    cz = move.ConstZone(value=ZoneAddress(0))
+    ret = func.Return(cz.result)
+    block = ir.Block(argtypes=(types.MethodType,))
+    for s in [cz, ret]:
+        block.stmts.append(s)
+    function = func.Function(
+        sym_name="main",
+        signature=func.Signature((), types.Any),
+        slots=(),
+        body=ir.Region(blocks=block),
+    )
+    dialects = ir.DialectGroup([stack_move.dialect, move.dialect, func.dialect])
+    return ir.Method(dialects=dialects, code=function, sym_name="main", arg_names=[])
+
+
+def test_emit_fails_fast_on_unlowered_move_stmt():
+    """emit() raises (even with no_raise=True) when a move statement is not
+    lowered, naming the offending statement kind rather than failing later."""
+    method = _move_kernel_with_unlowered_stmt()
+    with pytest.raises(ValueError, match="ConstZone"):
+        MoveToStackMove(arch_spec=_ARCH).emit(method, no_raise=True)

--- a/python/tests/test_utils.py
+++ b/python/tests/test_utils.py
@@ -1,0 +1,54 @@
+"""Tests for bloqade.lanes.utils helpers."""
+
+from kirin import ir, types
+from kirin.dialects import func
+
+from bloqade.lanes.bytecode.encoding import ZoneAddress
+from bloqade.lanes.dialects import move, stack_move
+from bloqade.lanes.utils import statements_outside_dialect_group
+
+
+def _method(*stmts, dialects: list) -> ir.Method:
+    block = ir.Block(argtypes=(types.MethodType,))
+    for s in stmts:
+        block.stmts.append(s)
+    function = func.Function(
+        sym_name="main",
+        signature=func.Signature((), types.Any),
+        slots=(),
+        body=ir.Region(blocks=block),
+    )
+    return ir.Method(
+        dialects=ir.DialectGroup(dialects),
+        code=function,
+        sym_name="main",
+        arg_names=[],
+    )
+
+
+def test_no_offenders_when_all_in_group():
+    cf = stack_move.ConstFloat(value=0.5)
+    ret = func.Return(cf.result)
+    method = _method(cf, ret, dialects=[stack_move.dialect, func.dialect])
+
+    assert statements_outside_dialect_group(method) == []
+
+
+def test_detects_statement_outside_group():
+    # move.ConstZone is present but move.dialect is NOT in the group.
+    cz = move.ConstZone(value=ZoneAddress(0))
+    ret = func.Return(cz.result)
+    method = _method(cz, ret, dialects=[stack_move.dialect, func.dialect])
+
+    offenders = statements_outside_dialect_group(method)
+
+    assert offenders == [cz]
+
+
+def test_no_offenders_when_dialect_present():
+    # Same statement, but now move.dialect IS in the group → no offenders.
+    cz = move.ConstZone(value=ZoneAddress(0))
+    ret = func.Return(cz.result)
+    method = _method(cz, ret, dialects=[stack_move.dialect, move.dialect, func.dialect])
+
+    assert statements_outside_dialect_group(method) == []


### PR DESCRIPTION
## Summary

Adds a `MoveToStackMove` transformation to `bloqade.lanes.transform`, in the same style as the existing `MoveToSquin*` objects. It wires the previously standalone move → stack_move rewrite pieces (`RewriteMoveToStackMove`, `stackify`, `dump_program`) into a single orchestrator.

Before this change these pieces existed but were only ever composed manually in unit tests — there was no `transform`-style entry point that lowered a `move`-dialect kernel to a canonicalized `stack_move` kernel.

## What it does

`MoveToStackMove.emit(main, no_raise=True) -> ir.Method` runs the full lowering pipeline on a **copy** of the input (input is left untouched):

1. `RewriteMoveToStackMove` — move → stack_move (strips Load/Store state threading, materializes address attributes as `Const*` SSA values, rebuilds Measure/AwaitMeasure/GetItem).
2. DCE + CSE to a fixpoint — the cleanup the encoder pipeline expects before stackification.
3. `similar(discard(move.dialect))` — drop the now-unused source dialect.
4. `stackify` — normalize into stack-consistent form (single block, each SSA value used at most once, defining statements in stack order).
5. `verify()` gated on `no_raise` (skips `verify_type`/`TypeInfer`, which `stack_move` has no rules for).

`emit_bytecode(main, version=(1, 0), no_raise=True) -> Program` additionally encodes the result to a bytecode `Program` via `dump_program`.

## Tests

New `python/tests/test_transform_move_to_stack_move.py` (6 tests): lowering correctness, stack-consistency, input immutability, the `no_raise=False` verify path, bytecode round-trip, and version passthrough. All pass alongside the existing `test_move2stack_move` / `test_stackify` suites (36 total). `isort` / `black` / `ruff` / `pyright` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)