### PR TITLE
refactor(search): replace u8-discriminant triplet round-trip with a typed newtype

### DIFF
--- a/crates/bloqade-lanes-bytecode-core/src/arch/addr.rs
+++ b/crates/bloqade-lanes-bytecode-core/src/arch/addr.rs
@@ -22,8 +22,11 @@ pub struct ZonedWordRef {
 
 /// Atom movement direction along a transport bus.
 ///
-/// The `Ord` derive orders variants by their `#[repr(u8)]` discriminant
-/// (`Forward < Backward`), which downstream deterministic sort keys rely on.
+/// Variants are declared in ascending discriminant order
+/// (`Forward = 0 < Backward = 1`), so the derived `Ord` yields the same
+/// order as a comparison of the `#[repr(u8)]` values. Downstream
+/// deterministic sort keys rely on this — keep the declaration order aligned
+/// with the discriminants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 pub enum Direction {
@@ -35,9 +38,11 @@ pub enum Direction {
 
 /// Type of transport bus used for an atom move operation.
 ///
-/// The `Ord` derive orders variants by their `#[repr(u8)]` discriminant
-/// (`SiteBus < WordBus < ZoneBus`), which downstream deterministic sort keys
-/// rely on.
+/// Variants are declared in ascending discriminant order
+/// (`SiteBus = 0 < WordBus = 1 < ZoneBus = 2`), so the derived `Ord` yields
+/// the same order as a comparison of the `#[repr(u8)]` values. Downstream
+/// deterministic sort keys rely on this — keep the declaration order aligned
+/// with the discriminants.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 pub enum MoveType {

--- a/crates/bloqade-lanes-bytecode-core/src/arch/addr.rs
+++ b/crates/bloqade-lanes-bytecode-core/src/arch/addr.rs
@@ -21,7 +21,10 @@ pub struct ZonedWordRef {
 }
 
 /// Atom movement direction along a transport bus.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// The `Ord` derive orders variants by their `#[repr(u8)]` discriminant
+/// (`Forward < Backward`), which downstream deterministic sort keys rely on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 pub enum Direction {
     /// Movement from source to destination (value 0).
@@ -31,7 +34,11 @@ pub enum Direction {
 }
 
 /// Type of transport bus used for an atom move operation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// The `Ord` derive orders variants by their `#[repr(u8)]` discriminant
+/// (`SiteBus < WordBus < ZoneBus`), which downstream deterministic sort keys
+/// rely on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 pub enum MoveType {
     /// Moves atoms between sites within a word (value 0).

--- a/crates/bloqade-lanes-search/src/drivers/entropy.rs
+++ b/crates/bloqade-lanes-search/src/drivers/entropy.rs
@@ -29,7 +29,7 @@ use crate::primitives::ordering::{
 };
 use crate::primitives::path::find_path_occupied;
 use crate::traits::Goal;
-use bloqade_lanes_bytecode_core::arch::addr::{Direction, LaneAddr, LocationAddr, MoveType};
+use bloqade_lanes_bytecode_core::arch::addr::{LaneAddr, LocationAddr};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
@@ -371,21 +371,6 @@ fn cmp_group_entries(a: &ScoredEntry, b: &ScoredEntry) -> Ordering {
     })
 }
 
-fn decode_triplet_key(mt_u8: u8, dir_u8: u8) -> (MoveType, Direction) {
-    let mt = match mt_u8 {
-        x if x == MoveType::SiteBus as u8 => MoveType::SiteBus,
-        x if x == MoveType::WordBus as u8 => MoveType::WordBus,
-        x if x == MoveType::ZoneBus as u8 => MoveType::ZoneBus,
-        _ => unreachable!("invalid MoveType discriminant: {mt_u8}"),
-    };
-    let dir = match dir_u8 {
-        x if x == Direction::Forward as u8 => Direction::Forward,
-        x if x == Direction::Backward as u8 => Direction::Backward,
-        _ => unreachable!("invalid Direction discriminant: {dir_u8}"),
-    };
-    (mt, dir)
-}
-
 fn build_deadlock_breaker_candidate(
     config: &Config,
     occupied: &HashSet<u64>,
@@ -411,9 +396,16 @@ fn build_deadlock_breaker_candidate(
     }
 
     let mut best: Option<(usize, f64, MoveSet, Config)> = None;
-    for ((mt_u8, bus_id, dir_u8), mut qubits) in groups {
+    for (
+        TripletKey {
+            move_type: mt,
+            bus_id,
+            direction: dir,
+        },
+        mut qubits,
+    ) in groups
+    {
         qubits.sort_by(cmp_group_entries);
-        let (mt, dir) = decode_triplet_key(mt_u8, dir_u8);
         let grid_ctx = BusGridContext::new(ctx.index, mt, bus_id, None, dir, occupied);
 
         let mut entries: HashMap<u64, u64> = HashMap::new();
@@ -879,7 +871,7 @@ pub(crate) fn generate_candidates(
             let delta_d = d_now - effective_d_after;
             let delta_m = m_after - m_now;
 
-            let triplet_key = (lane.move_type as u8, lane.bus_id, lane.direction as u8);
+            let triplet_key = TripletKey::new(lane.move_type, lane.bus_id, lane.direction);
             raw_deltas.push((
                 triplet_key,
                 qid,
@@ -955,9 +947,16 @@ pub(crate) fn generate_candidates(
     // Step 5: per group, build AOD-compatible rectangular grids.
     let mut candidates: Vec<(f64, MoveSet, Config)> = Vec::new();
 
-    for ((mt_u8, bus_id, dir_u8), mut qubits) in groups {
+    for (
+        TripletKey {
+            move_type: mt,
+            bus_id,
+            direction: dir,
+        },
+        mut qubits,
+    ) in groups
+    {
         qubits.sort_by(cmp_group_entries);
-        let (mt, dir) = decode_triplet_key(mt_u8, dir_u8);
 
         let grid_ctx = BusGridContext::new(ctx.index, mt, bus_id, None, dir, &occupied);
 
@@ -1810,6 +1809,7 @@ fn get_next_candidate(
 mod tests {
     use super::*;
     use crate::test_utils::{example_arch_json, loc};
+    use bloqade_lanes_bytecode_core::arch::addr::{Direction, MoveType};
     use bloqade_lanes_bytecode_core::arch::types::TransportPath;
 
     fn make_index() -> LaneIndex {
@@ -2194,9 +2194,11 @@ mod tests {
 
     #[test]
     fn scored_entry_tie_break_is_deterministic() {
+        let key_bus1 = TripletKey::new(MoveType::WordBus, 1, Direction::Backward);
+        let key_bus2 = TripletKey::new(MoveType::WordBus, 2, Direction::Backward);
         let mut entries = [
             (
-                (1, 2, 1),
+                key_bus2,
                 ScoredEntry {
                     qubit_id: 8,
                     score: 3.0,
@@ -2205,7 +2207,7 @@ mod tests {
                 },
             ),
             (
-                (1, 1, 1),
+                key_bus1,
                 ScoredEntry {
                     qubit_id: 4,
                     score: 3.0,
@@ -2214,7 +2216,7 @@ mod tests {
                 },
             ),
             (
-                (1, 1, 1),
+                key_bus1,
                 ScoredEntry {
                     qubit_id: 4,
                     score: 3.0,
@@ -2226,11 +2228,11 @@ mod tests {
 
         entries.sort_by(cmp_scored_entries);
 
-        assert_eq!(entries[0].0, (1, 1, 1));
+        assert_eq!(entries[0].0, key_bus1);
         assert_eq!(entries[0].1.lane_encoded, 10);
-        assert_eq!(entries[1].0, (1, 1, 1));
+        assert_eq!(entries[1].0, key_bus1);
         assert_eq!(entries[1].1.lane_encoded, 12);
-        assert_eq!(entries[2].0, (1, 2, 1));
+        assert_eq!(entries[2].0, key_bus2);
     }
 
     #[test]

--- a/crates/bloqade-lanes-search/src/dsl/pipeline.rs
+++ b/crates/bloqade-lanes-search/src/dsl/pipeline.rs
@@ -23,13 +23,13 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use bloqade_lanes_bytecode_core::arch::addr::{Direction, LaneAddr, LocationAddr, MoveType};
+use bloqade_lanes_bytecode_core::arch::addr::{LaneAddr, LocationAddr};
 
 use crate::ops::aod_grid::BusGridContext;
 use crate::primitives::config::Config;
 use crate::primitives::graph::MoveSet;
 use crate::primitives::lane_index::LaneIndex;
-use crate::primitives::ordering::cmp_moveset_config_tiebreak;
+use crate::primitives::ordering::{TripletKey, cmp_moveset_config_tiebreak};
 
 /// One scored `(qubit, lane)` pair produced by Stage 1 of the pipeline.
 #[derive(Debug, Clone)]
@@ -38,9 +38,6 @@ pub(crate) struct ScoredLane {
     pub lane: LaneAddr,
     pub score: f64,
 }
-
-/// Triplet key `(move_type, bus_id, direction)` as encoded `u8`/`u32`.
-pub(crate) type TripletKey = (u8, u32, u8);
 
 /// Group of [`ScoredLane`]s sharing the same triplet key.
 #[derive(Debug, Clone)]
@@ -63,10 +60,10 @@ pub(crate) struct PackedCandidate {
 pub(crate) fn group_by_triplet(scored: Vec<ScoredLane>) -> Vec<TripletGroup> {
     let mut groups: BTreeMap<TripletKey, Vec<ScoredLane>> = BTreeMap::new();
     for entry in scored {
-        let key = (
-            entry.lane.move_type as u8,
+        let key = TripletKey::new(
+            entry.lane.move_type,
             entry.lane.bus_id,
-            entry.lane.direction as u8,
+            entry.lane.direction,
         );
         groups.entry(key).or_default().push(entry);
     }
@@ -100,13 +97,11 @@ pub(crate) fn pack_aod_rectangles(
         if entries.is_empty() {
             continue;
         }
-        let (mt_u8, bus_id, dir_u8) = key;
-        let Some(mt) = decode_move_type(mt_u8) else {
-            continue;
-        };
-        let Some(dir) = decode_direction(dir_u8) else {
-            continue;
-        };
+        let TripletKey {
+            move_type: mt,
+            bus_id,
+            direction: dir,
+        } = key;
 
         // Build the grid context across all zones for the bus.
         let grid_ctx = BusGridContext::new(index, mt, bus_id, None, dir, &occupied);
@@ -171,28 +166,6 @@ pub(crate) fn pack_aod_rectangles(
     });
 
     candidates
-}
-
-fn decode_move_type(v: u8) -> Option<MoveType> {
-    if v == MoveType::SiteBus as u8 {
-        Some(MoveType::SiteBus)
-    } else if v == MoveType::WordBus as u8 {
-        Some(MoveType::WordBus)
-    } else if v == MoveType::ZoneBus as u8 {
-        Some(MoveType::ZoneBus)
-    } else {
-        None
-    }
-}
-
-fn decode_direction(v: u8) -> Option<Direction> {
-    if v == Direction::Forward as u8 {
-        Some(Direction::Forward)
-    } else if v == Direction::Backward as u8 {
-        Some(Direction::Backward)
-    } else {
-        None
-    }
 }
 
 #[cfg(test)]

--- a/crates/bloqade-lanes-search/src/generators/cz_coordination.rs
+++ b/crates/bloqade-lanes-search/src/generators/cz_coordination.rs
@@ -111,7 +111,18 @@ impl CzCoordination for EntanglingCoordination<'_> {
 
 #[cfg(test)]
 mod tests {
+    use bloqade_lanes_bytecode_core::arch::addr::{Direction, MoveType};
+
     use super::*;
+
+    // Two distinct bus triplets for boost tests; the specific variants are
+    // irrelevant — only triplet equality/inequality matters.
+    fn key_a() -> TripletKey {
+        TripletKey::new(MoveType::WordBus, 1, Direction::Backward)
+    }
+    fn key_b() -> TripletKey {
+        TripletKey::new(MoveType::ZoneBus, 2, Direction::Backward)
+    }
 
     fn triple(qubit_id: u32, score: i32) -> ScoredTriple {
         ScoredTriple {
@@ -155,12 +166,9 @@ mod tests {
 
     #[test]
     fn fixed_target_boost_is_noop() {
-        // key (1,1,1) shared by qubits 0 and 1 — would be boosted in entangling
+        // key_a shared by qubits 0 and 1 — would be boosted in entangling
         // mode, must be untouched in fixed mode.
-        let mut selected = vec![
-            ((1u8, 1u32, 1u8), triple(0, 5)),
-            ((1u8, 1u32, 1u8), triple(1, 5)),
-        ];
+        let mut selected = vec![(key_a(), triple(0, 5)), (key_a(), triple(1, 5))];
         let before = selected.iter().map(|e| e.1.score).collect::<Vec<_>>();
         FixedTargetCoordination.boost_coordinated_pairs(&mut selected);
         let after = selected.iter().map(|e| e.1.score).collect::<Vec<_>>();
@@ -170,14 +178,14 @@ mod tests {
     #[test]
     fn entangling_boosts_shared_triplet_for_both_pair_members() {
         // qubits 0 and 1 form a CZ pair and both have an entry on triplet
-        // key (1,1,1): both get +1. The (2,2,2) entry for qubit 0 is not
+        // key_a: both get +1. The key_b entry for qubit 0 is not
         // shared and must NOT be boosted.
         let pairs = [(0u32, 1u32)];
         let policy = EntanglingCoordination { pairs: &pairs };
         let mut selected = vec![
-            ((1u8, 1u32, 1u8), triple(0, 5)),
-            ((1u8, 1u32, 1u8), triple(1, 7)),
-            ((2u8, 2u32, 2u8), triple(0, 3)),
+            (key_a(), triple(0, 5)),
+            (key_a(), triple(1, 7)),
+            (key_b(), triple(0, 3)),
         ];
         policy.boost_coordinated_pairs(&mut selected);
         assert_eq!(selected[0].1.score, 6, "shared entry for q0 boosted");
@@ -190,10 +198,7 @@ mod tests {
         // qubits 0 and 1 are paired but sit on different triplets: no boost.
         let pairs = [(0u32, 1u32)];
         let policy = EntanglingCoordination { pairs: &pairs };
-        let mut selected = vec![
-            ((1u8, 1u32, 1u8), triple(0, 5)),
-            ((2u8, 2u32, 2u8), triple(1, 7)),
-        ];
+        let mut selected = vec![(key_a(), triple(0, 5)), (key_b(), triple(1, 7))];
         policy.boost_coordinated_pairs(&mut selected);
         assert_eq!(selected[0].1.score, 5);
         assert_eq!(selected[1].1.score, 7);
@@ -205,10 +210,7 @@ mod tests {
         // (1) is absent, so nothing is boosted.
         let pairs = [(0u32, 1u32)];
         let policy = EntanglingCoordination { pairs: &pairs };
-        let mut selected = vec![
-            ((1u8, 1u32, 1u8), triple(0, 5)),
-            ((1u8, 1u32, 1u8), triple(2, 7)),
-        ];
+        let mut selected = vec![(key_a(), triple(0, 5)), (key_a(), triple(2, 7))];
         policy.boost_coordinated_pairs(&mut selected);
         assert_eq!(selected[0].1.score, 5);
         assert_eq!(selected[1].1.score, 7);

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -11,7 +11,7 @@ use std::cell::Cell;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use bloqade_lanes_bytecode_core::arch::addr::{Direction, LaneAddr, LocationAddr, MoveType};
+use bloqade_lanes_bytecode_core::arch::addr::{LaneAddr, LocationAddr};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
 
@@ -411,7 +411,7 @@ impl MoveGenerator for HeuristicGenerator {
                     );
                 }
 
-                let triplet_key = (lane.move_type as u8, lane.bus_id, lane.direction as u8);
+                let triplet_key = TripletKey::new(lane.move_type, lane.bus_id, lane.direction);
                 all_scores.push((
                     triplet_key,
                     ScoredTriple {
@@ -432,7 +432,7 @@ impl MoveGenerator for HeuristicGenerator {
         for &(qid, loc_enc) in &accidental_cz_qubits {
             let loc = LocationAddr::decode(loc_enc);
             for (lane, dst) in escape_targets(loc, &occupied, ctx.index) {
-                let triplet_key = (lane.move_type as u8, lane.bus_id, lane.direction as u8);
+                let triplet_key = TripletKey::new(lane.move_type, lane.bus_id, lane.direction);
                 spectator_escapes.push((
                     triplet_key,
                     ScoredTriple {
@@ -503,7 +503,7 @@ impl MoveGenerator for HeuristicGenerator {
                 let (qid, loc_enc) = accidental_cz_qubits[0];
                 let loc = LocationAddr::decode(loc_enc);
                 if let Some((lane, dst)) = escape_targets(loc, &occupied, ctx.index).next() {
-                    let triplet_key = (lane.move_type as u8, lane.bus_id, lane.direction as u8);
+                    let triplet_key = TripletKey::new(lane.move_type, lane.bus_id, lane.direction);
                     selected.push((
                         triplet_key,
                         ScoredTriple {
@@ -536,20 +536,15 @@ impl MoveGenerator for HeuristicGenerator {
         // `candidates` is irrelevant — Step 6 re-sorts by score.
         let mut seen_movesets: HashSet<MoveSet> = HashSet::new();
 
-        for ((mt_u8, bus_id, dir_u8), qubits) in groups {
-            // Reconstruct typed triplet from u8 discriminants.
-            let mt = match mt_u8 {
-                x if x == MoveType::SiteBus as u8 => MoveType::SiteBus,
-                x if x == MoveType::WordBus as u8 => MoveType::WordBus,
-                x if x == MoveType::ZoneBus as u8 => MoveType::ZoneBus,
-                _ => unreachable!("invalid MoveType discriminant: {mt_u8}"),
-            };
-            let dir = match dir_u8 {
-                x if x == Direction::Forward as u8 => Direction::Forward,
-                x if x == Direction::Backward as u8 => Direction::Backward,
-                _ => unreachable!("invalid Direction discriminant: {dir_u8}"),
-            };
-
+        for (
+            TripletKey {
+                move_type: mt,
+                bus_id,
+                direction: dir,
+            },
+            qubits,
+        ) in groups
+        {
             // Build grid context from ALL lanes on this bus group (cross-zone).
             let grid_ctx = crate::ops::aod_grid::BusGridContext::new(
                 ctx.index, mt, bus_id, None, dir, &occupied,
@@ -646,6 +641,7 @@ impl MoveGenerator for HeuristicGenerator {
 mod tests {
     use std::collections::HashSet;
 
+    use bloqade_lanes_bytecode_core::arch::addr::{Direction, MoveType};
     use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
 
     use super::*;
@@ -1477,9 +1473,11 @@ mod tests {
 
     #[test]
     fn scored_triple_tie_break_is_deterministic() {
+        let key_bus1 = TripletKey::new(MoveType::WordBus, 1, Direction::Backward);
+        let key_bus2 = TripletKey::new(MoveType::WordBus, 2, Direction::Backward);
         let mut entries = [
             (
-                (1, 2, 3),
+                key_bus2,
                 ScoredTriple {
                     qubit_id: 9,
                     score: 7,
@@ -1488,7 +1486,7 @@ mod tests {
                 },
             ),
             (
-                (1, 1, 3),
+                key_bus1,
                 ScoredTriple {
                     qubit_id: 2,
                     score: 7,
@@ -1497,7 +1495,7 @@ mod tests {
                 },
             ),
             (
-                (1, 1, 3),
+                key_bus1,
                 ScoredTriple {
                     qubit_id: 1,
                     score: 7,
@@ -1509,11 +1507,11 @@ mod tests {
 
         entries.sort_by(cmp_scored_triples);
 
-        assert_eq!(entries[0].0, (1, 1, 3));
+        assert_eq!(entries[0].0, key_bus1);
         assert_eq!(entries[0].1.lane_encoded, 13);
-        assert_eq!(entries[1].0, (1, 1, 3));
+        assert_eq!(entries[1].0, key_bus1);
         assert_eq!(entries[1].1.lane_encoded, 15);
-        assert_eq!(entries[2].0, (1, 2, 3));
+        assert_eq!(entries[2].0, key_bus2);
     }
 
     #[test]

--- a/crates/bloqade-lanes-search/src/primitives/ordering.rs
+++ b/crates/bloqade-lanes-search/src/primitives/ordering.rs
@@ -8,12 +8,12 @@ use crate::primitives::graph::MoveSet;
 /// Deterministic sort/group key for a bus triplet: `(move_type, bus_id,
 /// direction)`.
 ///
-/// Derived `Ord` compares fields in declaration order, exactly as the former
-/// `(u8, u32, u8)` tuple did: `MoveType` and `Direction` order by their
-/// `#[repr(u8)]` discriminant, and those discriminants match the prior
-/// `as u8` casts — so `BTreeMap`/`sort` iteration order is preserved. Keeping
-/// the enums typed removes the encode-as-`u8` / decode-by-`match` round-trip
-/// at the use sites.
+/// Derived `Ord` compares the fields in declaration order, exactly as the
+/// former `(u8, u32, u8)` tuple did. `MoveType`/`Direction` declare their
+/// variants in ascending discriminant order, so their derived `Ord` matches
+/// the numeric `#[repr(u8)]` values — i.e. the prior `as u8` casts — and
+/// `BTreeMap`/`sort` iteration order is preserved. Keeping the enums typed
+/// removes the encode-as-`u8` / decode-by-`match` round-trip at the use sites.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct TripletKey {
     pub(crate) move_type: MoveType,

--- a/crates/bloqade-lanes-search/src/primitives/ordering.rs
+++ b/crates/bloqade-lanes-search/src/primitives/ordering.rs
@@ -1,9 +1,35 @@
 use std::cmp::Ordering;
 
+use bloqade_lanes_bytecode_core::arch::addr::{Direction, MoveType};
+
 use crate::primitives::config::Config;
 use crate::primitives::graph::MoveSet;
 
-pub(crate) type TripletKey = (u8, u32, u8);
+/// Deterministic sort/group key for a bus triplet: `(move_type, bus_id,
+/// direction)`.
+///
+/// Derived `Ord` compares fields in declaration order, exactly as the former
+/// `(u8, u32, u8)` tuple did: `MoveType` and `Direction` order by their
+/// `#[repr(u8)]` discriminant, and those discriminants match the prior
+/// `as u8` casts — so `BTreeMap`/`sort` iteration order is preserved. Keeping
+/// the enums typed removes the encode-as-`u8` / decode-by-`match` round-trip
+/// at the use sites.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct TripletKey {
+    pub(crate) move_type: MoveType,
+    pub(crate) bus_id: u32,
+    pub(crate) direction: Direction,
+}
+
+impl TripletKey {
+    pub(crate) fn new(move_type: MoveType, bus_id: u32, direction: Direction) -> Self {
+        Self {
+            move_type,
+            bus_id,
+            direction,
+        }
+    }
+}
 
 /// Shared deterministic tie-breaker for triplet-scored entries.
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## Summary

Closes #742.

The bus-triplet key was built by casting typed enums to `u8` — `(lane.move_type as u8, lane.bus_id, lane.direction as u8)` — and later reconstructed by hand-written `match` blocks guarded by `unreachable!`. Those `unreachable!` arms were load-bearing on an encode-as-`u8` / decode-by-`match` invariant maintained by hand in the same files.

This keeps the triplet typed end-to-end:

- **`primitives/ordering.rs`** — replaced `type TripletKey = (u8, u32, u8)` with a typed newtype `struct TripletKey { move_type: MoveType, bus_id: u32, direction: Direction }` (deriving `Ord`/`Hash`), plus a `::new()` constructor.
- **`arch/addr.rs`** — added `PartialOrd, Ord` derives to `MoveType` and `Direction` (the enabling change).
- **`generators/heuristic.rs`** and **`drivers/entropy.rs`** — construction sites now call `TripletKey::new(...)`; group destructuring uses a struct pattern. The `as u8` casts and the `unreachable!` reconstruction (including entropy's `decode_triplet_key` helper) are gone.
- **`dsl/pipeline.rs`** (Move Policy DSL) — migrated its own local `TripletKey` alias + `decode_move_type`/`decode_direction` helpers to the shared typed newtype. See note below.

## Ordering preservation (the issue's caveat)

The derived `Ord` on the struct compares fields in declaration order, and the enums order by their `#[repr(u8)]` discriminant (declaration order matches discriminant order). This is identical to the former `(u8, u32, u8)` lexicographic comparison, so `BTreeMap` iteration order and tie-breaks are unchanged — the cross-platform determinism guarantees from #719 hold.

## Note on the DSL pipeline (Starlark boundary)

`dsl/pipeline.rs` looked like it might have to stay on raw `u8`s because it's fed by Starlark policy code. It doesn't: the Starlark boundary (`Lane(...)` / `arch_spec.lane(...)` in `bloqade-lanes-dsl-core`) decodes the raw discriminant ints into typed `MoveType`/`Direction` **before** constructing a `StarlarkLane(LaneAddr)` (invalid values error out there). By the time `group_by_triplet` runs, `entry.lane.move_type`/`direction` are already typed enums — the `as u8` cast + `Option`-returning decode-back was a redundant round-trip on already-valid data, exactly the pattern this issue targets. Migrated for consistency.

## Acceptance criteria

- [x] No `as u8` / `unreachable!` round-trip for the bus triplet in `heuristic.rs` (also removed in `entropy.rs` and `dsl/pipeline.rs`, which shared the type/pattern).
- [x] Deterministic candidate ordering preserved — existing tests pass, incl. `scored_triple_tie_break_is_deterministic`, `scored_entry_tie_break_is_deterministic`, and the DSL snapshot/params tests that exercise the real Starlark pipeline.

## Testing

- `cargo check --workspace --all-targets` ✅
- `cargo clippy` (core + search, `-D warnings`) ✅
- `cargo test` (core + search): 213 + 299 tests pass ✅
- `cargo fmt --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)