### PR TITLE
fix(gemini): make tabledecoder import optional

### DIFF
--- a/python/bloqade/gemini/decoding/table_decoders.py
+++ b/python/bloqade/gemini/decoding/table_decoders.py
@@ -3,15 +3,46 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import stim
-from bloqade.decoders import TableDecoder
-from bloqade.decoders._decoders.mld.utils import pack_boolean_array, shots_to_counts
 
 from .confidence import ConfidenceDecoder, _validate_detector_bits
 
 # NOTE: We will plan to move this code to bloqade-decoders.
+
+_TABLE_DECODER_MISSING_MSG = (
+    "Table confidence decoding requires the optional table decoder. Install it "
+    "with `bloqade-lanes[msd-reprod]`."
+)
+
+if TYPE_CHECKING:
+    from bloqade.decoders import TableDecoder
+    from bloqade.decoders._decoders.mld.utils import (
+        pack_boolean_array,
+        shots_to_counts,
+    )
+else:
+    try:
+        from bloqade.decoders import TableDecoder
+        from bloqade.decoders._decoders.mld.utils import (
+            pack_boolean_array,
+            shots_to_counts,
+        )
+    except ImportError:
+
+        class TableDecoder:  # type: ignore[no-redef]
+            """Runtime stub used when the optional TableDecoder is absent."""
+
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                raise ImportError(_TABLE_DECODER_MISSING_MSG)
+
+        def _missing_table_decoder(*args: Any, **kwargs: Any) -> Any:
+            raise ImportError(_TABLE_DECODER_MISSING_MSG)
+
+        pack_boolean_array = _missing_table_decoder
+        shots_to_counts = _missing_table_decoder
 
 logger = logging.getLogger(__name__)
 

--- a/python/tests/gemini/decoding/test_decoding_imports.py
+++ b/python/tests/gemini/decoding/test_decoding_imports.py
@@ -1,3 +1,8 @@
+import subprocess
+import sys
+import textwrap
+
+
 def test_gemini_decoding_public_imports():
     from bloqade.gemini import decoding
 
@@ -8,3 +13,31 @@ def test_gemini_decoding_public_imports():
     assert hasattr(decoding, "magic_state_dist_steane")
     assert not hasattr(decoding, "DEFAULT_TARGET_BLOCH")
     assert not hasattr(decoding, "plot_decoder_curves")
+
+
+def test_gemini_imports_without_table_decoder():
+    """Missing optional TableDecoder is reported only when it is constructed."""
+
+    script = """
+        import bloqade.decoders
+
+        del bloqade.decoders.TableDecoder
+
+        import stim
+        from bloqade.gemini.decoding.table_decoders import TableDecoderWithConfidence
+
+        try:
+            TableDecoderWithConfidence(stim.DetectorErrorModel(""), num_shots=0)
+        except ImportError as exc:
+            assert "bloqade-lanes[msd-reprod]" in str(exc)
+        else:
+            raise AssertionError("expected the optional-dependency error")
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
In case we run into a similar error, so we don't require `TableDecoder` to be defined in bloqade.decoders