### PR TITLE
build: bump development version to 0.12.0-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.0-dev"
+version = "0.12.0-dev"
 
 [workspace.dependencies]
 # vihaco — virtual ISA + machine framework (QuEra, MIT).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "bloqade-lanes"
-version = "0.11.0-dev"
+version = "0.12.0-dev"
 description = "Components for defining and manipulating lane-based structures in Bloqade for neutral atom quantum computing."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -337,7 +337,7 @@ mle = [
 
 [[package]]
 name = "bloqade-lanes"
-version = "0.11.0.dev0"
+version = "0.12.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "bloqade-circuit", extra = ["qasm2"] },


### PR DESCRIPTION
Bumps the workspace and Python package to the next development version now that `release-0-11` is cut.

- `Cargo.toml` workspace version → `0.12.0-dev`
- `pyproject.toml` version → `0.12.0-dev`
- `uv.lock` synced (`bloqade-lanes==0.12.0.dev0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)