### PR TITLE
fix: moved import in demo notebook

### DIFF
--- a/demo/physical_arch_customization.py
+++ b/demo/physical_arch_customization.py
@@ -33,9 +33,8 @@
 #
 # Import utilities to define the SQuIN kernel dialect that we will be writing our programs in.
 
-import itertools
-
 # %%
+import itertools
 import math
 from typing import Any, Literal, TypeVar
 


### PR DESCRIPTION
Tiny fix to move import to code cell (and not to markdown cell) due to linter change