### PR TITLE
build(deps): bump pyo3 0.24 -> 0.29 to close 2 Dependabot alerts

### DIFF
--- a/crates/bloqade-lanes-bytecode-python/Cargo.toml
+++ b/crates/bloqade-lanes-bytecode-python/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 bloqade-lanes-bytecode-core = { path = "../bloqade-lanes-bytecode-core" }
 bloqade-lanes-dsl-core = { path = "../bloqade-lanes-dsl-core" }
 bloqade-lanes-search = { path = "../bloqade-lanes-search" }
-pyo3 = { version = "0.24", features = ["extension-module", "abi3-py310"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 
 # vihaco-backed ISA types nested in the bindings (CPU ops via vihaco-cpu).

--- a/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
@@ -1,5 +1,9 @@
 use pyo3::prelude::*;
 
+// `PyObject` was removed from pyo3 0.29's exports; keep the historical alias
+// so `check_locations` / `check_lanes` return-type signatures stay legible.
+type PyObject = Py<PyAny>;
+
 use bloqade_lanes_bytecode_core::arch::addr as rs_addr;
 use bloqade_lanes_bytecode_core::arch::types as rs;
 use bloqade_lanes_bytecode_core::version::Version;

--- a/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/arch_python.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 
 // `PyObject` was removed from pyo3 0.29's exports; keep the historical alias
 // so `check_locations` / `check_lanes` return-type signatures stay legible.
-type PyObject = Py<PyAny>;
+pub(crate) type PyObject = Py<PyAny>;
 
 use bloqade_lanes_bytecode_core::arch::addr as rs_addr;
 use bloqade_lanes_bytecode_core::arch::types as rs;

--- a/crates/bloqade-lanes-bytecode-python/src/errors.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/errors.rs
@@ -1,6 +1,10 @@
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 
+// `PyObject` was removed from pyo3 0.29's exports; keep the historical alias
+// so error-conversion helpers below stay legible.
+type PyObject = Py<PyAny>;
+
 use bloqade_lanes_bytecode_core::arch::query::{LaneGroupError, LocationGroupError};
 use bloqade_lanes_bytecode_core::arch::validate::ArchSpecError;
 use bloqade_lanes_bytecode_core::isa::INSTRUCTION_WIDTH;

--- a/crates/bloqade-lanes-bytecode-python/src/errors.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/errors.rs
@@ -2,8 +2,10 @@ use pyo3::prelude::*;
 use pyo3::types::PyList;
 
 // `PyObject` was removed from pyo3 0.29's exports; keep the historical alias
-// so error-conversion helpers below stay legible.
-type PyObject = Py<PyAny>;
+// so error-conversion helpers below stay legible. `pub(crate)` matches the
+// visibility of the `pub fn` items that use it in their signatures — a
+// private alias here would risk `private_interfaces` under stricter lints.
+pub(crate) type PyObject = Py<PyAny>;
 
 use bloqade_lanes_bytecode_core::arch::query::{LaneGroupError, LocationGroupError};
 use bloqade_lanes_bytecode_core::arch::validate::ArchSpecError;

--- a/crates/bloqade-lanes-bytecode-python/src/policy_runner_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/policy_runner_python.rs
@@ -47,10 +47,10 @@ fn pyany_to_json(v: &Bound<'_, PyAny>) -> PyResult<serde_json::Value> {
         Ok(serde_json::json!(f))
     } else if let Ok(s) = v.extract::<String>() {
         Ok(serde_json::Value::String(s))
-    } else if let Ok(list) = v.downcast::<PyList>() {
+    } else if let Ok(list) = v.cast::<PyList>() {
         let items: PyResult<Vec<_>> = list.iter().map(|x| pyany_to_json(&x)).collect();
         Ok(serde_json::Value::Array(items?))
-    } else if let Ok(dict) = v.downcast::<PyDict>() {
+    } else if let Ok(dict) = v.cast::<PyDict>() {
         pydict_to_json(dict)
     } else {
         Err(PyValueError::new_err(format!(
@@ -292,7 +292,7 @@ impl PyPolicyRunner {
 
         let index = Arc::clone(&self.index);
         let result = py
-            .allow_threads(|| {
+            .detach(|| {
                 solve_with_policy(
                     initial_pairs,
                     target_pairs,

--- a/crates/bloqade-lanes-bytecode-python/src/search_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/search_python.rs
@@ -9,6 +9,10 @@ use std::sync::Arc;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
+// `PyObject` was removed from pyo3 0.29's exports; keep the historical alias
+// so the attempts-list getter's return signature stays legible.
+type PyObject = Py<PyAny>;
+
 use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
 use bloqade_lanes_search::DeadlockPolicy;
 use bloqade_lanes_search::drivers::entropy::{
@@ -1214,7 +1218,7 @@ impl PyMultiSolveResult {
     /// `candidate_index`, `status`, `nodes_expanded`.
     #[getter]
     fn attempts(&self) -> PyResult<Vec<PyObject>> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             self.inner
                 .attempts
                 .iter()
@@ -1521,7 +1525,7 @@ impl PyTargetSolver {
         let blocked_locs: Vec<LocationAddr> = blocked.iter().map(|loc| loc.inner).collect();
 
         let result = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.inner
                     .solve(initial_pairs, target_pairs, blocked_locs, max_expansions)
             })
@@ -1578,7 +1582,7 @@ impl PySingleHeuristicCzPlacement {
         let blocked_locs: Vec<LocationAddr> = blocked.iter().map(|loc| loc.inner).collect();
 
         let result = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.inner.solve(
                     &initial_pairs,
                     &controls,
@@ -1608,7 +1612,7 @@ impl PySingleHeuristicCzPlacement {
         let blocked_locs: Vec<LocationAddr> = blocked.iter().map(|loc| loc.inner).collect();
 
         let result = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.inner.solve_with_attempts(
                     initial_pairs,
                     &controls,
@@ -1676,7 +1680,7 @@ impl PyLooseGoalCzPlacement {
         let future = future_cz_layers.unwrap_or_default();
 
         let result = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.inner.solve_pairs(
                     initial_pairs,
                     &cz_pairs,
@@ -1706,7 +1710,7 @@ impl PyLooseGoalCzPlacement {
         let blocked_locs: Vec<LocationAddr> = blocked.iter().map(|loc| loc.inner).collect();
 
         let result = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.inner.solve(
                     &initial_pairs,
                     &controls,
@@ -1781,7 +1785,7 @@ impl PyRecedingHorizonCzPlacement {
         let future = future_cz_layers.unwrap_or_default();
 
         let result = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.inner.solve_pairs(
                     initial_pairs,
                     &cz_pairs,
@@ -1811,7 +1815,7 @@ impl PyRecedingHorizonCzPlacement {
         let blocked_locs: Vec<LocationAddr> = blocked.iter().map(|loc| loc.inner).collect();
 
         let result = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.inner.solve(
                     &initial_pairs,
                     &controls,
@@ -1875,7 +1879,7 @@ impl PyNoHomeCzPlacement {
         let future = future_cz_layers.unwrap_or_default();
 
         let result = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.inner.solve_pairs(
                     initial_pairs,
                     &cz_pairs,
@@ -1905,7 +1909,7 @@ impl PyNoHomeCzPlacement {
         let blocked_locs: Vec<LocationAddr> = blocked.iter().map(|loc| loc.inner).collect();
 
         let result = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.inner.solve(
                     &initial_pairs,
                     &controls,

--- a/crates/bloqade-lanes-bytecode-python/src/search_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/search_python.rs
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 
 // `PyObject` was removed from pyo3 0.29's exports; keep the historical alias
 // so the attempts-list getter's return signature stays legible.
-type PyObject = Py<PyAny>;
+pub(crate) type PyObject = Py<PyAny>;
 
 use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
 use bloqade_lanes_search::DeadlockPolicy;

--- a/crates/bloqade-lanes-bytecode-python/src/target_generator_dsl_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/target_generator_dsl_python.rs
@@ -55,7 +55,7 @@ impl PyTargetPolicyRunner {
         };
 
         let result = py
-            .allow_threads(|| {
+            .detach(|| {
                 let mut observer =
                     bloqade_lanes_search::dsl::target_generator_dsl::NoOpTargetObserver;
                 self.inner.generate(


### PR DESCRIPTION
## Summary

- Bumps `pyo3` in `crates/bloqade-lanes-bytecode-python` from **0.24** to **0.29** to close the two open Dependabot alerts on this repo.
- Migrates the bindings crate to the 0.29 API surface (`with_gil` → `attach`, `allow_threads` → `detach`, `downcast` → `cast`, restore local `PyObject` alias).
- Full Rust + Python test suites pass against the new pyo3.

## Dependabot alerts closed

| # | Severity | GHSA | Summary |
|---|---|---|---|
| [#11](https://github.com/QuEraComputing/bloqade-lanes/security/dependabot/11) | HIGH | [GHSA-36hh-v3qg-5jq4](https://github.com/advisories/GHSA-36hh-v3qg-5jq4) | OOB read in `PyList` / `PyTuple` iterators' `nth` / `nth_back` |
| [#12](https://github.com/QuEraComputing/bloqade-lanes/security/dependabot/12) | MEDIUM | [GHSA-chgr-c6px-7xpp](https://github.com/advisories/GHSA-chgr-c6px-7xpp) | Missing `Sync` bound on `PyCFunction::new_closure` |

**Reachability:** neither `.nth` / `.nth_back` on `PyList`/`PyTuple` iterators nor `PyCFunction::new_closure` is called anywhere in this crate — so the actual exposure to these CVEs is zero. Bumping is still the right call: it's the durable fix (future scans stay green) and gets us onto a supported pyo3 line before the next advisory lands.

## API migrations (pyo3 0.24 → 0.29)

| Old | New | Sites |
|---|---|---|
| `Python::with_gil` | `Python::attach` | 1 |
| `Python::allow_threads(...)` | `Python::detach(...)` | 10 |
| `Bound::downcast::<T>()` | `Bound::cast::<T>()` | 2 |
| `PyObject` (removed from `pyo3` exports) | local `type PyObject = Py<PyAny>;` alias | 3 files |

The `PyObject` alias is kept locally rather than churning all 13 call sites — the two are the same type in every pyo3 version, and the alias makes the migration diff minimal and easy to revert.

## Follow-up (not in this PR)

- 25 deprecation warnings about the auto-`FromPyObject` derive on `#[pyclass]` types that also derive `Clone`. Migrating requires deciding, per class, whether to opt in with `#[pyclass(from_py_object)]` or opt out with `#[pyclass(skip_from_py_object)]`. Left for a separate PR since it's a behavioural knob, not a security fix.
- Consider adding `cargo` to `.github/dependabot.yml` so future Rust advisories get auto-PRs.

## Test plan

- [x] `just test-rust` — 213 passing
- [x] `just test-python` — 1802 passing, 6 skipped, 1 xpassed
- [x] `just develop-python` builds cleanly (25 deprecation warnings, 0 errors)
- [x] `cargo clippy` + `cargo fmt` + `pyright` all clean via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)