### PR TITLE
fix: updated steane7_noisy_initialize to use unpaired scaled noise channels

### DIFF
--- a/python/bloqade/lanes/noise_model.py
+++ b/python/bloqade/lanes/noise_model.py
@@ -205,6 +205,9 @@ def generate_logical_noise_model(
     cz_paired_error_probabilities = ilist.IList(
         [cz_paired_error_dict.get(k, 0.0) for k in PAIRED_KEYS]
     )
+    cz_unpaired_gate_px, cz_unpaired_gate_py, cz_unpaired_gate_pz = (
+        noise_model.cz_unpaired_pauli_rates
+    )
 
     clean_init, noisy_init = steane7_initialize_with_noise(
         local_px=local_px,
@@ -218,9 +221,9 @@ def generate_logical_noise_model(
         sitter_px=sitter_px,
         sitter_py=sitter_py,
         sitter_pz=sitter_pz,
-        cz_unpaired_gate_px=noise_model.cz_unpaired_gate_px,
-        cz_unpaired_gate_py=noise_model.cz_unpaired_gate_py,
-        cz_unpaired_gate_pz=noise_model.cz_unpaired_gate_pz,
+        cz_unpaired_gate_px=cz_unpaired_gate_px,
+        cz_unpaired_gate_py=cz_unpaired_gate_py,
+        cz_unpaired_gate_pz=cz_unpaired_gate_pz,
         sit_loss_prob=noise_model.sit_loss_prob,
         cz_errors=cz_paired_error_probabilities,
         cz_paired_loss=noise_model.cz_gate_loss_prob,

--- a/python/tests/test_noise_scaling.py
+++ b/python/tests/test_noise_scaling.py
@@ -172,3 +172,27 @@ def test_logical_init_kernels_honor_scaling_factor():
         assert _has(
             consts, expected
         ), f"logical init: expected scaled {getter}[0]={expected}, got {sorted(consts)}"
+
+
+def test_logical_init_cz_unpaired_rates_honor_scaling_factor():
+    """The Steane initializer must use the scaled unpaired-CZ getter."""
+    raw_rates = (0.011, 0.013, 0.017)
+    model = GeminiOneZoneNoiseModel(
+        scaling_factor=2.0,
+        cz_unpaired_gate_px=raw_rates[0],
+        cz_unpaired_gate_py=raw_rates[1],
+        cz_unpaired_gate_pz=raw_rates[2],
+    )
+
+    nm = generate_logical_noise_model(model)
+    _, noisy = nm.get_logical_initialize()
+    assert noisy is not None
+    consts = _float_constants(noisy)
+
+    for raw, expected in zip(raw_rates, model.cz_unpaired_pauli_rates):
+        assert _has(
+            consts, expected
+        ), f"logical init: expected scaled unpaired-CZ rate {expected}"
+        assert not _has(
+            consts, raw
+        ), f"logical init: unexpectedly baked raw unpaired-CZ rate {raw}"


### PR DESCRIPTION
Small fix to https://github.com/QuEraComputing/bloqade-lanes/pull/814 to add cz_unpaired_pauli_rates (for scaled getters for noise model) to the steane7_noisy_initialize() kernel