### PR TITLE
fix(gemini): make Gurobi decoder optional so bloqade.lanes imports without it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,11 @@ sim = [
     "bloqade-tsim~=0.1.3",
 ]
 decoding = [
-    # GurobiDecoder (and its Gurobi MLE confidence wrapper) lives behind the
-    # `mle` extra of bloqade-decoders, which also pulls in gurobipy. Keeping it
-    # optional means the base install never requires Gurobi to import.
-    "bloqade-decoders[mle]>=0.6.0",
+    # Optional confidence decoders (Gurobi MLE + table/MLD) live behind the
+    # `mle`/`mld` extras of bloqade-decoders, which also pull in their solver
+    # backends (gurobipy, polars, ...). Keeping them optional means the base
+    # install never requires a decoder backend to import.
+    "bloqade-decoders[mle, mld]>=0.6.0",
 ]
 visualization = [
     "matplotlib>=3.9.4",
@@ -47,7 +48,9 @@ visualization = [
     "pyqt5>=5.15.11;  sys_platform == 'linux'",
 ]
 msd-reprod = [
-    "bloqade-decoders[mle, mld]>=0.6.0",
+    # Decoder backends come from the shared `decoding` extra; this adds the
+    # extras specific to the MSD reproduction notebooks.
+    "bloqade-lanes[decoding]",
     "clifft; python_version >= '3.12'",
     "ipywidgets"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,12 @@ sim = [
     "bloqade-circuit[cirq, tsim]~=0.15.0",
     "bloqade-tsim~=0.1.3",
 ]
+decoding = [
+    # GurobiDecoder (and its Gurobi MLE confidence wrapper) lives behind the
+    # `mle` extra of bloqade-decoders, which also pulls in gurobipy. Keeping it
+    # optional means the base install never requires Gurobi to import.
+    "bloqade-decoders[mle]>=0.6.0",
+]
 visualization = [
     "matplotlib>=3.9.4",
     "scipy>=1.15.3",

--- a/python/bloqade/gemini/decoding/confidence.py
+++ b/python/bloqade/gemini/decoding/confidence.py
@@ -7,21 +7,37 @@ from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, cast
 
 import numpy as np
 import numpy.typing as npt
-from bloqade.decoders import GurobiDecoder
+
+_GUROBI_MISSING_MSG = (
+    "Gurobi confidence decoding requires the optional Gurobi decoder. Install "
+    "it with `bloqade-lanes[decoding]` (which pulls in `bloqade-decoders[mle]` "
+    "and `gurobipy`)."
+)
 
 if TYPE_CHECKING:
     import gurobipy as gp  # type: ignore[reportMissingImports]
+    from bloqade.decoders import GurobiDecoder
+else:
+    try:
+        # `GurobiDecoder` is only exported by `bloqade-decoders` when its
+        # optional `mle` extra (and `gurobipy`) are installed. Keep it off the
+        # eager import path so importing `bloqade.gemini` / `bloqade.lanes`
+        # never requires the Gurobi decoder; defer the error to construction.
+        from bloqade.decoders import GurobiDecoder
+    except ImportError:
+
+        class GurobiDecoder:  # type: ignore[no-redef]
+            """Runtime stub used when the optional Gurobi decoder is absent."""
+
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise ImportError(_GUROBI_MISSING_MSG)
 
 
 def _gurobipy() -> Any:
     try:
         import gurobipy as gp  # type: ignore[reportMissingImports]
     except ImportError as exc:
-        raise ImportError(
-            "Gurobi confidence decoding requires the optional `gurobipy` "
-            "dependency. Install it with `bloqade-lanes[msd-reprod]` or "
-            "include `gurobipy` in your environment."
-        ) from exc
+        raise ImportError(_GUROBI_MISSING_MSG) from exc
 
     return gp
 

--- a/python/bloqade/gemini/decoding/table_decoders.py
+++ b/python/bloqade/gemini/decoding/table_decoders.py
@@ -14,7 +14,7 @@ from .confidence import ConfidenceDecoder, _validate_detector_bits
 
 _TABLE_DECODER_MISSING_MSG = (
     "Table confidence decoding requires the optional table decoder. Install it "
-    "with `bloqade-lanes[msd-reprod]`."
+    "with `bloqade-lanes[decoding]`."
 )
 
 if TYPE_CHECKING:

--- a/python/tests/gemini/decoding/test_decoding_imports.py
+++ b/python/tests/gemini/decoding/test_decoding_imports.py
@@ -1,3 +1,9 @@
+import builtins
+import importlib
+
+import pytest
+
+
 def test_gemini_decoding_public_imports():
     from bloqade.gemini import decoding
 
@@ -8,3 +14,38 @@ def test_gemini_decoding_public_imports():
     assert hasattr(decoding, "magic_state_dist_steane")
     assert not hasattr(decoding, "DEFAULT_TARGET_BLOCH")
     assert not hasattr(decoding, "plot_decoder_curves")
+
+
+def test_confidence_imports_without_gurobi_decoder(monkeypatch):
+    """`bloqade.gemini` (hence `bloqade.lanes`) must import even when the
+    optional Gurobi decoder is unavailable; the error is deferred to use.
+
+    Regression test for #840: `bloqade-decoders` only exports `GurobiDecoder`
+    with its `mle` extra installed, and an eager top-level import broke the
+    whole import chain for downstream consumers without that extra.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "bloqade.decoders" and fromlist and "GurobiDecoder" in fromlist:
+            raise ImportError("cannot import name 'GurobiDecoder'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    confidence = importlib.reload(
+        importlib.import_module("bloqade.gemini.decoding.confidence")
+    )
+
+    # Import succeeds and the public symbol is still present...
+    cls = confidence.GurobiDecoderWithConfidence
+    # ...but constructing it without the optional dependency raises clearly.
+    with pytest.raises(ImportError, match="bloqade-lanes\\[decoding\\]"):
+        cls()
+
+
+@pytest.fixture(autouse=True)
+def _restore_confidence_module():
+    """Reload confidence after the missing-Gurobi test so real state is back."""
+    yield
+    importlib.reload(importlib.import_module("bloqade.gemini.decoding.confidence"))

--- a/python/tests/gemini/decoding/test_decoding_imports.py
+++ b/python/tests/gemini/decoding/test_decoding_imports.py
@@ -29,7 +29,7 @@ def test_gemini_imports_without_table_decoder():
         try:
             TableDecoderWithConfidence(stim.DetectorErrorModel(""), num_shots=0)
         except ImportError as exc:
-            assert "bloqade-lanes[msd-reprod]" in str(exc)
+            assert "bloqade-lanes[decoding]" in str(exc)
         else:
             raise AssertionError("expected the optional-dependency error")
     """

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ cudaq = [
     { name = "qbraid-qir", extra = ["squin"], marker = "sys_platform != 'win32'" },
 ]
 decoding = [
-    { name = "bloqade-decoders", extra = ["mle"] },
+    { name = "bloqade-decoders", extra = ["mld", "mle"] },
 ]
 msd-reprod = [
     { name = "bloqade-decoders", extra = ["mld", "mle"] },
@@ -420,8 +420,8 @@ requires-dist = [
     { name = "bloqade-circuit", extras = ["cirq", "tsim"], marker = "extra == 'sim'", specifier = "~=0.15.0" },
     { name = "bloqade-circuit", extras = ["qasm2"], specifier = "~=0.15.0" },
     { name = "bloqade-core", specifier = "~=0.6.4" },
-    { name = "bloqade-decoders", extras = ["mle"], marker = "extra == 'decoding'", specifier = ">=0.6.0" },
-    { name = "bloqade-decoders", extras = ["mle", "mld"], marker = "extra == 'msd-reprod'", specifier = ">=0.6.0" },
+    { name = "bloqade-decoders", extras = ["mle", "mld"], marker = "extra == 'decoding'", specifier = ">=0.6.0" },
+    { name = "bloqade-lanes", extras = ["decoding"], marker = "extra == 'msd-reprod'" },
     { name = "bloqade-tsim", marker = "extra == 'sim'", specifier = "~=0.1.3" },
     { name = "clifft", marker = "python_full_version >= '3.12' and extra == 'msd-reprod'" },
     { name = "cudaq", marker = "sys_platform != 'win32' and extra == 'cudaq'", specifier = ">=0.13.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -358,6 +358,9 @@ cudaq = [
     { name = "cudaq", version = "0.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform != 'win32'" },
     { name = "qbraid-qir", extra = ["squin"], marker = "sys_platform != 'win32'" },
 ]
+decoding = [
+    { name = "bloqade-decoders", extra = ["mle"] },
+]
 msd-reprod = [
     { name = "bloqade-decoders", extra = ["mld", "mle"] },
     { name = "clifft", marker = "python_full_version >= '3.12'" },
@@ -417,6 +420,7 @@ requires-dist = [
     { name = "bloqade-circuit", extras = ["cirq", "tsim"], marker = "extra == 'sim'", specifier = "~=0.15.0" },
     { name = "bloqade-circuit", extras = ["qasm2"], specifier = "~=0.15.0" },
     { name = "bloqade-core", specifier = "~=0.6.4" },
+    { name = "bloqade-decoders", extras = ["mle"], marker = "extra == 'decoding'", specifier = ">=0.6.0" },
     { name = "bloqade-decoders", extras = ["mle", "mld"], marker = "extra == 'msd-reprod'", specifier = ">=0.6.0" },
     { name = "bloqade-tsim", marker = "extra == 'sim'", specifier = "~=0.1.3" },
     { name = "clifft", marker = "python_full_version >= '3.12' and extra == 'msd-reprod'" },
@@ -434,7 +438,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "scipy", marker = "extra == 'visualization'", specifier = ">=1.15.3" },
 ]
-provides-extras = ["cudaq", "sim", "visualization", "msd-reprod"]
+provides-extras = ["cudaq", "sim", "decoding", "visualization", "msd-reprod"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Fixes #840. Installing/importing `bloqade-lanes` broke downstream (e.g. `bloqade.flair.upstream`) with:

```
ImportError: cannot import name 'GurobiDecoder' from 'bloqade.decoders'
```

`bloqade-decoders` only exports `GurobiDecoder` when its optional `mle` extra (which brings `gurobipy`) is installed. `bloqade/gemini/decoding/confidence.py` imported it at module top level, so the whole `bloqade.gemini` → `bloqade.lanes` import chain required the Gurobi decoder — a dependency that isn't part of the base install.

## Changes

- **`confidence.py`** — guard the `from bloqade.decoders import GurobiDecoder` import: the real type is used under `TYPE_CHECKING`, and at runtime we fall back to a small stub that raises a clear `ImportError` only when a `GurobiDecoderWithConfidence` is actually constructed. The class definition and public symbol survive without the dependency.
- **`pyproject.toml`** — add a `decoding` optional extra (`bloqade-decoders[mle]`) so users who want Gurobi confidence decoding can opt in with `bloqade-lanes[decoding]`.
- **test** — regression test asserting the import chain survives a missing `GurobiDecoder` and that construction raises with a pointer to the extra.

## Verification

- `bloqade.gemini` / `bloqade.lanes` import cleanly with and without the Gurobi decoder available.
- Full `python/tests/gemini/decoding/` suite: 70 passed.
- black / isort / ruff / pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)