### PR TITLE
fix(search): include inter-zone zone_buses in move search graph

### DIFF
--- a/crates/bloqade-lanes-search/src/primitives/lane_index.rs
+++ b/crates/bloqade-lanes-search/src/primitives/lane_index.rs
@@ -154,6 +154,52 @@ impl LaneIndex {
             }
         }
 
+        // Zone buses: inter-zone word movement. Unlike site/word buses these
+        // live on the spec itself (not per-zone), so they are registered after
+        // the per-zone loop. Each `(src_ref, dst_ref)` pair moves a word across
+        // a zone boundary; the destination zone/word is derived by
+        // `lane_endpoints` from the zone-bus table, so we only encode the
+        // forward source here. Mirrors Python's `PathFinder` zone-bus loop.
+        //
+        // Both the source and destination word sets of a zone bus are validated
+        // to form AOD-compatible rectangles at arch-build time (see
+        // `ArchBuilder.connect`), so the AOD rectangle builder can treat zone
+        // buses exactly like intra-zone buses.
+        let sites_per_word = arch_spec
+            .words
+            .iter()
+            .map(|w| w.sites.len())
+            .max()
+            .unwrap_or(0) as u32;
+        for (bus_idx, bus) in arch_spec.zone_buses.iter().enumerate() {
+            let bus_id = bus_idx as u32;
+            for direction in [Direction::Forward, Direction::Backward] {
+                for src_ref in &bus.src {
+                    let zone_id = src_ref.zone_id as u32;
+                    let word_id = src_ref.word_id as u32;
+                    for site_id in 0..sites_per_word {
+                        let lane = LaneAddr {
+                            move_type: MoveType::ZoneBus,
+                            zone_id,
+                            word_id,
+                            site_id,
+                            bus_id,
+                            direction,
+                        };
+                        register_lane(
+                            lane,
+                            bus_id,
+                            zone_id,
+                            direction,
+                            MoveType::ZoneBus,
+                            &mut positions,
+                            &arch_spec,
+                        );
+                    }
+                }
+            }
+        }
+
         // Build lane duration cache from transport paths.
         let mut lane_durations: HashMap<u64, f64> = HashMap::new();
         let mut fastest: Option<f64> = None;
@@ -364,6 +410,49 @@ mod tests {
         // Site bus 0, zone 0, forward: src=[0,1,2,3,4] in words [0,1] → 5*2=10 lanes
         let lanes = index.lanes_for(MoveType::SiteBus, 0, 0, Direction::Forward);
         assert_eq!(lanes.len(), 10);
+    }
+
+    #[test]
+    fn zone_bus_edges_are_registered() {
+        // Regression for #845: inter-zone `zone_buses` must appear as edges in
+        // the search graph, mirroring Python's PathFinder.
+        let spec: ArchSpec =
+            serde_json::from_str(crate::test_utils::two_zone_bus_arch_json()).unwrap();
+        let index = LaneIndex::new(spec);
+
+        // The zone bus connects (zone 1, word 1, site 0) -> (zone 0, word 0, site 0).
+        let src = LocationAddr {
+            zone_id: 1,
+            word_id: 1,
+            site_id: 0,
+        };
+        let dst = LocationAddr {
+            zone_id: 0,
+            word_id: 0,
+            site_id: 0,
+        };
+
+        // A forward ZoneBus lane should originate from the memory-zone source.
+        let outgoing = index.outgoing_lanes(src);
+        let zone_lane = outgoing
+            .iter()
+            .find(|l| l.move_type == MoveType::ZoneBus)
+            .copied()
+            .expect("zone bus lane must be present in outgoing edges");
+
+        let (lsrc, ldst) = index.endpoints(&zone_lane).unwrap();
+        assert_eq!(lsrc, src);
+        assert_eq!(ldst, dst);
+
+        // The reverse (backward) edge must also exist so the graph is traversable
+        // in both directions, matching PathFinder's forward+reverse edge pair.
+        let back = index.outgoing_lanes(dst);
+        assert!(
+            back.iter().any(|l| {
+                l.move_type == MoveType::ZoneBus && index.endpoints(l).map(|(_, d)| d) == Some(src)
+            }),
+            "reverse zone bus edge (gate -> memory) must be present"
+        );
     }
 
     #[test]

--- a/crates/bloqade-lanes-search/src/test_utils.rs
+++ b/crates/bloqade-lanes-search/src/test_utils.rs
@@ -32,6 +32,53 @@ pub fn full_arch_json() -> &'static str {
     include_str!("../../../examples/arch/full.json")
 }
 
+/// Minimal two-zone architecture with a single inter-zone `zone_bus`.
+///
+/// Zone 0 ("gate") holds word 0 and zone 1 ("memory") holds word 1, each a
+/// single-site word. A one-to-one `zone_bus` connects (zone 1, word 1) ->
+/// (zone 0, word 0). There are no intra-zone buses, so the only edges in the
+/// search graph come from the zone bus — making this arch a focused regression
+/// fixture for inter-zone graph construction (issue #845).
+#[allow(dead_code)]
+pub fn two_zone_bus_arch_json() -> &'static str {
+    r#"{
+        "version": "2.0",
+        "words": [
+            { "sites": [[0, 0]] },
+            { "sites": [[0, 0]] }
+        ],
+        "zones": [
+            {
+                "name": "gate",
+                "grid": { "x_start": 0.0, "y_start": 0.0, "x_spacing": [], "y_spacing": [] },
+                "site_buses": [],
+                "word_buses": [],
+                "words_with_site_buses": [],
+                "sites_with_word_buses": [],
+                "entangling_pairs": []
+            },
+            {
+                "name": "memory",
+                "grid": { "x_start": 0.0, "y_start": 10.0, "x_spacing": [], "y_spacing": [] },
+                "site_buses": [],
+                "word_buses": [],
+                "words_with_site_buses": [],
+                "sites_with_word_buses": [],
+                "entangling_pairs": []
+            }
+        ],
+        "zone_buses": [
+            {
+                "src": [{ "zone_id": 1, "word_id": 1 }],
+                "dst": [{ "zone_id": 0, "word_id": 0 }]
+            }
+        ],
+        "modes": [
+            { "name": "default", "zones": [0, 1], "bitstring_order": [] }
+        ]
+    }"#
+}
+
 /// Example two-word architecture JSON for tests.
 ///
 /// Zone-centric schema: words at top level, zones own grids and buses.

--- a/python/tests/bytecode/test_zone_bus_search.py
+++ b/python/tests/bytecode/test_zone_bus_search.py
@@ -1,0 +1,88 @@
+"""Regression tests for inter-zone routing in the Rust move router (#845).
+
+The Rust ``SearchEngine`` / ``TargetSolver`` used to build its search graph
+from intra-zone buses only (site + word buses) and omit inter-zone
+``zone_buses``. As a result any cross-zone move was reported ``unsolvable``
+even when a direct inter-zone bus existed. These tests pin the fix: the search
+graph now includes ``zone_buses`` edges, matching Python's ``PathFinder``.
+"""
+
+from __future__ import annotations
+
+from bloqade.lanes.arch.path import PathFinder
+from bloqade.lanes.arch.spec import ArchSpec
+from bloqade.lanes.bytecode import _native
+from bloqade.lanes.bytecode._native import (
+    ArchSpec as RustArchSpec,
+    MoveSearch,
+    SearchEngine,
+)
+from bloqade.lanes.bytecode.encoding import LocationAddress
+
+# Minimal two-zone processor: zone 0 ("gate") holds word 0 and zone 1
+# ("memory") holds word 1, each a single-site word. A one-to-one zone_bus
+# connects (zone 1, word 1) -> (zone 0, word 0). No intra-zone buses exist, so
+# the only path between the zones is the inter-zone bus.
+_TWO_ZONE_ARCH_JSON = """
+{
+  "version": "2.0",
+  "words": [{ "sites": [[0, 0]] }, { "sites": [[0, 0]] }],
+  "zones": [
+    {
+      "name": "gate",
+      "grid": { "x_start": 0.0, "y_start": 0.0, "x_spacing": [], "y_spacing": [] },
+      "site_buses": [], "word_buses": [],
+      "words_with_site_buses": [], "sites_with_word_buses": [],
+      "entangling_pairs": []
+    },
+    {
+      "name": "memory",
+      "grid": { "x_start": 0.0, "y_start": 10.0, "x_spacing": [], "y_spacing": [] },
+      "site_buses": [], "word_buses": [],
+      "words_with_site_buses": [], "sites_with_word_buses": [],
+      "entangling_pairs": []
+    }
+  ],
+  "zone_buses": [
+    { "src": [{ "zone_id": 1, "word_id": 1 }], "dst": [{ "zone_id": 0, "word_id": 0 }] }
+  ],
+  "modes": [{ "name": "default", "zones": [0, 1], "bitstring_order": [] }]
+}
+"""
+
+
+def _arch() -> ArchSpec:
+    return ArchSpec(RustArchSpec.from_json(_TWO_ZONE_ARCH_JSON))
+
+
+def test_pathfinder_finds_inter_zone_path():
+    arch = _arch()
+    mem_loc = LocationAddress(1, 0, 1)
+    gate_loc = LocationAddress(0, 0, 0)
+    path = PathFinder(arch).find_path(mem_loc, gate_loc)
+    assert path is not None
+
+
+def test_rust_solver_routes_across_zone_bus():
+    arch = _arch()
+    mem_loc = LocationAddress(1, 0, 1)
+    gate_loc = LocationAddress(0, 0, 0)
+
+    engine = SearchEngine.from_arch_spec(arch._inner)
+    solver = _native.TargetSolver(engine, MoveSearch.entropy())
+    result = solver.solve({0: mem_loc._inner}, {0: gate_loc._inner}, [], None)
+
+    assert result.status == "solved"
+
+
+def test_rust_solver_routes_back_across_zone_bus():
+    # The reverse (gate -> memory) direction must also be traversable.
+    arch = _arch()
+    mem_loc = LocationAddress(1, 0, 1)
+    gate_loc = LocationAddress(0, 0, 0)
+
+    engine = SearchEngine.from_arch_spec(arch._inner)
+    solver = _native.TargetSolver(engine, MoveSearch.entropy())
+    result = solver.solve({0: gate_loc._inner}, {0: mem_loc._inner}, [], None)
+
+    assert result.status == "solved"


### PR DESCRIPTION
## Summary

The Rust move router (`SearchEngine.from_arch_spec` / `TargetSolver`) built its search graph from **intra-zone** buses only (site buses + word buses) and **omitted inter-zone `zone_buses`**. As a result the solver reported any cross-zone move as `unsolvable`, even a single-atom hop over a directly-connected inter-zone bus — blocking any placement strategy that stages atoms between zones (e.g. homing qubits in a storage/memory zone and routing them into a gate zone for CZ). The Python `PathFinder` already added these edges, so the architecture connectivity was fine; the gap was purely in the Rust engine's graph construction.

Fixes #845.

## What changed

- **`lane_index.rs`** — `LaneIndex::new` now registers `MoveType::ZoneBus` lanes for every `zone_bus`, mirroring the inter-zone edge loop in Python's `PathFinder`. Zone buses live on the spec (not per-zone), so registration happens after the per-zone loop; the destination zone/word is resolved by the existing `lane_endpoints`. Forward + backward lanes are added so the graph is traversable both ways.
- **`test_utils.rs`** — minimal 2-zone fixture whose only connectivity is a single inter-zone bus.
- **`test_zone_bus_search.py`** — FFI-level regression tests confirming `PathFinder` and the Rust `TargetSolver` agree on cross-zone routing in both directions.

## Why it's safe

Both the source and destination word sets of a `zone_bus` are validated as AOD-compatible rectangles at arch-build time (`ArchBuilder.connect`), so the entropy AOD-rectangle builder can treat zone buses exactly like intra-zone buses — a source sub-rectangle always maps to a valid destination sub-rectangle. No change to encoding or endpoint resolution was needed (`MoveType::ZoneBus` and cross-zone `lane_endpoints` already existed).

## Verification

- Issue repro: cross-zone move now `solved (nodes=1)` (was `unsolvable (nodes=0)`).
- New Rust unit test `zone_bus_edges_are_registered`: red → green.
- Search crate: 300 passed. bytecode + heuristics suites: 448 passed, 6 pre-existing skips.
- `cargo fmt` + `clippy -D warnings` clean; black/isort/ruff/pyright clean.
- No benchmark-baseline changes — no shipped arch has zone buses, so deterministic metrics are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)