### PR TITLE
Add per-call simulator sampling seeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ debug/
 Thumbs.db
 .claude/worktrees
 .claire/worktrees
+.worktrees/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/superpowers/plans/2026-07-15-tsim-run-seed.md
+++ b/docs/superpowers/plans/2026-07-15-tsim-run-seed.md
@@ -1,0 +1,135 @@
+# Per-call tsim sampling seed Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional per-call sampling seed to Gemini logical simulator task and convenience APIs.
+
+**Architecture:** Validate the seed once at the logical-task boundary, then select cached samplers for unseeded tsim calls and fresh compiled samplers for seeded calls. Forward the same keyword through asynchronous, simulator convenience, and CliffT override paths; a per-call CliffT seed overrides its existing task-level seed.
+
+**Tech Stack:** Python 3.10+, pytest, Stim, tsim, CliffT test doubles, Kirin.
+
+---
+
+### Task 1: Specify seeded task sampling behavior with tests
+
+**Files:**
+- Modify: `python/tests/test_device.py:316-383`
+- Modify: `python/tests/gemini/decoding/test_tasks.py:19-76`
+
+- [ ] **Step 1: Write failing logical-task tests**
+
+Add mocked tests that call `GeminiLogicalSimulatorTask.run(..., seed=0)` for:
+
+```python
+def test_run_clifford_compiles_seeded_stim_sampler():
+    task = _mock_task(is_clifford=True)
+    GeminiLogicalSimulatorTask.run(task, seed=0)
+    task.tsim_circuit.stim_circuit.compile_sampler.assert_called_once_with(seed=0)
+
+def test_run_non_clifford_compiles_fresh_seeded_sampler():
+    task = _mock_task(is_clifford=False)
+    GeminiLogicalSimulatorTask.run(task, seed=123)
+    task.tsim_circuit.compile_sampler.assert_called_once_with(seed=123)
+    task.measurement_sampler.sample.assert_not_called()
+```
+
+Cover detector equivalents, noisy/noiseless circuit selection, and no-seed
+cached sampler behavior. Add an explicit validation matrix that accepts `0`
+and `2**63 - 1` and rejects `True`, negative values, `2**63`, and a
+non-integer. Run the task's seeded `run_async(...).result()` path, then add a
+real fixed-batch non-Clifford tsim test showing two independent same-seed calls
+produce the same samples and that a seeded call does not change a following
+unseeded call's use of its cached sampler.
+
+- [ ] **Step 2: Write failing CliffT tests**
+
+Extend `_task_with_cached_programs` tests to show that `seed=` overrides the
+task field, `seed=None` falls back to it, the same validation matrix fails
+before sampling, and `run_async(..., seed=...).result()` forwards to `run`.
+
+- [ ] **Step 3: Run focused tests and confirm they fail**
+
+Run: `uv run pytest python/tests/test_device.py python/tests/gemini/decoding/test_tasks.py -q`
+
+Expected: failures reporting that `run` and/or `_sample_clifft` do not accept `seed`.
+
+### Task 2: Implement seed validation and task propagation
+
+**Files:**
+- Modify: `python/bloqade/gemini/device/simulator.py:305-457`
+- Modify: `python/bloqade/gemini/decoding/tasks.py:43-198`
+
+- [ ] **Step 1: Add a shared seed validator in `simulator.py`**
+
+Implement a small helper accepting `None` or non-boolean `int` in `[0, 2**63)` and raising `ValueError` otherwise. Preserve `seed=0`.
+
+- [ ] **Step 2: Add seeded sampler selection to `GeminiLogicalSimulatorTask`**
+
+Add `seed` to all task `run` / `run_async` overloads and implementations. For a provided seed, compile a fresh sampler with `seed=seed`: Stim for Clifford circuits, tsim measurement or detector sampler for non-Clifford circuits. For `None`, retain the existing cached/non-cached code paths. Pass seed to `_run_detectors` and executor calls.
+
+- [ ] **Step 3: Update `_CliffTSimulatorTask`**
+
+Add the same `seed` keyword to its sampling, `run`, and `run_async` methods. `_sample_clifft` uses the per-call seed when non-`None`; otherwise it retains `self.seed` fallback. Validate with the shared helper.
+
+- [ ] **Step 4: Run focused tests and confirm they pass**
+
+Run: `uv run pytest python/tests/test_device.py python/tests/gemini/decoding/test_tasks.py -q`
+
+Expected: PASS.
+
+### Task 3: Add simulator convenience forwarding and verification
+
+**Files:**
+- Modify: `python/bloqade/gemini/device/simulator.py:540-641`
+- Modify: `python/tests/test_device.py:316-383`
+
+- [ ] **Step 1: Write failing forwarding tests**
+
+Use a mock task returned by `GeminiLogicalSimulator.task` to verify:
+
+```python
+sim.run(main, shots=2, seed=123)
+task.run.assert_called_once_with(2, True, run_detectors=False, seed=123)
+
+sim.run_async(main, shots=2, run_detectors=True, seed=123)
+task.run_async.assert_called_once_with(2, True, run_detectors=True, seed=123)
+```
+
+Also use a task double returning an already-completed future so the test calls
+the simulator's `run_async(..., seed=123).result()` successfully for both
+measurement and detector branches.
+
+- [ ] **Step 2: Run forwarding tests and confirm they fail**
+
+Run: `uv run pytest python/tests/test_device.py -k seed -q`
+
+Expected: failure because the simulator methods do not accept or forward `seed`.
+
+- [ ] **Step 3: Add optional seed to simulator overloads and implementations**
+
+Add `seed: int | None = None` as a keyword-only argument and document it. Forward it unchanged to each newly created task's `run` or `run_async` call, including the detector branch.
+
+- [ ] **Step 4: Run all focused tests and static checks**
+
+Run:
+`uv run pytest python/tests/test_device.py python/tests/gemini/decoding/test_tasks.py -q`
+
+`uv run pyright python/bloqade/gemini/device/simulator.py python/bloqade/gemini/decoding/tasks.py`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full Python suite**
+
+Run: `just test-python`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add python/bloqade/gemini/device/simulator.py \
+    python/bloqade/gemini/decoding/tasks.py \
+    python/tests/test_device.py \
+    python/tests/gemini/decoding/test_tasks.py
+git commit -m "feat(python): add per-call simulator sampling seeds"
+```

--- a/docs/superpowers/specs/2026-07-15-tsim-run-seed-design.md
+++ b/docs/superpowers/specs/2026-07-15-tsim-run-seed-design.md
@@ -42,4 +42,6 @@ noiseless circuits. Async task and simulator calls will be checked through
 `.result()`. Tests will also confirm that a seeded call compiles a fresh
 sampler every time, `seed=None` continues to use the cached tsim samplers,
 two independent calls with the same seed reproduce samples at a fixed batch
-size, and a seeded call does not leak into a later unseeded call.
+size, and a seeded call does not leak into a later unseeded call. CliffT tests
+will cover per-call override of the task-level seed, its `seed=None` fallback,
+async forwarding, and invalid-seed rejection.

--- a/docs/superpowers/specs/2026-07-15-tsim-run-seed-design.md
+++ b/docs/superpowers/specs/2026-07-15-tsim-run-seed-design.md
@@ -1,0 +1,27 @@
+# Per-call tsim sampling seed
+
+## Goal
+
+Allow callers to seed one simulation invocation without changing the task's
+default cached sampler or the simulator's existing configuration.
+
+## API
+
+Add an optional keyword-only `seed: int | None = None` argument to
+`GeminiLogicalSimulatorTask.run`, `GeminiLogicalSimulatorTask.run_async`,
+`GeminiLogicalSimulator.run`, and `GeminiLogicalSimulator.run_async`.
+
+## Behavior
+
+When `seed` is `None`, retain the current paths and cached sampler behavior.
+When it is provided, compile a fresh seeded sampler for the specific call and
+pass it to both measurement and detector execution paths. This applies to the
+Stim path used for Clifford circuits and the tsim path used for non-Clifford
+circuits. The simulator convenience methods forward the argument to their
+newly created task.
+
+## Validation
+
+Unit tests will confirm that seeded calls pass the value to each backend's
+sampler compiler and that the simulator `run` and `run_async` methods forward
+the seed unchanged. Existing no-seed tests preserve the default behavior.

--- a/docs/superpowers/specs/2026-07-15-tsim-run-seed-design.md
+++ b/docs/superpowers/specs/2026-07-15-tsim-run-seed-design.md
@@ -9,7 +9,12 @@ default cached sampler or the simulator's existing configuration.
 
 Add an optional keyword-only `seed: int | None = None` argument to
 `GeminiLogicalSimulatorTask.run`, `GeminiLogicalSimulatorTask.run_async`,
-`GeminiLogicalSimulator.run`, and `GeminiLogicalSimulator.run_async`.
+`GeminiLogicalSimulator.run`, and `GeminiLogicalSimulator.run_async`. The
+same arguments will be added to the `_CliffTSimulatorTask` overrides so that
+`GeminiLogicalSimulator(backend="clifft")` supports the advertised API.
+
+The physical simulator is out of scope: this change is limited to the Gemini
+logical simulator and its task types.
 
 ## Behavior
 
@@ -20,8 +25,21 @@ Stim path used for Clifford circuits and the tsim path used for non-Clifford
 circuits. The simulator convenience methods forward the argument to their
 newly created task.
 
+For CliffT, the per-call seed takes precedence over the existing task-level
+`GeminiLogicalSimulator(seed=...)` value; when the per-call seed is `None`,
+the existing task-level value continues to apply. `seed=0` is a valid seed and
+must be forwarded. Valid seeds are non-boolean Python integers in the range
+`0 <= seed < 2**63`; invalid values raise `ValueError` before compilation so
+all supported backends have the same contract.
+
 ## Validation
 
 Unit tests will confirm that seeded calls pass the value to each backend's
 sampler compiler and that the simulator `run` and `run_async` methods forward
-the seed unchanged. Existing no-seed tests preserve the default behavior.
+the seed unchanged. They will cover Stim measurement, Stim detector
+conversion, tsim measurement, and tsim detector sampling with both noisy and
+noiseless circuits. Async task and simulator calls will be checked through
+`.result()`. Tests will also confirm that a seeded call compiles a fresh
+sampler every time, `seed=None` continues to use the cached tsim samplers,
+two independent calls with the same seed reproduce samples at a fixed batch
+size, and a seeded call does not leak into a later unseeded call.

--- a/python/bloqade/gemini/decoding/tasks.py
+++ b/python/bloqade/gemini/decoding/tasks.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, overload
 import numpy as np
 
 from bloqade.gemini.device import DetectorResult, GeminiLogicalSimulatorTask, Result
+from bloqade.gemini.device.simulator import _validate_seed
 
 if TYPE_CHECKING:
     from clifft import Program, SampleResult  # type: ignore[reportMissingImports]
@@ -72,7 +73,11 @@ class _CliffTSimulatorTask(GeminiLogicalSimulatorTask[RetType]):
         shots: int,
         *,
         with_noise: bool = True,
+        seed: int | None = None,
     ) -> SampleResult:
+        _validate_seed(seed)
+        _validate_seed(self.seed)
+
         clifft = _clifft()
 
         # TODO: check if _run_clifft() is ever called with run()... because I think we might be calling sample_clifft_det_obs always?
@@ -82,8 +87,9 @@ class _CliffTSimulatorTask(GeminiLogicalSimulatorTask[RetType]):
             else self.clifft_noiseless_tsim_program
         )
         sample_kwargs: dict[str, int] = {"shots": int(shots)}
-        if self.seed is not None:
-            sample_kwargs["seed"] = int(self.seed)
+        effective_seed = self.seed if seed is None else seed
+        if effective_seed is not None:
+            sample_kwargs["seed"] = effective_seed
         return cast("SampleResult", clifft.sample(program, **sample_kwargs))
 
     @overload
@@ -93,6 +99,7 @@ class _CliffTSimulatorTask(GeminiLogicalSimulatorTask[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: Literal[False] = ...,
+        seed: int | None = None,
     ) -> Result[RetType]: ...
 
     @overload
@@ -102,6 +109,7 @@ class _CliffTSimulatorTask(GeminiLogicalSimulatorTask[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: Literal[True],
+        seed: int | None = None,
     ) -> DetectorResult: ...
 
     @overload
@@ -111,6 +119,7 @@ class _CliffTSimulatorTask(GeminiLogicalSimulatorTask[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: bool,
+        seed: int | None = None,
     ) -> Result[RetType] | DetectorResult: ...
 
     def run(
@@ -119,10 +128,11 @@ class _CliffTSimulatorTask(GeminiLogicalSimulatorTask[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: bool = False,
+        seed: int | None = None,
     ) -> Result[RetType] | DetectorResult:
         """Sample detector and observable arrays using CliffT."""
 
-        sample_result = self._sample_clifft(shots, with_noise=with_noise)
+        sample_result = self._sample_clifft(shots, with_noise=with_noise, seed=seed)
         # NOTE: this should be a no-op if detectors/observables are already of the right type
         detectors = np.asarray(sample_result.detectors, dtype=np.uint8)
         observables = np.asarray(sample_result.observables, dtype=np.uint8)
@@ -156,6 +166,7 @@ class _CliffTSimulatorTask(GeminiLogicalSimulatorTask[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: Literal[False] = ...,
+        seed: int | None = None,
     ) -> Future[Result[RetType]]: ...
 
     @overload
@@ -165,6 +176,7 @@ class _CliffTSimulatorTask(GeminiLogicalSimulatorTask[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: Literal[True],
+        seed: int | None = None,
     ) -> Future[DetectorResult]: ...
 
     # NOTE: defining run_async because GeminiLogicalSimulatorTask exposes this in public API.
@@ -175,8 +187,12 @@ class _CliffTSimulatorTask(GeminiLogicalSimulatorTask[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: bool = False,
+        seed: int | None = None,
     ) -> Future[Result[RetType]] | Future[DetectorResult]:
         """Run the CliffT sampler asynchronously."""
+
+        _validate_seed(seed)
+        _validate_seed(self.seed)
 
         # TODO: should GeminiLogicalSimulatorTask.run_async preserve NumPy-array
         # results for detector-heavy workflows instead of wrapping list-backed
@@ -189,6 +205,7 @@ class _CliffTSimulatorTask(GeminiLogicalSimulatorTask[RetType]):
                     shots,
                     with_noise,
                     run_detectors=True,
+                    seed=seed,
                 ),
             )
         return cast(
@@ -198,6 +215,7 @@ class _CliffTSimulatorTask(GeminiLogicalSimulatorTask[RetType]):
                 shots,
                 with_noise,
                 run_detectors=False,
+                seed=seed,
             ),
         )
 

--- a/python/bloqade/gemini/device/simulator.py
+++ b/python/bloqade/gemini/device/simulator.py
@@ -29,6 +29,13 @@ if TYPE_CHECKING:
 RetType = TypeVar("RetType")
 
 
+def _validate_seed(seed: int | None) -> None:
+    if seed is not None and (
+        isinstance(seed, bool) or not isinstance(seed, int) or not 0 <= seed < 2**63
+    ):
+        raise ValueError("seed must be a non-bool int in the range [0, 2**63).")
+
+
 def _default_noise_model() -> "LogicalNoiseModelABC":
     from bloqade.lanes.noise_model import generate_logical_noise_model
 
@@ -308,6 +315,7 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: Literal[False] = ...,
+        seed: int | None = None,
     ) -> Result[RetType]: ...
 
     @overload
@@ -317,6 +325,7 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: Literal[True],
+        seed: int | None = None,
     ) -> DetectorResult: ...
 
     @overload
@@ -326,6 +335,7 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: bool,
+        seed: int | None = None,
     ) -> Result[RetType] | DetectorResult: ...
 
     def run(
@@ -334,6 +344,7 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: bool = False,
+        seed: int | None = None,
     ) -> Result[RetType] | DetectorResult:
         """Run the kernel and get simulation results.
 
@@ -343,6 +354,7 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
             run_detectors (bool): When ``True``, use the detector sampler instead of
                 the measurement sampler for faster detector/observable sampling.
                 Defaults to False.
+            seed (int | None): Optional sampler seed. Defaults to None.
 
         Returns:
             Result[RetType]: When ``run_detectors=False``, the full simulation result
@@ -351,17 +363,24 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
                 detector and observable outcomes.
 
         """
-        if run_detectors:
-            return self._run_detectors(shots, with_noise)
+        _validate_seed(seed)
 
-        if self.tsim_circuit.is_clifford:
-            c = self.tsim_circuit if with_noise else self.noiseless_tsim_circuit
-            sampler = c.stim_circuit.compile_sampler()
+        if run_detectors:
+            return self._run_detectors(shots, with_noise, seed=seed)
+
+        c = self.tsim_circuit if with_noise else self.noiseless_tsim_circuit
+        if c.is_clifford:
+            sampler = c.stim_circuit.compile_sampler(seed=seed)
         else:
+            # TODO: for the seeded case, also cache the sampler for repeated sampling for the same seed.
             sampler = (
-                self.measurement_sampler
-                if with_noise
-                else self.noiseless_measurement_sampler
+                (
+                    self.measurement_sampler
+                    if with_noise
+                    else self.noiseless_measurement_sampler
+                )
+                if seed is None
+                else c.compile_sampler(seed=seed)
             )
 
         raw_results = sampler.sample(shots=shots).tolist()
@@ -375,7 +394,13 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
             fidelity_max,
         )
 
-    def _run_detectors(self, shots: int = 1, with_noise: bool = True) -> DetectorResult:
+    def _run_detectors(
+        self,
+        shots: int = 1,
+        with_noise: bool = True,
+        *,
+        seed: int | None = None,
+    ) -> DetectorResult:
         """Run the detector sampler for faster detector/observable sampling.
 
         This skips the full measurement sampler and directly samples detector
@@ -385,23 +410,32 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
         Args:
             shots (int): Number of shots to run. Defaults to 1.
             with_noise (bool): Whether to include noise in the simulation. Defaults to True.
+            seed (int | None): Optional sampler seed. Defaults to None.
 
         Returns:
             DetectorResult: The result containing detector and observable outcomes.
 
         """
+        _validate_seed(seed)
+
         c = self.tsim_circuit if with_noise else self.noiseless_tsim_circuit
         if c.is_clifford:
             # Use Stim for the Clifford case. Since .detector_sampler uses a reference
             # sample which flips outcomes, we use the measurement sampler and convert to
             # detectors and observables while explicitly skipping the reference sample.
-            sampler = c.stim_circuit.compile_sampler()
+            sampler = c.stim_circuit.compile_sampler(seed=seed)
             m2det = c.compile_m2d_converter(skip_reference_sample=True)
             samples = sampler.sample(shots=shots)
             det_obs = m2det.convert(measurements=samples, separate_observables=True)
         else:
             sampler = (
-                self.detector_sampler if with_noise else self.noiseless_detector_sampler
+                (
+                    self.detector_sampler
+                    if with_noise
+                    else self.noiseless_detector_sampler
+                )
+                if seed is None
+                else c.compile_detector_sampler(seed=seed)
             )
             det_obs: tuple[np.ndarray, np.ndarray] = sampler.sample(
                 shots=shots, separate_observables=True
@@ -423,6 +457,7 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: Literal[False] = ...,
+        seed: int | None = None,
     ) -> Future[Result[RetType]]: ...
 
     @overload
@@ -432,6 +467,7 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: Literal[True],
+        seed: int | None = None,
     ) -> Future[DetectorResult]: ...
 
     def run_async(
@@ -440,6 +476,7 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
         with_noise: bool = True,
         *,
         run_detectors: bool = False,
+        seed: int | None = None,
     ) -> Future[Result[RetType]] | Future[DetectorResult]:
         """Run the kernel asynchronously and get simulation results.
 
@@ -448,6 +485,7 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
             with_noise (bool): Whether to include noise in the simulation. Defaults to True.
             run_detectors (bool): When ``True``, use the detector sampler instead of
                 the measurement sampler. Defaults to False.
+            seed (int | None): Optional sampler seed. Defaults to None.
 
         Returns:
             Future[Result[RetType]]: When ``run_detectors=False``, a future resolving
@@ -456,11 +494,13 @@ class GeminiLogicalSimulatorTask(Generic[RetType]):
                 to the detector result.
 
         """
+        _validate_seed(seed)
+
         if run_detectors:
             return self._thread_pool_executor.submit(
-                self._run_detectors, shots, with_noise
+                self._run_detectors, shots, with_noise, seed=seed
             )
-        return self._thread_pool_executor.submit(self.run, shots, with_noise)
+        return self._thread_pool_executor.submit(self.run, shots, with_noise, seed=seed)
 
 
 @dataclass
@@ -477,6 +517,7 @@ class GeminiLogicalSimulator:
     """The noise model used for simulation. Defaults to :func:`generate_logical_noise_model`."""
     backend: str = "tsim"
     """Sampling backend for tasks created by this simulator."""
+    # TODO: get rid of "seed" on the GeminiLogicalSimulator; we do NOT want to support it (was mainly for a shim to support CliffTSimulatorTask before)
     seed: int | None = None
     """Optional backend seed for task sampling."""
 
@@ -504,6 +545,9 @@ class GeminiLogicalSimulator:
             GeminiLogicalSimulatorTask[RetType]: The compiled simulation task.
 
         """
+        if self.backend == "clifft":
+            _validate_seed(self.seed)
+
         from bloqade.lanes.logical_mvp import compile_task
 
         (
@@ -544,6 +588,7 @@ class GeminiLogicalSimulator:
         with_noise: bool = True,
         *,
         run_detectors: Literal[False] = ...,
+        seed: int | None = None,
     ) -> Result[RetType]: ...
 
     @overload
@@ -554,6 +599,7 @@ class GeminiLogicalSimulator:
         with_noise: bool = True,
         *,
         run_detectors: Literal[True],
+        seed: int | None = None,
     ) -> DetectorResult: ...
 
     @overload
@@ -564,6 +610,7 @@ class GeminiLogicalSimulator:
         with_noise: bool = True,
         *,
         run_detectors: bool,
+        seed: int | None = None,
     ) -> Result[RetType] | DetectorResult: ...
 
     def run(
@@ -573,6 +620,7 @@ class GeminiLogicalSimulator:
         with_noise: bool = True,
         *,
         run_detectors: bool = False,
+        seed: int | None = None,
     ) -> Result[RetType] | DetectorResult:
         """Run the kernel and get simulation results.
 
@@ -583,6 +631,7 @@ class GeminiLogicalSimulator:
             run_detectors (bool): When ``True``, use the detector sampler instead of
                 the measurement sampler for faster detector/observable sampling.
                 Defaults to False.
+            seed (int | None): Optional sampler seed. Defaults to None.
 
         Returns:
             Result[RetType]: When ``run_detectors=False``, the full simulation result.
@@ -590,8 +639,9 @@ class GeminiLogicalSimulator:
                 detector and observable outcomes.
 
         """
+        _validate_seed(seed)
         return self.task(logical_squin_kernel).run(
-            shots, with_noise, run_detectors=run_detectors
+            shots, with_noise, run_detectors=run_detectors, seed=seed
         )
 
     @overload
@@ -602,6 +652,7 @@ class GeminiLogicalSimulator:
         with_noise: bool = True,
         *,
         run_detectors: Literal[False] = ...,
+        seed: int | None = None,
     ) -> Future[Result[RetType]]: ...
 
     @overload
@@ -612,6 +663,7 @@ class GeminiLogicalSimulator:
         with_noise: bool = True,
         *,
         run_detectors: Literal[True],
+        seed: int | None = None,
     ) -> Future[DetectorResult]: ...
 
     def run_async(
@@ -621,6 +673,7 @@ class GeminiLogicalSimulator:
         with_noise: bool = True,
         *,
         run_detectors: bool = False,
+        seed: int | None = None,
     ) -> Future[Result[RetType]] | Future[DetectorResult]:
         """Run the kernel asynchronously and get simulation results.
 
@@ -630,6 +683,7 @@ class GeminiLogicalSimulator:
             with_noise (bool): Whether to include noise in the simulation. Defaults to True.
             run_detectors (bool): When ``True``, use the detector sampler instead of
                 the measurement sampler. Defaults to False.
+            seed (int | None): Optional sampler seed. Defaults to None.
 
         Returns:
             Future[Result[RetType]]: When ``run_detectors=False``, a future resolving
@@ -638,10 +692,11 @@ class GeminiLogicalSimulator:
                 to the detector result.
 
         """
+        _validate_seed(seed)
         task = self.task(logical_squin_kernel)
         if run_detectors:
-            return task.run_async(shots, with_noise, run_detectors=True)
-        return task.run_async(shots, with_noise)
+            return task.run_async(shots, with_noise, run_detectors=True, seed=seed)
+        return task.run_async(shots, with_noise, seed=seed)
 
     def visualize(
         self,

--- a/python/tests/gemini/decoding/test_tasks.py
+++ b/python/tests/gemini/decoding/test_tasks.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from types import ModuleType
 from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
 
 from bloqade.gemini.decoding.tasks import _CliffTSimulatorTask
 
@@ -50,7 +54,7 @@ def test_sample_clifft_uses_noisy_program_and_omits_missing_seed(monkeypatch):
     assert calls == [("noisy-program", {"shots": 7})]
 
 
-def test_sample_clifft_uses_noiseless_program_and_seed(monkeypatch):
+def test_sample_clifft_uses_noiseless_program_and_task_seed(monkeypatch):
     calls: list[tuple[object, dict[str, int]]] = []
     fake_clifft = ModuleType("clifft")
 
@@ -72,3 +76,97 @@ def test_sample_clifft_uses_noiseless_program_and_seed(monkeypatch):
 
     assert result.observables == [[False]]
     assert calls == [("noiseless-program", {"shots": 11, "seed": 123})]
+
+
+def test_sample_clifft_per_call_seed_overrides_task_seed(monkeypatch):
+    calls: list[tuple[object, dict[str, int]]] = []
+    fake_clifft = ModuleType("clifft")
+
+    def sample(program: object, **kwargs: int) -> _FakeSampleResult:
+        calls.append((program, kwargs))
+        return _FakeSampleResult([], [], [])
+
+    cast(Any, fake_clifft).sample = sample
+    monkeypatch.setitem(sys.modules, "clifft", fake_clifft)
+
+    _task_with_cached_programs(seed=123)._sample_clifft(
+        2,
+        with_noise=True,
+        seed=0,
+    )
+
+    assert calls == [("noisy-program", {"shots": 2, "seed": 0})]
+
+
+def test_sample_clifft_none_seed_falls_back_to_task_seed(monkeypatch):
+    calls: list[tuple[object, dict[str, int]]] = []
+    fake_clifft = ModuleType("clifft")
+
+    def sample(program: object, **kwargs: int) -> _FakeSampleResult:
+        calls.append((program, kwargs))
+        return _FakeSampleResult([], [], [])
+
+    cast(Any, fake_clifft).sample = sample
+    monkeypatch.setitem(sys.modules, "clifft", fake_clifft)
+
+    _task_with_cached_programs(seed=123)._sample_clifft(
+        2,
+        with_noise=True,
+        seed=None,
+    )
+
+    assert calls == [("noisy-program", {"shots": 2, "seed": 123})]
+
+
+@pytest.mark.parametrize("seed", [True, -1, 2**63, 1.5, "1"])
+def test_sample_clifft_rejects_invalid_per_call_seed_before_sampling(
+    monkeypatch, seed: object
+):
+    calls: list[tuple[object, dict[str, int]]] = []
+    fake_clifft = ModuleType("clifft")
+
+    def sample(program: object, **kwargs: int) -> _FakeSampleResult:
+        calls.append((program, kwargs))
+        return _FakeSampleResult([], [], [])
+
+    cast(Any, fake_clifft).sample = sample
+    monkeypatch.setitem(sys.modules, "clifft", fake_clifft)
+
+    with pytest.raises((TypeError, ValueError), match="seed must be"):
+        _task_with_cached_programs(seed=123)._sample_clifft(
+            2,
+            with_noise=True,
+            seed=cast(int | None, seed),
+        )
+
+    assert calls == []
+
+
+def test_clifft_run_async_forwards_per_call_seed_and_returns_result(monkeypatch):
+    calls: list[tuple[object, dict[str, int]]] = []
+    fake_clifft = ModuleType("clifft")
+
+    def sample(program: object, **kwargs: int) -> _FakeSampleResult:
+        calls.append((program, kwargs))
+        return _FakeSampleResult(
+            detectors=[[False]],
+            observables=[[True]],
+            measurements=[[False]],
+        )
+
+    cast(Any, fake_clifft).sample = sample
+    monkeypatch.setitem(sys.modules, "clifft", fake_clifft)
+
+    task = _task_with_cached_programs(seed=123)
+    object.__setattr__(task, "_thread_pool_executor", ThreadPoolExecutor(max_workers=1))
+    object.__setattr__(task, "fidelity_bounds", lambda: (0.5, 0.9))
+    object.__setattr__(task, "detector_error_model", object())
+    object.__setattr__(task, "_post_processing", MagicMock())
+
+    try:
+        result = task.run_async(shots=2, with_noise=False, seed=0).result()
+    finally:
+        task._thread_pool_executor.shutdown()
+
+    assert result.measurements == [[False]]
+    assert calls == [("noiseless-program", {"shots": 2, "seed": 0})]

--- a/python/tests/test_device.py
+++ b/python/tests/test_device.py
@@ -1,5 +1,6 @@
 import math
-from typing import Any
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -327,7 +328,7 @@ def test_run_clifford_uses_stim_sampler():
 
     result = GeminiLogicalSimulatorTask.run(task, shots=1, with_noise=True)
 
-    task.tsim_circuit.stim_circuit.compile_sampler.assert_called_once_with()
+    task.tsim_circuit.stim_circuit.compile_sampler.assert_called_once_with(seed=None)
     task.measurement_sampler.sample.assert_not_called()
     assert isinstance(result, Result)
     assert result._raw_measurements == samples.tolist()
@@ -341,6 +342,312 @@ def test_run_non_clifford_uses_measurement_sampler():
 
     task.measurement_sampler.sample.assert_called_once_with(shots=1)
     task.tsim_circuit.stim_circuit.compile_sampler.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("with_noise", "circuit_attribute"),
+    [(True, "tsim_circuit"), (False, "noiseless_tsim_circuit")],
+)
+def test_seed_zero_is_forwarded_to_stim_sampler(
+    with_noise: bool, circuit_attribute: str
+):
+    task = _mock_task(is_clifford=True)
+    circuit = getattr(task, circuit_attribute)
+    samples = np.array([[True]])
+    circuit.stim_circuit.compile_sampler.return_value.sample.return_value = samples
+
+    result = GeminiLogicalSimulatorTask.run(
+        task, shots=1, with_noise=with_noise, seed=0
+    )
+
+    circuit.stim_circuit.compile_sampler.assert_called_once_with(seed=0)
+    assert isinstance(result, Result)
+    assert result._raw_measurements == samples.tolist()
+
+
+def test_seeded_stim_sampler_reproduces_fixed_batch():
+    import stim
+
+    task = _mock_task(is_clifford=True)
+    task.tsim_circuit.stim_circuit = stim.Circuit("H 0\nM 0")
+
+    first = GeminiLogicalSimulatorTask.run(task, shots=64, seed=17)
+    second = GeminiLogicalSimulatorTask.run(task, shots=64, seed=17)
+
+    assert first.measurements == second.measurements
+
+
+@pytest.mark.parametrize(
+    ("with_noise", "circuit_attribute"),
+    [(True, "tsim_circuit"), (False, "noiseless_tsim_circuit")],
+)
+@pytest.mark.parametrize(
+    ("run_detectors", "compile_method", "cached_sampler_attribute"),
+    [
+        (False, "compile_sampler", "measurement_sampler"),
+        (True, "compile_detector_sampler", "detector_sampler"),
+    ],
+)
+def test_seeded_non_clifford_run_compiles_fresh_sampler(
+    with_noise: bool,
+    circuit_attribute: str,
+    run_detectors: bool,
+    compile_method: str,
+    cached_sampler_attribute: str,
+):
+    task = _mock_task(is_clifford=False)
+    circuit = getattr(task, circuit_attribute)
+    sampler = getattr(circuit, compile_method).return_value
+    if run_detectors:
+        sampler.sample.return_value = (
+            np.array([[True]]),
+            np.array([[False]]),
+        )
+    else:
+        sampler.sample.return_value = np.array([[True]])
+
+    if run_detectors:
+        GeminiLogicalSimulatorTask._run_detectors(
+            task, shots=1, with_noise=with_noise, seed=17
+        )
+    else:
+        GeminiLogicalSimulatorTask.run(
+            task,
+            shots=1,
+            with_noise=with_noise,
+            run_detectors=False,
+            seed=17,
+        )
+
+    getattr(circuit, compile_method).assert_called_once_with(seed=17)
+    selected_cached_sampler_attribute = (
+        cached_sampler_attribute
+        if with_noise
+        else f"noiseless_{cached_sampler_attribute}"
+    )
+    getattr(task, selected_cached_sampler_attribute).sample.assert_not_called()
+
+
+def test_seeded_non_clifford_run_does_not_leak_into_unseeded_cache():
+    task = _mock_task(is_clifford=False)
+    seeded_sampler = task.tsim_circuit.compile_sampler.return_value
+    seeded_sampler.sample.return_value = np.array([[True]])
+    task.measurement_sampler.sample.return_value = np.array([[False]])
+
+    GeminiLogicalSimulatorTask.run(task, shots=1, seed=17)
+    result = GeminiLogicalSimulatorTask.run(task, shots=1, seed=None)
+
+    task.tsim_circuit.compile_sampler.assert_called_once_with(seed=17)
+    seeded_sampler.sample.assert_called_once_with(shots=1)
+    task.measurement_sampler.sample.assert_called_once_with(shots=1)
+    assert result.measurements == [[False]]
+
+
+@pytest.mark.parametrize(
+    ("with_noise", "cached_sampler_attribute"),
+    [(True, "measurement_sampler"), (False, "noiseless_measurement_sampler")],
+)
+@pytest.mark.parametrize("run_detectors", [False, True])
+def test_unseeded_non_clifford_run_uses_cached_sampler(
+    with_noise: bool, cached_sampler_attribute: str, run_detectors: bool
+):
+    task = _mock_task(is_clifford=False)
+    sampler_attribute = (
+        cached_sampler_attribute
+        if not run_detectors
+        else cached_sampler_attribute.replace("measurement", "detector")
+    )
+    sampler = getattr(task, sampler_attribute)
+    if run_detectors:
+        sampler.sample.return_value = (
+            np.array([[True]]),
+            np.array([[False]]),
+        )
+    else:
+        sampler.sample.return_value = np.array([[True]])
+
+    if run_detectors:
+        GeminiLogicalSimulatorTask._run_detectors(task, shots=1, with_noise=with_noise)
+    else:
+        GeminiLogicalSimulatorTask.run(
+            task, shots=1, with_noise=with_noise, run_detectors=False
+        )
+
+    sampler.sample.assert_called_once()
+    task.tsim_circuit.compile_sampler.assert_not_called()
+    task.noiseless_tsim_circuit.compile_sampler.assert_not_called()
+    task.tsim_circuit.compile_detector_sampler.assert_not_called()
+    task.noiseless_tsim_circuit.compile_detector_sampler.assert_not_called()
+
+
+@pytest.mark.parametrize("seed", [0, 2**63 - 1])
+def test_task_run_accepts_valid_seed_values(seed: int):
+    task = _mock_task(is_clifford=True)
+    task.tsim_circuit.stim_circuit.compile_sampler.return_value.sample.return_value = (
+        np.array([[True]])
+    )
+
+    GeminiLogicalSimulatorTask.run(task, shots=1, seed=seed)
+
+    task.tsim_circuit.stim_circuit.compile_sampler.assert_called_once_with(seed=seed)
+
+
+@pytest.mark.parametrize("seed", [True, -1, 2**63, 1.5, "1"])
+def test_task_run_rejects_invalid_seed_before_sampling(seed: object):
+    task = _mock_task(is_clifford=True)
+
+    with pytest.raises((TypeError, ValueError), match="seed must be"):
+        GeminiLogicalSimulatorTask.run(task, shots=1, seed=cast(int | None, seed))
+
+    task.tsim_circuit.stim_circuit.compile_sampler.assert_not_called()
+
+
+def test_task_run_async_forwards_seed_and_returns_result():
+    task = _mock_task(is_clifford=True)
+    executor = ThreadPoolExecutor(max_workers=1)
+    task._thread_pool_executor = executor
+    expected_result = object()
+    task.run.return_value = expected_result
+
+    try:
+        result = GeminiLogicalSimulatorTask.run_async(
+            task, shots=3, with_noise=False, seed=0
+        ).result()
+    finally:
+        executor.shutdown()
+
+    assert result is expected_result
+    task.run.assert_called_once_with(3, False, seed=0)
+
+
+def test_task_run_async_forwards_seed_to_detector_path():
+    task = _mock_task(is_clifford=False)
+    executor = ThreadPoolExecutor(max_workers=1)
+    task._thread_pool_executor = executor
+    expected_result = object()
+    task._run_detectors.return_value = expected_result
+
+    try:
+        result = GeminiLogicalSimulatorTask.run_async(
+            task, shots=3, with_noise=False, run_detectors=True, seed=0
+        ).result()
+    finally:
+        executor.shutdown()
+
+    assert result is expected_result
+    task._run_detectors.assert_called_once_with(3, False, seed=0)
+
+
+def test_task_run_forwards_seed_to_detector_path():
+    task = _mock_task(is_clifford=False)
+    expected_result = object()
+    task._run_detectors.return_value = expected_result
+
+    result = GeminiLogicalSimulatorTask.run(
+        task, shots=3, with_noise=False, run_detectors=True, seed=0
+    )
+
+    assert result is expected_result
+    task._run_detectors.assert_called_once_with(3, False, seed=0)
+
+
+@pytest.mark.parametrize(
+    ("with_noise", "circuit_attribute"),
+    [(True, "tsim_circuit"), (False, "noiseless_tsim_circuit")],
+)
+def test_seeded_clifford_detector_sampling_uses_stim_seed_and_m2d(
+    with_noise: bool, circuit_attribute: str
+):
+    task = _mock_task(is_clifford=True)
+    samples = np.array([[True, False]])
+    detectors, observables = np.array([[True]]), np.array([[False]])
+    circuit = getattr(task, circuit_attribute)
+    sampler = circuit.stim_circuit.compile_sampler.return_value
+    sampler.sample.return_value = samples
+    m2d = circuit.compile_m2d_converter.return_value
+    m2d.convert.return_value = (detectors, observables)
+
+    result = GeminiLogicalSimulatorTask._run_detectors(
+        task, shots=1, with_noise=with_noise, seed=17
+    )
+
+    circuit.stim_circuit.compile_sampler.assert_called_once_with(seed=17)
+    sampler.sample.assert_called_once_with(shots=1)
+    circuit.compile_m2d_converter.assert_called_once_with(skip_reference_sample=True)
+    m2d.convert.assert_called_once_with(measurements=samples, separate_observables=True)
+    assert isinstance(result, DetectorResult)
+
+
+def test_task_run_accepts_explicit_none_seed():
+    task = _mock_task(is_clifford=True)
+    task.tsim_circuit.stim_circuit.compile_sampler.return_value.sample.return_value = (
+        np.array([[True]])
+    )
+
+    GeminiLogicalSimulatorTask.run(task, shots=1, seed=None)
+
+    task.tsim_circuit.stim_circuit.compile_sampler.assert_called_once_with(seed=None)
+
+
+@pytest.mark.parametrize("seed", [0, None])
+@pytest.mark.parametrize("run_detectors", [False, True])
+def test_simulator_run_forwards_seed_to_task(
+    monkeypatch, seed: int | None, run_detectors: bool
+):
+    sim = GeminiLogicalSimulator()
+    task = MagicMock()
+    expected_result = object()
+    task.run.return_value = expected_result
+    monkeypatch.setattr(sim, "task", MagicMock(return_value=task))
+
+    result = sim.run(
+        main,
+        shots=3,
+        with_noise=False,
+        run_detectors=run_detectors,
+        seed=seed,
+    )
+
+    assert result is expected_result
+    task.run.assert_called_once_with(3, False, run_detectors=run_detectors, seed=seed)
+
+
+@pytest.mark.parametrize("run_detectors", [False, True])
+def test_simulator_run_async_forwards_seed_and_returns_result(
+    monkeypatch, run_detectors: bool
+):
+    sim = GeminiLogicalSimulator()
+    task = MagicMock()
+    expected_result = object()
+    future = Future()
+    future.set_result(expected_result)
+    task.run_async.return_value = future
+    monkeypatch.setattr(sim, "task", MagicMock(return_value=task))
+
+    result = sim.run_async(
+        main,
+        shots=3,
+        with_noise=False,
+        run_detectors=run_detectors,
+        seed=0,
+    ).result()
+
+    assert result is expected_result
+    if run_detectors:
+        task.run_async.assert_called_once_with(3, False, run_detectors=True, seed=0)
+    else:
+        task.run_async.assert_called_once_with(3, False, seed=0)
+
+
+def test_simulator_clifft_task_seed_rejected_before_compilation(monkeypatch):
+    sim = GeminiLogicalSimulator(backend="clifft", seed=-1)
+    compile_task = MagicMock()
+    monkeypatch.setattr("bloqade.lanes.logical_mvp.compile_task", compile_task)
+
+    with pytest.raises(ValueError, match="seed must be"):
+        sim.run(main, seed=None)
+
+    compile_task.assert_not_called()
 
 
 def test_run_detectors_clifford_converts_via_m2d():


### PR DESCRIPTION
closes https://github.com/QuEraComputing/bloqade-lanes/issues/811
- ^ Adds "seed" option to "task.run(seed=...)".

## Summary

Adds an optional keyword-only `seed` argument to the Gemini logical simulator
sampling APIs:

```python
task.run(shots=100, seed=123)
task.run_async(shots=100, seed=123)
simulator.run(kernel, shots=100, seed=123)
simulator.run_async(kernel, shots=100, seed=123)
```

- Propagates the seed through measurement and detector sampling, including
  asynchronous calls.
- Supports the Stim/tsim paths and the CliffT backend.
- Uses a per-call CliffT seed in preference to the task-level simulator seed;
  `seed=None` retains the task-level CliffT default.
- Validates seeds consistently: they must be non-boolean integers in
  `[0, 2**63)`.
- Preserves existing cached measurement/detector samplers for unseeded,
  non-Clifford tsim calls. Seeded non-Clifford calls compile a fresh sampler.

## Tests

- Added coverage for seeded and unseeded measurement/detector sampling across
  noisy and noiseless circuits.
- Added checks for async forwarding, Seed `0`, invalid values, CliffT seed
  precedence, reproducible seeded Stim batches, and no leakage from a seeded
  call into the unseeded cached path.

## Verification

```text
uv run pytest python/tests/test_device.py -k seed -q
# 32 passed

uv run pytest python/tests/gemini/decoding/test_tasks.py -q
# 10 passed

uv run pyright python/tests/gemini/decoding/test_tasks.py python/tests/test_device.py
# 0 errors
```
