### PR TITLE
fix(arch): emit shared-template zone-local word IDs from ArchBuilder

### DIFF
--- a/docs/superpowers/plans/2026-07-29-word-id-shared-template-fix.md
+++ b/docs/superpowers/plans/2026-07-29-word-id-shared-template-fix.md
@@ -1,6 +1,6 @@
 # Fix: builder must emit shared-template word IDs (LocationAddress convention)
 
-**Status:** planned (not started)
+**Status:** implemented — branch `fix/word-id-shared-template`, PR #849 (labeled `backport v0.11`). Python + Rust suites green.
 **Date:** 2026-07-29
 **Author:** Phillip Weinberg (with Claude)
 
@@ -185,3 +185,37 @@ templates, so validation is cheap and the public API is preserved.
   `_word_id_offsets` / `_total_words` usage is confined to the three `build/`
   files (`imperative.py`, `word_factory.py`, `blueprint.py`); nothing in
   `visualize/`, `analysis/`, or `heuristics/` references the offset machinery.
+
+## Implementation status (done — 2026-07-29)
+
+Implemented on branch `fix/word-id-shared-template` (PR #849, `backport v0.11`).
+Steps 1–4 and 6–7 landed as written; step 5 was intentionally skipped (see
+below). Deviations from the plan discovered during execution:
+
+- **"No bundled multi-zone specs" was wrong.** Two bundled architectures are
+  built through `build_arch` as genuine multi-zone specs: `generic_full`
+  (3 zones, 32-word template) and `gemini_full` (3 zones, 10-word template).
+  They are latent — imported only by their own tests, not by demos, notebooks,
+  benchmarks, or production — so word counts change from the concatenated
+  totals (96, 30) to the shared-template sizes (32, 10) with no downstream
+  blast radius. Their source docstrings were updated too.
+- **Test blast radius was 7 files, not 1.** Beyond `test_arch_builder.py`, the
+  offset convention was codified in `test_builder.py`, `test_topology.py`,
+  `test_word_factory.py`, `test_generic_full.py`, `test_gemini_full.py`, and
+  `layout/test_path.py`. `layout/test_path.py` needed a genuine rewrite (its
+  cross-zone "bare word-id union" check is meaningless under the shared
+  template; the zone-aware `get_lane_address(...) is None` assertion preserves
+  the real invariant).
+- **Step 5 skipped.** No Rust changes were made; the validator cannot
+  distinguish the two models, as documented above.
+- **`ArchBlueprint.total_words` removed.** It summed per-zone counts, which no
+  longer equals `len(ArchSpec.words)` under the shared template and had no
+  production consumer. `words_per_zone` (which now equals the template size) is
+  the correct accessor.
+- **`_compute_paths(zone_id, word_offset)` → `_compute_paths(zone_id)`.** The
+  `word_offset` parameter was dropped; lane addresses now carry zone-local
+  `word_id` for both SITE and WORD move types.
+
+Verification: `pytest python/tests` — all green (1815 passed at first full run,
+`total_words` cleanup applied after); `just test-rust` — 213 passed, 0 failed;
+black / isort / ruff / pyright clean.

--- a/docs/superpowers/plans/2026-07-29-word-id-shared-template-fix.md
+++ b/docs/superpowers/plans/2026-07-29-word-id-shared-template-fix.md
@@ -1,0 +1,187 @@
+# Fix: builder must emit shared-template word IDs (LocationAddress convention)
+
+**Status:** planned (not started)
+**Date:** 2026-07-29
+**Author:** Phillip Weinberg (with Claude)
+
+## Problem
+
+The zone-centric ArchSpec model has one correct convention for `word_id`, but
+the Python architecture *builder* implements a different, legacy one. They only
+coexist today because every bundled spec is single-zone (all offsets are 0).
+
+### The correct convention (LocationAddress / shared template)
+
+`words` is ONE global template list. `word_id` indexes it and is **reused
+identically by every zone** (each zone addresses `0..Nw-1`); `zone_id`
+disambiguates. A `LocationAddr` is `(zone_id, word_id, site_id)`.
+
+Evidence this is the intended model (all consumers already assume it):
+
+- Rust `Zone` struct has **no `words` field** — `crates/bloqade-lanes-bytecode-core/src/arch/types.rs:49-68`. Zones cannot own slicing.
+- `ArchSpec.words: Vec<Word>`, "A word's ID is its index in this list" — `types.rs:96`.
+- `Word.sites` are `[x_idx, y_idx]` index pairs into the **parent zone's grid** — `types.rs:40-43`. One template applied per-zone against each zone's own grid.
+- `query.rs:415-422` `location_position()` / `query.rs:199-201` `word_by_id()` resolve `self.words.get(loc.word_id)` **ignoring `zone_id`**.
+- `query.rs:366-377` `zone_location_index()` uses `wid * spw + sid` and bounds-checks against the single global `words.len()`.
+- `atom_state.rs:225`: *"In the zone-centric model, all zones share the same words."*
+- Rust test helper `make_valid_two_zone_spec()` (`validate.rs:522-583`) is a 2-zone spec with a **2-word global list** and a `zone_bus` whose dst is `(zone_id 1, word_id 0)` — a second zone re-addressing `word_id 0` against a 2-word template is only valid under the shared-template convention (concatenation would need 4 words).
+- Docs: `docs/src/arch/zone-centric-concepts.md` ("Words — The Shared Template", Invariant #5).
+
+### The legacy/buggy convention (offset / concatenation)
+
+The builder concatenates each zone's words into one flat list and **offsets
+`word_id` per zone** (zone 0 = `0..Nw0-1`, zone 1 = `Nw0..`). For a 2-zone,
+2-word device it emits `words=[W0,W1,W2,W3]` (4) with zone 1 owning IDs 2,3 —
+where the model wants `words=[W0,W1]` (2) with both zones addressing 0,1.
+
+Offending sites:
+
+- `python/bloqade/lanes/arch/build/imperative.py`
+  - `ArchBuilder._word_id_offsets` / `_total_words` (`:1066`, `:1071`)
+  - `add_zone()` accumulates offsets (`:1091-1092`)
+  - `build()` concatenates `all_words` (`:1200-1204`)
+  - `build()` applies `offset + w` to word_buses (`:1211-1219`),
+    `words_with_site_buses` (`:1224-1232`), `entangling_pairs` (`:1236-1238`),
+    zone_buses (`:1252-1263`), modes/`bitstring_order` (`:1266-1282`)
+  - `_compute_paths()` `global_word = word_offset + local_word` (`:968`, `:1034`)
+- `python/bloqade/lanes/arch/build/word_factory.py`
+  - `WordGrid.word_id_offset` field (`:32`), `word_id_at()` (`:38-40`),
+    `all_word_ids` (`:42-45`), `cz_pairs()` (`:47-51`)
+- `python/bloqade/lanes/arch/build/blueprint.py`
+  - `word_id_offset += zone_spec.num_words` accumulation (`:240`, `:248`)
+  - `w - offset` round-trip conversions (`:289-294`, `:298-303`, `:319-329`)
+
+### Why it's redundant (key investigation finding)
+
+The offset machinery is pure round-tripping and the shared template is already
+the de-facto reality:
+
+1. `ArchBlueprint.__post_init__` already **forces uniform grid dims** across
+   zones — `blueprint.py:137-141` ("All zones must have the same grid
+   dimensions").
+2. `create_zone_words()` output depends only on `num_rows/num_cols` + `layout`
+   + `word_id_offset` — so every zone's word slicing is **byte-for-byte
+   identical except for the added offset** (`word_factory.py:70-94`).
+3. Flow is local→global→local→global: `create_zone_words` stamps global IDs →
+   topology generators emit global via `word_id_at()`
+   (`topology.py:140,187,284`) → blueprint subtracts offset back to local
+   (`blueprint.py:289-329`) → `ArchBuilder.build()` re-adds it. Setting every
+   offset to 0 collapses the whole chain with **no behavioral change on
+   existing single-zone specs**.
+
+### Validator gap (and why Rust can't close it)
+
+`crates/.../arch/validate.rs` only bounds-checks referenced `word_id` against
+the **global** `words.len()` (`:196-210`, `:266-299`, `:367-403`) — which the
+concatenation model satisfies. Crucially, the Rust validator **structurally
+cannot** detect concatenation: `Zone` has no per-zone word count (no `words`
+field), so a concatenated 2-zone × Nw-word spec is indistinguishable from a
+legitimate `2*Nw`-word shared template where zone 0 uses `0..Nw-1` and zone 1
+uses `Nw..2Nw-1`. Both are valid ArchSpecs. Therefore the guard against
+re-entry cannot live in Rust — it must live on the **Python builder**
+(the identical-template check, step 2) plus the inverted tests.
+
+## Blast radius / current state
+
+- **No bundled multi-zone specs, and the builder is not even in the shipped
+  path.** Both bundled specs are single-zone AND JSON-loaded —
+  `gemini/physical/spec.py:25` and the logical spec both do
+  `_RustArchSpec.from_json(...)`, never `ArchBuilder`. So this is a latent
+  correctness fix, not a live-data migration, and shipped data provably cannot
+  shift.
+- **What actually breaks under a concatenated multi-zone spec.** The spec stays
+  a *valid* ArchSpec — `location_position`, `word_partner_map`, `word_zone_map`
+  all still run. The break is a **contract mismatch**: a consumer that addresses
+  zone-1 atoms with zone-local IDs (`0..Nw-1`), as the docs mandate, will miss on
+  `zone.words_with_site_buses.contains(&word_id)` (`query.rs:313`),
+  `sites_with_word_buses` (`:328`), and get wrong flat indices from
+  `zone_location_index`, because the builder wrote *global* IDs into those
+  per-zone lists. It is not a blanket "every consumer crashes."
+- **Tests currently codify the bug.** `python/tests/arch/test_arch_builder.py`:
+  - class `TestArchBuilderMultiZoneOffsets` (`:680-762`) asserts offset/global
+    IDs (`>= 4`, `len(words) == 8`).
+  - `test_multi_zone_with_connection` (`:541`) asserts `len(words) == 4`.
+  - `test_global_word_ids_assigned` (`:597`) asserts `len(words) == 4`.
+  These must **invert** to the shared-template contract.
+
+## Design decision
+
+Keep the per-zone `ZoneBuilder.add_word` API (minimal change) but make
+`ArchBuilder.build()` **validate that all zones declare an identical word
+template and emit that single `Nw`-length list with no offsets.** Chosen over
+"words at ArchBuilder level" because the blueprint already guarantees identical
+templates, so validation is cheap and the public API is preserved.
+
+## Implementation steps (TDD)
+
+1. **Red test** — add `TestArchBuilderSharedTemplate` to
+   `python/tests/arch/test_arch_builder.py` asserting:
+   - two zones with identical 4-word templates → `len(spec.words) == 4`
+   - zone 1 word_buses / entangling_pairs reference `0..Nw-1`
+   - both zones' word_buses are identical
+   - zone_bus src/dst word_ids are zone-local (`0..Nw-1`), disambiguated by zone_id
+   - mismatched templates across zones → `ValueError(match="same word template")`
+   (Draft already written in the working session; re-add it.)
+
+2. **`imperative.py` `ArchBuilder`**
+   - delete `_word_id_offsets`, `_total_words`; `add_zone()` stops tracking offsets
+   - in `build()`, validate every zone's `_words` equals zone 0's `_words`
+     (raise `ValueError("... same word template ...")` otherwise); emit that
+     single list as `all_words` (length `Nw`)
+   - drop every `offset + w` (word_buses, `words_with_site_buses`,
+     `entangling_pairs`, zone_buses, modes `bitstring_order`)
+   - `_compute_paths()` uses local `word_id` directly (drop `word_offset` param
+     / set to 0)
+
+3. **`word_factory.py`** — remove `WordGrid.word_id_offset`; `word_id_at`,
+   `all_word_ids`, `cz_pairs` return template-local IDs. Update signature of
+   `create_zone_words` (drop `word_id_offset`).
+   - **Public-API change:** `WordGrid` and `create_zone_words` are re-exported
+     from `arch/__init__.py` and `arch/build/__init__.py`, and `word_id_at` /
+     `all_word_ids` / `cz_pairs` change semantics global→local. Decide
+     explicitly: hard-remove (fine for pre-1.0 dev SDK — chosen here) vs. keep a
+     deprecated no-op `word_id_offset=0` param. Note the break in the commit body.
+
+4. **`blueprint.py`** — drop the `word_id_offset` accumulation (`:240,248`) and
+   the `w - offset` conversions (become identities). Confirm topology
+   generators now receive/emit template-local IDs consistently.
+
+5. **Rust validator** (`validate.rs`) — **no effective guard is possible here.**
+   The `word_id < words.len()` bound already exists (`:202-209`, `:282-297`) and
+   is exactly what concatenation passes; see "Validator gap" above for why Rust
+   can't distinguish the two models. Do NOT rely on a Rust check for regression
+   protection — the real guards are the builder's identical-template validation
+   (step 2) and the inverted tests (step 6). Optional: refresh the doc comment on
+   `zone_location_index` / `WordRef` to restate the zone-local contract, purely
+   as documentation.
+
+6. **Invert the offset tests** — rewrite `TestArchBuilderMultiZoneOffsets` →
+   shared-template assertions; fix `test_multi_zone_with_connection` and
+   `test_global_word_ids_assigned` (`len == 4` → `len == 2`). Flag each flipped
+   assertion in the commit body.
+
+7. **Verify** — `just test-python` + `just test-rust`. Benchmark metrics
+   **cannot** shift: the shipped specs are JSON-loaded (`from_json`), so
+   `ArchBuilder` produces none of the benchmarked data, and even for
+   builder-made single-zone specs every offset is already 0. Regenerating the
+   baselines is unnecessary; if `latest_physical.csv` / `latest_logical.csv` do
+   diff, treat it as a signal that something unexpected changed, not as a
+   routine baseline refresh.
+
+## Risks / watch-items
+
+- A caller using the **imperative `ArchBuilder` directly** with genuinely
+  different per-zone words would now get a `ValueError`. That's correct under
+  the model. **Grep done:** the only `ArchBuilder()` caller outside
+  `python/tests/` is `blueprint.py:308`, which always feeds identical templates
+  (uniform grid dims + deterministic `create_zone_words`), so no production
+  caller trips the new check.
+- Topology generators (`topology.py`) work in `word_id_at()` space; once
+  offsets are 0 they emit template-local IDs — double-check no generator does
+  independent offset math (the `s * d + offset` at `:238-252` is site-group
+  expansion, unrelated to zone word offsets).
+- `visualize/` or `analysis/` code that assumed concatenated global IDs for
+  multi-zone rendering. **Grep done:** every `word_id_offset` / `word_offset` /
+  `_word_id_offsets` / `_total_words` usage is confined to the three `build/`
+  files (`imperative.py`, `word_factory.py`, `blueprint.py`); nothing in
+  `visualize/`, `analysis/`, or `heuristics/` references the offset machinery.

--- a/docs/superpowers/plans/2026-07-29-word-id-shared-template-fix.md
+++ b/docs/superpowers/plans/2026-07-29-word-id-shared-template-fix.md
@@ -7,8 +7,13 @@
 ## Problem
 
 The zone-centric ArchSpec model has one correct convention for `word_id`, but
-the Python architecture *builder* implements a different, legacy one. They only
-coexist today because every bundled spec is single-zone (all offsets are 0).
+the Python architecture *builder* implements a different, legacy one. The bug
+stayed invisible because every zone reuses a byte-identical word template, so
+the per-zone offsets were pure round-tripping (see "Why it's redundant"). The
+bundled *multi-zone* builder specs (`generic_full`, `gemini_full`) **do** flow
+through the offset path with non-zero offsets, but their concatenated word
+counts were only ever asserted by their own tests; the shipped Gemini device
+specs are single-zone JSON (`from_json`) and never touch the builder at all.
 
 ### The correct convention (LocationAddress / shared template)
 

--- a/python/bloqade/lanes/arch/build/blueprint.py
+++ b/python/bloqade/lanes/arch/build/blueprint.py
@@ -111,8 +111,9 @@ class ArchBlueprint:
     """High-level architecture definition composed of named zones and layout.
 
     Zones are ordered by insertion order of the ``zones`` dict, which
-    determines word ID assignment (contiguous per zone) and vertical
-    layout (top to bottom).
+    determines ``zone_id`` assignment and vertical layout (top to bottom).
+    All zones share one word template addressed by zone-local word IDs
+    (``0..Nw-1``); ``zone_id`` disambiguates.
 
     Args:
         zones: Named zones with their specifications.
@@ -236,16 +237,10 @@ def build_arch(
             raise ValueError(f"Unknown zone '{zone_b}' in connection")
 
     # 1. Create word grids (preserves row/col structure for topology generators).
+    # Word IDs are zone-local (0..Nw-1) and shared identically across zones.
     zone_grids: dict[str, WordGrid] = {}
-    word_id_offset = 0
     for zone_name, zone_spec in blueprint.zones.items():
-        grid = create_zone_words(
-            zone_spec,
-            layout,
-            word_id_offset=word_id_offset,
-        )
-        zone_grids[zone_name] = grid
-        word_id_offset += zone_spec.num_words
+        zone_grids[zone_name] = create_zone_words(zone_spec, layout)
 
     # 2. Build ZoneBuilders from blueprint zones.
     zone_builders: dict[str, ZoneBuilder] = {}
@@ -283,23 +278,17 @@ def build_arch(
             ):
                 zone.add_site_bus(list(bus.src), list(bus.dst))
 
-        # Intra-zone word buses from topology.
+        # Intra-zone word buses from topology (already zone-local IDs).
         if zone_spec.word_topology is not None:
             for bus in zone_spec.word_topology.generate_word_buses(word_grid):
-                # Topology generators use global word IDs; convert to zone-local.
-                offset = word_grid.word_id_offset
-                zone.add_word_bus(
-                    src=[w - offset for w in bus.src],
-                    dst=[w - offset for w in bus.dst],
-                )
+                zone.add_word_bus(src=list(bus.src), dst=list(bus.dst))
 
-        # Entangling pairs.
+        # Entangling pairs (cz_pairs yields zone-local word IDs).
         if zone_spec.entangling:
-            offset = word_grid.word_id_offset
             pairs = list(word_grid.cz_pairs())
             zone.add_entangling_pairs(
-                [a - offset for a, _ in pairs],
-                [b - offset for _, b in pairs],
+                [a for a, _ in pairs],
+                [b for _, b in pairs],
             )
 
         zone_builders[zone_name] = zone
@@ -316,16 +305,12 @@ def build_arch(
     for (zone_a_name, zone_b_name), topology in connections.items():
         grid_a = zone_grids[zone_a_name]
         grid_b = zone_grids[zone_b_name]
-        offset_a = grid_a.word_id_offset
-        offset_b = grid_b.word_id_offset
 
         for bus in topology.generate_word_buses(grid_a, grid_b):
-            # Convert global word IDs to zone-local for connect().
-            src_local = [w - offset_a for w in bus.src]
-            dst_local = [w - offset_b for w in bus.dst]
+            # Topology generators already emit zone-local word IDs.
             arch_builder.connect(
-                src=(zone_a_name, src_local),
-                dst=(zone_b_name, dst_local),
+                src=(zone_a_name, list(bus.src)),
+                dst=(zone_b_name, list(bus.dst)),
             )
 
     # 5. Modes.

--- a/python/bloqade/lanes/arch/build/blueprint.py
+++ b/python/bloqade/lanes/arch/build/blueprint.py
@@ -143,13 +143,13 @@ class ArchBlueprint:
 
     @property
     def words_per_zone(self) -> int:
-        """Number of words per zone (all zones have equal grid dimensions)."""
-        return next(iter(self.zones.values())).num_words
+        """Number of words per zone (all zones have equal grid dimensions).
 
-    @property
-    def total_words(self) -> int:
-        """Total number of words across all zones."""
-        return sum(spec.num_words for spec in self.zones.values())
+        Under the shared-template convention this is also the size of the
+        single global word list (``len(ArchSpec.words)``): every zone reuses
+        the same ``0..Nw-1`` template.
+        """
+        return next(iter(self.zones.values())).num_words
 
     @property
     def zone_names(self) -> tuple[str, ...]:

--- a/python/bloqade/lanes/arch/build/imperative.py
+++ b/python/bloqade/lanes/arch/build/imperative.py
@@ -899,7 +899,7 @@ class ZoneBuilder:
         return tuple((w[0] / _NM_PER_UM, w[1] / _NM_PER_UM) for w in path_nm)
 
     def _compute_paths(
-        self, zone_id: int, word_offset: int
+        self, zone_id: int
     ) -> dict[LaneAddress, tuple[tuple[float, float], ...]]:
         """Compute axis-aligned AOD waypoint paths for all buses.
 
@@ -965,11 +965,10 @@ class ZoneBuilder:
                     lane_src = self._site_nm(local_word, src_s)
                     lane_path_nm = self._apply_deltas(lane_src, ref_waypoints)
                     lane_path = self._path_nm_to_um(lane_path_nm)
-                    global_word = word_offset + local_word
                     for direction in (Direction.FORWARD, Direction.BACKWARD):
                         lane = LaneAddress(
                             MoveType.SITE,
-                            global_word,
+                            local_word,
                             src_s,
                             bus_id,
                             direction,
@@ -1031,11 +1030,10 @@ class ZoneBuilder:
                     lane_src = self._site_nm(src_w, site_id)
                     lane_path_nm = self._apply_deltas(lane_src, ref_waypoints)
                     lane_path = self._path_nm_to_um(lane_path_nm)
-                    global_src = word_offset + src_w
                     for direction in (Direction.FORWARD, Direction.BACKWARD):
                         lane = LaneAddress(
                             MoveType.WORD,
-                            global_src,
+                            src_w,
                             site_id,
                             bus_id,
                             direction,
@@ -1056,25 +1054,27 @@ class ZoneBuilder:
 class ArchBuilder:
     """Compose ``ZoneBuilder``s into a complete ``ArchSpec``.
 
-    Each zone added gets assigned global word IDs. Inter-zone connections
-    go into ``zone_buses``. Calls Rust validation on ``build()``.
+    All zones share ONE word template: ``word_id`` is zone-local
+    (``0..Nw-1``) and reused identically by every zone, disambiguated by
+    ``zone_id`` (the LocationAddress convention). Inter-zone connections go
+    into ``zone_buses``. Calls Rust validation on ``build()``.
     """
 
     def __init__(self) -> None:
         self._zones: list[ZoneBuilder] = []
         self._zone_name_to_id: dict[str, int] = {}
-        self._word_id_offsets: list[int] = []
         self._connections: list[
             tuple[tuple[str, Sequence[int]], tuple[str, Sequence[int]]]
         ] = []
         self._modes: list[tuple[str, list[str]]] = []
-        self._total_words: int = 0
         self._blockade_radius: float | None = None
 
     def add_zone(self, zone: ZoneBuilder) -> int:
-        """Add a zone. Returns zone_id. Assigns global word IDs.
+        """Add a zone. Returns zone_id.
 
-        Validates that sites_per_word matches across all zones.
+        Validates that sites_per_word matches across all zones. The word
+        template itself is validated for cross-zone identity at
+        :meth:`build` time.
         """
         if zone.name in self._zone_name_to_id:
             raise ValueError(f"Duplicate zone name: '{zone.name}'")
@@ -1088,8 +1088,6 @@ class ArchBuilder:
                 )
         zone_id = len(self._zones)
         self._zone_name_to_id[zone.name] = zone_id
-        self._word_id_offsets.append(self._total_words)
-        self._total_words += zone.num_words
         self._zones.append(zone)
         return zone_id
 
@@ -1197,45 +1195,46 @@ class ArchBuilder:
         Raises:
             ValueError: If Rust validation fails.
         """
-        # 1. Collect all words with global IDs.
+        # 1. All zones share ONE word template (LocationAddress convention):
+        # word_id is zone-local (0..Nw-1) and reused identically by every
+        # zone; zone_id disambiguates. Validate that every zone declares the
+        # same template, then emit that single Nw-length list.
         all_words: list[Word] = []
-        for zone in self._zones:
-            for positions in zone._words:
-                all_words.append(Word(tuple(positions)))
+        if self._zones:
+            template = self._zones[0]._words
+            for zone in self._zones[1:]:
+                if zone._words != template:
+                    raise ValueError(
+                        f"zone '{zone.name}' declares a different word "
+                        f"template than zone '{self._zones[0].name}'; all "
+                        f"zones must share the same word template (word_id is "
+                        f"zone-local and reused identically across zones)."
+                    )
+            all_words = [Word(tuple(positions)) for positions in template]
 
         # 2. Build Rust Zone objects.
-        # Zone-local word IDs must be translated to global IDs for the Rust
-        # ArchSpec, which uses global word indices everywhere.
+        # Word IDs are zone-local (0..Nw-1): every zone addresses the same
+        # shared template, so no offset translation is applied. zone_id
+        # disambiguates identical word_ids across zones.
         rust_zones: list[_RustZone] = []
-        for zone_idx, zone in enumerate(self._zones):
-            offset = self._word_id_offsets[zone_idx]
+        for zone in self._zones:
             site_buses = [_RustSiteBus(src=s, dst=d) for s, d in zone._site_buses]
             word_buses = [
-                _RustWordBus(
-                    src=[offset + w for w in s],
-                    dst=[offset + w for w in d],
-                )
-                for s, d in zone._word_buses
+                _RustWordBus(src=list(s), dst=list(d)) for s, d in zone._word_buses
             ]
             # Only words flagged at add_word(has_site_bus=True) are
             # eligible for site-bus transport. Default is True, so the
             # historical "all words opt-in when any site bus exists"
             # behavior is preserved unless the caller overrides.
             words_with_site_buses = (
-                [
-                    offset + w
-                    for w in range(zone.num_words)
-                    if zone._word_has_site_bus[w]
-                ]
+                [w for w in range(zone.num_words) if zone._word_has_site_bus[w]]
                 if site_buses
                 else []
             )
             sites_with_word_buses = (
                 list(range(zone.sites_per_word)) if word_buses else []
             )
-            entangling_pairs = [
-                (offset + a, offset + b) for a, b in zone._entangling_pairs
-            ]
+            entangling_pairs = list(zone._entangling_pairs)
             rust_zones.append(
                 _RustZone(
                     name=zone.name,
@@ -1249,16 +1248,16 @@ class ArchBuilder:
             )
 
         # 3. Build zone_buses from connect() calls.
+        # word_ids stay zone-local; the (zone_id, word_id) pair addresses the
+        # shared template within each endpoint zone.
         zone_buses: list[_RustZoneBus] = []
         for (src_name, src_words), (dst_name, dst_words) in self._connections:
             src_zid = self._zone_name_to_id[src_name]
             dst_zid = self._zone_name_to_id[dst_name]
-            src_offset = self._word_id_offsets[src_zid]
-            dst_offset = self._word_id_offsets[dst_zid]
             zone_buses.append(
                 _RustZoneBus(
-                    src=[(src_zid, src_offset + w) for w in src_words],
-                    dst=[(dst_zid, dst_offset + w) for w in dst_words],
+                    src=[(src_zid, w) for w in src_words],
+                    dst=[(dst_zid, w) for w in dst_words],
                 )
             )
 
@@ -1268,11 +1267,10 @@ class ArchBuilder:
             zone_ids = [self._zone_name_to_id[z] for z in zone_names]
             bitstring_order: list[_RustLocAddr] = []
             for zid in zone_ids:
-                offset = self._word_id_offsets[zid]
                 zone = self._zones[zid]
                 for w in range(zone.num_words):
                     for s in range(zone.sites_per_word):
-                        bitstring_order.append(_RustLocAddr(zid, offset + w, s))
+                        bitstring_order.append(_RustLocAddr(zid, w, s))
             modes.append(
                 _RustMode(
                     name=mode_name,
@@ -1284,8 +1282,7 @@ class ArchBuilder:
         # 5. Compute AOD waypoint paths for site and word buses.
         all_paths: dict[LaneAddress, tuple[tuple[float, float], ...]] = {}
         for zone_idx, zone in enumerate(self._zones):
-            offset = self._word_id_offsets[zone_idx]
-            all_paths.update(zone._compute_paths(zone_idx, offset))
+            all_paths.update(zone._compute_paths(zone_idx))
 
         # 6. Determine the blockade radius to record on the ArchSpec.
         # Precedence: explicit build(blockade_radius=...) argument >

--- a/python/bloqade/lanes/arch/build/word_factory.py
+++ b/python/bloqade/lanes/arch/build/word_factory.py
@@ -58,8 +58,6 @@ class WordGrid:
 def create_zone_words(
     zone_spec: ZoneSpec,
     layout: DeviceLayout,
-    x_offset: float = 0.0,
-    y_offset: float = 0.0,
 ) -> WordGrid:
     """Create all words for a zone in a 2D grid layout.
 

--- a/python/bloqade/lanes/arch/build/word_factory.py
+++ b/python/bloqade/lanes/arch/build/word_factory.py
@@ -24,25 +24,29 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class WordGrid:
-    """2D grid of words within a zone, preserving row/col structure."""
+    """2D grid of words within a zone, preserving row/col structure.
+
+    Word IDs are zone-local (``0..Nw-1``) under the shared-template
+    convention: every zone reuses the same word IDs, disambiguated by
+    ``zone_id`` at the ArchSpec level.
+    """
 
     words: tuple[Word, ...]
     num_rows: int
     num_cols: int
-    word_id_offset: int
 
     def word_at(self, row: int, col: int) -> Word:
         """Get the word at a given grid position."""
         return self.words[row * self.num_cols + col]
 
     def word_id_at(self, row: int, col: int) -> int:
-        """Get the global word ID at a given grid position."""
-        return self.word_id_offset + row * self.num_cols + col
+        """Get the zone-local word ID at a given grid position."""
+        return row * self.num_cols + col
 
     @property
     def all_word_ids(self) -> range:
-        """All word IDs in this grid (contiguous range)."""
-        return range(self.word_id_offset, self.word_id_offset + len(self.words))
+        """All zone-local word IDs in this grid (``0..Nw-1``)."""
+        return range(len(self.words))
 
     def cz_pairs(self) -> Iterator[tuple[int, int]]:
         """Yield (word_id_a, word_id_b) for all CZ entangling pairs."""
@@ -56,7 +60,6 @@ def create_zone_words(
     layout: DeviceLayout,
     x_offset: float = 0.0,
     y_offset: float = 0.0,
-    word_id_offset: int = 0,
 ) -> WordGrid:
     """Create all words for a zone in a 2D grid layout.
 
@@ -90,5 +93,4 @@ def create_zone_words(
         words=tuple(words),
         num_rows=zone_spec.num_rows,
         num_cols=zone_spec.num_cols,
-        word_id_offset=word_id_offset,
     )

--- a/python/bloqade/lanes/arch/gemini_full/spec.py
+++ b/python/bloqade/lanes/arch/gemini_full/spec.py
@@ -1,8 +1,10 @@
 """Gemini full architecture: 3-zone neutral atom processor.
 
 Layout: storage_top → entangling → storage_bottom.
-Each zone has 5 rows x 2 columns = 10 words, with 17 sites per word.
-Total: 30 words, 510 sites, 5 entangling pairs (85 CZ locations).
+Each zone has 5 rows x 2 columns = 10 words, with 17 sites per word. All
+zones share ONE 10-word template (170 template sites) addressed by
+zone-local word IDs; ``zone_id`` disambiguates. The entangling zone
+declares 5 entangling pairs (85 CZ locations).
 """
 
 from __future__ import annotations

--- a/python/bloqade/lanes/arch/generic_full/spec.py
+++ b/python/bloqade/lanes/arch/generic_full/spec.py
@@ -1,8 +1,10 @@
 """Generic full architecture: 3-zone neutral atom processor.
 
 Layout: storage_top → entangling → storage_bottom.
-Each zone has 8 rows x 4 columns = 32 words, with 8 sites per word.
-Total: 96 words, 768 sites, 16 entangling pairs.
+Each zone has 8 rows x 4 columns = 32 words, with 8 sites per word. All
+zones share ONE 32-word template (256 template sites) addressed by
+zone-local word IDs; ``zone_id`` disambiguates. The entangling zone
+declares 16 entangling pairs.
 
 All zones have full site (hypercube) and word (diagonal) connectivity.
 """

--- a/python/tests/arch/test_arch_builder.py
+++ b/python/tests/arch/test_arch_builder.py
@@ -538,7 +538,8 @@ class TestArchBuilder:
         arch.add_mode("all", ["proc", "mem"])
         spec = arch.build()
         assert len(spec.zones) == 2
-        assert len(spec.words) == 4
+        # Shared template: both zones reuse the same 2-word list.
+        assert len(spec.words) == 2
         assert len(spec.zone_buses) == 1
 
     def test_unknown_zone_in_connect_raises(self):
@@ -569,7 +570,7 @@ class TestArchBuilder:
         with pytest.raises(ValueError, match="Unknown zone"):
             arch.add_mode("test", ["missing"])
 
-    def test_global_word_ids_assigned(self):
+    def test_shared_template_word_ids_assigned(self):
         z1 = ZoneBuilder(
             "a",
             _make_grid(4, 1),
@@ -594,7 +595,8 @@ class TestArchBuilder:
         arch.add_zone(z2)
         arch.add_mode("all", ["a", "b"])
         spec = arch.build()
-        assert len(spec.words) == 4
+        # Both zones share ONE 2-word template addressed as 0..1.
+        assert len(spec.words) == 2
 
     def test_entangling_pairs_in_single_zone(self):
         zone = ZoneBuilder(
@@ -677,8 +679,18 @@ class TestArchBuilder:
         assert spec is not None
 
 
-class TestArchBuilderMultiZoneOffsets:
-    """Verify global word ID translation for second+ zones."""
+class TestArchBuilderSharedTemplate:
+    """Zones share ONE word template; word_id is zone-local (0..Nw-1).
+
+    This is the LocationAddress convention the Rust model and docs assume:
+    ``words`` is a single global template addressed by every zone as
+    ``0..Nw-1``, disambiguated by ``zone_id``.  See
+    ``docs/superpowers/plans/2026-07-29-word-id-shared-template-fix.md``.
+    """
+
+    @staticmethod
+    def _bus_pairs(zone) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+        return [(tuple(b.src), tuple(b.dst)) for b in zone.word_buses]
 
     def _make_two_zone_arch(self):
         proc = ZoneBuilder(
@@ -703,6 +715,7 @@ class TestArchBuilderMultiZoneOffsets:
             x_clearance=_DEFAULT_CL,
             y_clearance=_DEFAULT_CL,
         )
+        # Identical word template to proc (same slices / grid indices).
         mem.add_word(slice(0, 2), [0])
         mem.add_word(slice(2, 4), [0])
         mem.add_word(slice(0, 2), [1])
@@ -717,49 +730,85 @@ class TestArchBuilderMultiZoneOffsets:
         arch.add_mode("all", ["proc", "mem"])
         return arch.build()
 
-    def test_second_zone_word_buses_use_global_ids(self):
+    def test_single_shared_word_template(self):
+        """Two zones with an identical 4-word template → ONE 4-word list."""
         spec = self._make_two_zone_arch()
-        # proc is zone 0 (words 0-3), mem is zone 1 (words 4-7)
-        mem_zone = spec.zones[1]
-        for bus in mem_zone.word_buses:
-            for w in bus.src:
-                assert w >= 4, f"mem word bus src {w} should be >= 4 (global)"
-            for w in bus.dst:
-                assert w >= 4, f"mem word bus dst {w} should be >= 4 (global)"
+        assert len(spec.words) == 4
+        assert len(spec.zones) == 2
 
-    def test_second_zone_entangling_pairs_use_global_ids(self):
+    def test_word_buses_are_zone_local(self):
         spec = self._make_two_zone_arch()
-        mem_zone = spec.zones[1]
-        for a, b in mem_zone.entangling_pairs:
-            assert a >= 4, f"mem entangling pair word {a} should be >= 4"
-            assert b >= 4, f"mem entangling pair word {b} should be >= 4"
+        for zone in spec.zones:
+            for bus in zone.word_buses:
+                for w in list(bus.src) + list(bus.dst):
+                    assert 0 <= w < 4, f"word bus id {w} must be zone-local (0..3)"
 
-    def test_second_zone_words_with_site_buses_use_global_ids(self):
+    def test_both_zones_word_buses_identical(self):
+        """Shared template ⇒ every zone's word_buses reference the same IDs."""
         spec = self._make_two_zone_arch()
-        # proc zone has site buses → words_with_site_buses should be [0,1,2,3]
-        assert all(w < 4 for w in spec.zones[0].words_with_site_buses)
-        # mem zone has no site buses → empty
-        assert spec.zones[1].words_with_site_buses == []
+        assert self._bus_pairs(spec.zones[0]) == self._bus_pairs(spec.zones[1])
 
-    def test_zone_bus_tuples_correct(self):
+    def test_entangling_pairs_are_zone_local(self):
+        spec = self._make_two_zone_arch()
+        for zone in spec.zones:
+            for a, b in zone.entangling_pairs:
+                assert 0 <= a < 4
+                assert 0 <= b < 4
+
+    def test_zone_bus_word_ids_are_zone_local(self):
         spec = self._make_two_zone_arch()
         assert len(spec.zone_buses) == 1
         zb = spec.zone_buses[0]
-        # src should be zone 0, words 0-3
         for zone_id, word_id in zb.src:
             assert zone_id == 0
             assert 0 <= word_id < 4
-        # dst should be zone 1, words 4-7
         for zone_id, word_id in zb.dst:
             assert zone_id == 1
-            assert 4 <= word_id < 8
+            # zone-local under the shared template, NOT global 4..7
+            assert 0 <= word_id < 4
+
+    def test_words_with_site_buses_are_zone_local(self):
+        spec = self._make_two_zone_arch()
+        # proc has a site bus → all four template words opt in (zone-local).
+        assert spec.zones[0].words_with_site_buses == [0, 1, 2, 3]
+        # mem has no site bus → empty.
+        assert spec.zones[1].words_with_site_buses == []
 
     def test_rust_validation_passes_multi_zone(self):
-        """Multi-zone with buses and entangling pairs on both zones passes Rust validation."""
         spec = self._make_two_zone_arch()
         assert spec is not None
         assert len(spec.zones) == 2
-        assert len(spec.words) == 8
+        assert len(spec.words) == 4
+
+    def test_mismatched_templates_raise(self):
+        """Zones declaring different word templates are rejected at build()."""
+        proc = ZoneBuilder(
+            "proc",
+            _make_grid(4, 2),
+            word_shape=(2, 1),
+            x_clearance=_DEFAULT_CL,
+            y_clearance=_DEFAULT_CL,
+        )
+        proc.add_word(slice(0, 2), [0])
+        proc.add_word(slice(2, 4), [0])
+
+        mem = ZoneBuilder(
+            "mem",
+            _make_grid(4, 2, y_offset=10.0),
+            word_shape=(2, 1),
+            x_clearance=_DEFAULT_CL,
+            y_clearance=_DEFAULT_CL,
+        )
+        # Different template: second word occupies a different grid region.
+        mem.add_word(slice(0, 2), [0])
+        mem.add_word(slice(0, 2), [1])
+
+        arch = ArchBuilder()
+        arch.add_zone(proc)
+        arch.add_zone(mem)
+        arch.add_mode("all", ["proc", "mem"])
+        with pytest.raises(ValueError, match="same word template"):
+            arch.build()
 
 
 class TestBuilderEdgeCases:
@@ -933,7 +982,7 @@ class TestInconsistentBusDisplacement:
         zone.add_word_bus(src=[0, 2], dst=[1, 5])
 
         with pytest.warns(UserWarning, match="inconsistent word displacements"):
-            paths = zone._compute_paths(zone_id=0, word_offset=0)
+            paths = zone._compute_paths(zone_id=0)
 
         assert not any(k.move_type == MoveType.WORD for k in paths)
 
@@ -960,7 +1009,7 @@ class TestSearchFailureWarning:
 
         with _w.catch_warnings(record=True) as w:
             _w.simplefilter("always")
-            paths = zone._compute_paths(zone_id=0, word_offset=0)
+            paths = zone._compute_paths(zone_id=0)
             # Either warning fires (search failed) or paths found
             if any("no valid path" in str(warning.message) for warning in w):
                 assert not any(k.move_type == MoveType.WORD for k in paths)
@@ -996,50 +1045,52 @@ class TestComputePaths:
 
     def test_site_bus_forward_path(self):
         zone = self._make_zone_with_site_bus()
-        paths = zone._compute_paths(zone_id=0, word_offset=0)
+        paths = zone._compute_paths(zone_id=0)
         lane = LaneAddress(MoveType.SITE, 0, 0, 0, Direction.FORWARD, 0)
         assert lane in paths
         assert paths[lane] == ((0.0, 0.0), (10.0, 0.0))
 
     def test_site_bus_backward_is_reversed(self):
         zone = self._make_zone_with_site_bus()
-        paths = zone._compute_paths(zone_id=0, word_offset=0)
+        paths = zone._compute_paths(zone_id=0)
         fwd = LaneAddress(MoveType.SITE, 0, 0, 0, Direction.FORWARD, 0)
         bwd = LaneAddress(MoveType.SITE, 0, 0, 0, Direction.BACKWARD, 0)
         assert paths[bwd] == paths[fwd][::-1]
 
     def test_site_bus_applies_to_all_words(self):
         zone = self._make_zone_with_site_bus()
-        paths = zone._compute_paths(zone_id=0, word_offset=0)
+        paths = zone._compute_paths(zone_id=0)
         lane = LaneAddress(MoveType.SITE, 1, 0, 0, Direction.FORWARD, 0)
         assert lane in paths
         assert paths[lane] == ((20.0, 0.0), (30.0, 0.0))
 
     def test_word_bus_forward_path(self):
         zone = self._make_zone_with_word_bus()
-        paths = zone._compute_paths(zone_id=0, word_offset=0)
+        paths = zone._compute_paths(zone_id=0)
         lane = LaneAddress(MoveType.WORD, 0, 0, 0, Direction.FORWARD, 0)
         assert lane in paths
         assert paths[lane] == ((0.0, 0.0), (0.0, 20.0))
 
     def test_word_bus_backward_is_reversed(self):
         zone = self._make_zone_with_word_bus()
-        paths = zone._compute_paths(zone_id=0, word_offset=0)
+        paths = zone._compute_paths(zone_id=0)
         fwd = LaneAddress(MoveType.WORD, 0, 0, 0, Direction.FORWARD, 0)
         bwd = LaneAddress(MoveType.WORD, 0, 0, 0, Direction.BACKWARD, 0)
         assert paths[bwd] == paths[fwd][::-1]
 
     def test_word_bus_all_sites_get_paths(self):
         zone = self._make_zone_with_word_bus()
-        paths = zone._compute_paths(zone_id=0, word_offset=0)
+        paths = zone._compute_paths(zone_id=0)
         for site_id in range(2):
             lane = LaneAddress(MoveType.WORD, 0, site_id, 0, Direction.FORWARD, 0)
             assert lane in paths
 
-    def test_word_offset_applied(self):
+    def test_paths_use_zone_local_word_ids(self):
+        # Word IDs in lane addresses are zone-local (0..Nw-1); zone_id
+        # disambiguates. No per-zone offset is applied.
         zone = self._make_zone_with_site_bus()
-        paths = zone._compute_paths(zone_id=1, word_offset=4)
-        lane = LaneAddress(MoveType.SITE, 4, 0, 0, Direction.FORWARD, 1)
+        paths = zone._compute_paths(zone_id=1)
+        lane = LaneAddress(MoveType.SITE, 0, 0, 0, Direction.FORWARD, 1)
         assert lane in paths
 
     def test_no_buses_returns_empty(self):
@@ -1048,7 +1099,7 @@ class TestComputePaths:
             "z", grid, word_shape=(2, 1), x_clearance=5.0, y_clearance=5.0
         )
         zone.add_word(slice(0, 2), [0])
-        paths = zone._compute_paths(zone_id=0, word_offset=0)
+        paths = zone._compute_paths(zone_id=0)
         assert paths == {}
 
     def test_cross_column_word_bus_uses_clearance(self):
@@ -1059,7 +1110,7 @@ class TestComputePaths:
         zone.add_word(slice(0, 2), [0])
         zone.add_word(slice(2, 4), [0])
         zone.add_word_bus(src=[0], dst=[1])
-        paths = zone._compute_paths(zone_id=0, word_offset=0)
+        paths = zone._compute_paths(zone_id=0)
         lane = LaneAddress(MoveType.WORD, 0, 0, 0, Direction.FORWARD, 0)
         path = paths[lane]
         # col_diff=2 > 1 → routing via y-clearance
@@ -1076,7 +1127,7 @@ class TestComputePaths:
         zone.add_word(slice(0, 2), [1])
         zone.add_word(slice(2, 4), [1])
         zone.add_word_bus(src=[0, 1], dst=[2, 3])
-        paths = zone._compute_paths(zone_id=0, word_offset=0)
+        paths = zone._compute_paths(zone_id=0)
         lane = LaneAddress(MoveType.WORD, 0, 0, 0, Direction.FORWARD, 0)
         # col_diff=0, row_diff=1 → straight
         assert paths[lane] == ((0.0, 0.0), (0.0, 20.0))
@@ -1127,7 +1178,7 @@ class TestArchBuilderPaths:
         path = spec.get_path(lane)
         assert path == ((0.0, 0.0), (10.0, 0.0))
 
-    def test_multi_zone_paths_use_correct_offsets(self):
+    def test_multi_zone_paths_use_zone_local_ids(self):
         proc = ZoneBuilder(
             "proc",
             _make_spaced_grid(4, 1, x_spacing=10.0),
@@ -1157,10 +1208,12 @@ class TestArchBuilderPaths:
         arch.add_mode("all", ["proc", "mem"])
         spec = arch.build()
 
-        lane0 = LaneAddress(MoveType.SITE, 0, 0, 0, Direction.FORWARD, 0)
-        assert lane0 in spec.paths
-        lane2 = LaneAddress(MoveType.SITE, 2, 0, 0, Direction.FORWARD, 1)
-        assert lane2 in spec.paths
+        # Both zones' site-bus lanes address zone-local word 0; only the
+        # zone_id differs (shared template).
+        lane_proc = LaneAddress(MoveType.SITE, 0, 0, 0, Direction.FORWARD, 0)
+        assert lane_proc in spec.paths
+        lane_mem = LaneAddress(MoveType.SITE, 0, 0, 0, Direction.FORWARD, 1)
+        assert lane_mem in spec.paths
 
     def test_no_buses_no_paths(self):
         zone = ZoneBuilder(

--- a/python/tests/arch/test_builder.py
+++ b/python/tests/arch/test_builder.py
@@ -95,7 +95,9 @@ class TestBuildArchTwoZones:
     def test_two_zones_no_connection(self) -> None:
         bp = _two_zone_blueprint()
         result = build_arch(bp)
-        assert len(result.arch.words) == 8  # 4 + 4
+        # Shared word template: both zones reuse the SAME 4-word list
+        # (zone-local IDs 0..3), so the global list has 4 entries, not 8.
+        assert len(result.arch.words) == 4
         assert result.zone_indices == {"proc": 0, "mem": 1}
         # Only proc has word topology → 2 word buses (1 zone, no split)
         assert len(result.arch.word_buses) == 2
@@ -118,8 +120,8 @@ class TestBuildArchTwoZones:
         result = build_arch(bp)
         proc_grid = result.zone_grids["proc"]
         mem_grid = result.zone_grids["mem"]
-        assert proc_grid.word_id_offset == 0
-        assert mem_grid.word_id_offset == 4
+        # Shared template: both zones expose the same zone-local word IDs.
+        assert list(proc_grid.all_word_ids) == list(mem_grid.all_word_ids)
         assert proc_grid.num_rows == 2
         assert mem_grid.num_rows == 2
 
@@ -182,7 +184,8 @@ class TestBuildArchThreeZones:
                 ("buffer", "mem"): MatchingTopology(),
             },
         )
-        assert len(result.arch.words) == 12
+        # Shared template: 3 zones reuse the SAME 4-word list (2x2).
+        assert len(result.arch.words) == 4
         # 1:1 mapping: proc=0, buffer=1, mem=2
         assert result.zone_indices == {"proc": 0, "buffer": 1, "mem": 2}
         # Proc: 2 hypercube word buses (no split)
@@ -275,13 +278,12 @@ class TestBuildArchPerBusWords:
         # AllToAll(4 sites) = 6 buses for mem → 8 total
         assert len(arch.site_buses) == 8
 
-        # Proc is zone 0 with words [0, 1], mem is zone 1 with words [2, 3]
-        # words_with_site_buses uses global IDs
+        # Shared template: both zones address zone-local words [0, 1].
         assert arch.zones[0].words_with_site_buses == [0, 1]
-        assert arch.zones[1].words_with_site_buses == [2, 3]
+        assert arch.zones[1].words_with_site_buses == [0, 1]
 
-        # has_site_buses = union across zones (global IDs)
-        assert _has_site_buses(arch) == frozenset({0, 1, 2, 3})
+        # Union across zones collapses to the shared zone-local IDs.
+        assert _has_site_buses(arch) == frozenset({0, 1})
 
     def test_single_zone_site_buses_have_words(self) -> None:
         """Single zone with site topology → all words have site buses."""
@@ -379,13 +381,15 @@ class TestPathFinderIntegration:
         )
         pf = PathFinder(result.arch)
 
-        # proc word 0 (zone 0) → mem word 2 (zone 1, same site): reachable via zone bus
+        # proc word 0 (zone 0) → mem word 0 (zone 1, same zone-local ID and
+        # site): reachable via the matching zone bus. Under the shared
+        # template the destination word_id is zone-local (0), not global (2).
         proc_zone_id = result.zone_indices["proc"]
         mem_zone_id = result.zone_indices["mem"]
         assert (
             pf.find_path(
                 LocationAddress(0, 0, proc_zone_id),
-                LocationAddress(2, 0, mem_zone_id),
+                LocationAddress(0, 0, mem_zone_id),
             )
             is not None
         )

--- a/python/tests/arch/test_gemini_full.py
+++ b/python/tests/arch/test_gemini_full.py
@@ -71,11 +71,14 @@ def gemini_full():
 
 class TestGeminiFull:
     def test_word_count(self, gemini_full):
-        assert len(gemini_full.arch.words) == 30
+        # Shared template: all 3 zones reuse ONE 10-word list (5 rows x 2
+        # cols), addressed zone-locally.
+        assert len(gemini_full.arch.words) == 10
 
     def test_site_count(self, gemini_full):
+        # Template sites: 10 words x 17 sites.
         total_sites = sum(len(w.sites) for w in gemini_full.arch.words)
-        assert total_sites == 510
+        assert total_sites == 170
 
     def test_zone_count(self, gemini_full):
         assert len(gemini_full.arch.zones) == 3

--- a/python/tests/arch/test_generic_full.py
+++ b/python/tests/arch/test_generic_full.py
@@ -38,8 +38,9 @@ class TestDiagonalWordTopologyMultiColumn:
         topo = DiagonalWordTopology()
         buses = topo.generate_word_buses(grid)
         for bus in buses:
-            src_cols = {(w - grid.word_id_offset) % 4 for w in bus.src}
-            dst_cols = {(w - grid.word_id_offset) % 4 for w in bus.dst}
+            # Word IDs are zone-local (0..Nw-1); column = id % num_cols.
+            src_cols = {w % 4 for w in bus.src}
+            dst_cols = {w % 4 for w in bus.dst}
             # src and dst should each be from a single column
             assert len(src_cols) == 1
             assert len(dst_cols) == 1
@@ -58,11 +59,14 @@ def generic_full():
 
 class TestGenericFull:
     def test_word_count(self, generic_full):
-        assert len(generic_full.arch.words) == 96
+        # Shared template: all 3 zones reuse ONE 32-word list (8 rows x 4
+        # cols), addressed zone-locally.
+        assert len(generic_full.arch.words) == 32
 
     def test_site_count(self, generic_full):
+        # Template sites: 32 words x 8 sites.
         total_sites = sum(len(w.sites) for w in generic_full.arch.words)
-        assert total_sites == 768
+        assert total_sites == 256
 
     def test_zone_count(self, generic_full):
         assert len(generic_full.arch.zones) == 3

--- a/python/tests/arch/test_topology.py
+++ b/python/tests/arch/test_topology.py
@@ -12,12 +12,10 @@ from bloqade.lanes.arch.build.topology import (
 from bloqade.lanes.arch.build.word_factory import WordGrid, create_zone_words
 
 
-def _make_grid(
-    num_rows: int = 2, num_cols: int = 4, word_id_offset: int = 0
-) -> WordGrid:
+def _make_grid(num_rows: int = 2, num_cols: int = 4) -> WordGrid:
     spec = ZoneSpec(num_rows=num_rows, num_cols=num_cols, entangling=True)
     layout = DeviceLayout(sites_per_word=4)
-    return create_zone_words(spec, layout, word_id_offset=word_id_offset)
+    return create_zone_words(spec, layout)
 
 
 # ── Site topologies ──
@@ -132,20 +130,21 @@ class TestHypercubeWordTopology:
         assert col_bus.src == [grid.word_id_at(0, 0), grid.word_id_at(1, 0)]
         assert col_bus.dst == [grid.word_id_at(0, 1), grid.word_id_at(1, 1)]
 
-    def test_word_id_offset(self) -> None:
-        grid = _make_grid(num_rows=2, num_cols=2, word_id_offset=10)
+    def test_word_ids_are_zone_local(self) -> None:
+        grid = _make_grid(num_rows=2, num_cols=2)
         topo = HypercubeWordTopology()
         buses = topo.generate_word_buses(grid)
         all_ids = set()
         for bus in buses:
             all_ids.update(bus.src)
             all_ids.update(bus.dst)
-        assert all_ids == {10, 11, 12, 13}
+        # Zone-local IDs 0..Nw-1 (shared template; no per-zone offset).
+        assert all_ids == {0, 1, 2, 3}
 
     def test_non_power_of_two_rows_raises(self) -> None:
         grid = _make_grid(num_rows=2, num_cols=4)
         # Hack the grid to have 3 rows
-        bad_grid = WordGrid(words=grid.words, num_rows=3, num_cols=4, word_id_offset=0)
+        bad_grid = WordGrid(words=grid.words, num_rows=3, num_cols=4)
         topo = HypercubeWordTopology()
         with pytest.raises(ValueError, match="power of 2"):
             topo.generate_word_buses(bad_grid)
@@ -156,8 +155,8 @@ class TestHypercubeWordTopology:
 
 class TestMatchingTopology:
     def test_1_to_1_matching(self) -> None:
-        grid_a = _make_grid(num_rows=2, num_cols=2, word_id_offset=0)
-        grid_b = _make_grid(num_rows=2, num_cols=2, word_id_offset=4)
+        grid_a = _make_grid(num_rows=2, num_cols=2)
+        grid_b = _make_grid(num_rows=2, num_cols=2)
         topo = MatchingTopology()
         buses = topo.generate_word_buses(grid_a, grid_b)
         assert len(buses) == 1
@@ -172,8 +171,8 @@ class TestMatchingTopology:
                 assert bus.dst[idx] == grid_b.word_id_at(r, c)
 
     def test_mismatched_dimensions_raises(self) -> None:
-        grid_a = _make_grid(num_rows=2, num_cols=2, word_id_offset=0)
-        grid_b = _make_grid(num_rows=2, num_cols=4, word_id_offset=4)
+        grid_a = _make_grid(num_rows=2, num_cols=2)
+        grid_b = _make_grid(num_rows=2, num_cols=4)
         topo = MatchingTopology()
         with pytest.raises(ValueError, match="Grid dimensions must match"):
             topo.generate_word_buses(grid_a, grid_b)

--- a/python/tests/arch/test_word_factory.py
+++ b/python/tests/arch/test_word_factory.py
@@ -6,24 +6,24 @@ from bloqade.lanes.arch.build.word_factory import WordGrid, create_zone_words
 
 class TestWordGrid:
     def _make_grid(self) -> WordGrid:
-        """Create a 2x4 entangling grid with offset 10."""
+        """Create a 2x4 entangling grid with zone-local word IDs."""
         spec = ZoneSpec(num_rows=2, num_cols=4, entangling=True)
         layout = DeviceLayout(sites_per_word=3)
-        return create_zone_words(spec, layout, word_id_offset=10)
+        return create_zone_words(spec, layout)
 
     def test_word_count(self) -> None:
         grid = self._make_grid()
         assert len(grid.words) == 8
         assert grid.num_rows == 2
         assert grid.num_cols == 4
-        assert grid.word_id_offset == 10
 
     def test_word_id_at(self) -> None:
+        # Word IDs are zone-local (0..Nw-1) under the shared template.
         grid = self._make_grid()
-        assert grid.word_id_at(0, 0) == 10
-        assert grid.word_id_at(0, 3) == 13
-        assert grid.word_id_at(1, 0) == 14
-        assert grid.word_id_at(1, 3) == 17
+        assert grid.word_id_at(0, 0) == 0
+        assert grid.word_id_at(0, 3) == 3
+        assert grid.word_id_at(1, 0) == 4
+        assert grid.word_id_at(1, 3) == 7
 
     def test_word_at_has_correct_sites(self) -> None:
         grid = self._make_grid()
@@ -35,14 +35,14 @@ class TestWordGrid:
     def test_cz_pairs(self) -> None:
         grid = self._make_grid()
         pairs = list(grid.cz_pairs())
-        assert pairs == [(10, 11), (12, 13), (14, 15), (16, 17)]
+        assert pairs == [(0, 1), (2, 3), (4, 5), (6, 7)]
 
 
 class TestCreateZoneWords:
     def test_entangling_zone_cz_pairing(self) -> None:
         spec = ZoneSpec(num_rows=1, num_cols=2, entangling=True)
         layout = DeviceLayout(sites_per_word=3)
-        grid = create_zone_words(spec, layout, word_id_offset=0)
+        grid = create_zone_words(spec, layout)
 
         assert len(grid.words) == 2
         # CZ pairing is now at the architecture level via cz_pairs()
@@ -65,12 +65,3 @@ class TestCreateZoneWords:
 
         for word in grid.words:
             assert len(word.site_indices) == 5
-
-    def test_word_id_offset_in_cz(self) -> None:
-        spec = ZoneSpec(num_rows=1, num_cols=2, entangling=True)
-        layout = DeviceLayout(sites_per_word=3)
-        grid = create_zone_words(spec, layout, word_id_offset=10)
-
-        # CZ pairing uses word IDs with offset
-        pairs = list(grid.cz_pairs())
-        assert pairs == [(10, 11)]

--- a/python/tests/arch/test_zone.py
+++ b/python/tests/arch/test_zone.py
@@ -75,7 +75,6 @@ class TestArchBlueprint:
             zones={"proc": ZoneSpec(num_rows=2, num_cols=4, entangling=True)}
         )
         assert bp.words_per_zone == 8
-        assert bp.total_words == 8
         assert bp.zone_names == ("proc",)
 
     def test_valid_two_zones(self) -> None:
@@ -85,8 +84,8 @@ class TestArchBlueprint:
                 "mem": ZoneSpec(num_rows=2, num_cols=4),
             }
         )
+        # Shared template: all zones reuse ONE 8-word list.
         assert bp.words_per_zone == 8
-        assert bp.total_words == 16
         assert bp.zone_names == ("proc", "mem")
 
     def test_valid_three_zones(self) -> None:
@@ -97,7 +96,8 @@ class TestArchBlueprint:
                 "mem": ZoneSpec(num_rows=2, num_cols=4),
             }
         )
-        assert bp.total_words == 24
+        # Shared template: 3 zones reuse ONE 8-word list.
+        assert bp.words_per_zone == 8
         assert bp.zone_names == ("proc", "buffer", "mem")
 
     def test_empty_zones_raises(self) -> None:

--- a/python/tests/layout/test_path.py
+++ b/python/tests/layout/test_path.py
@@ -210,13 +210,14 @@ def test_find_path_respects_per_bus_word_scoping():
     result = build_arch(bp, connections={("a", "b"): MatchingTopology()})
     arch = result.arch
 
-    # Zone B words should not have site bus moves
+    # Zone B has no site topology, so its OWN words_with_site_buses must be
+    # empty. Under the shared template, word IDs are zone-local and reused
+    # across zones, so site-bus scoping is only meaningful per zone — a bare
+    # union of word IDs across zones can no longer distinguish "zone A word 0"
+    # from "zone B word 0".
+    b_zone_id = result.zone_indices["b"]
+    assert arch.zones[b_zone_id].words_with_site_buses == []
     zone_b_words = set(result.zone_grids["b"].all_word_ids)
-    all_site_bus_words = frozenset(
-        w for z in arch.zones for w in z.words_with_site_buses
-    )
-    for word_id in zone_b_words:
-        assert word_id not in all_site_bus_words
 
     # Attempting an intra-word site move in zone B should fail (no site bus)
     b_word = min(zone_b_words)


### PR DESCRIPTION
## Problem

The zone-centric ArchSpec model treats `words` as **one global template** addressed identically by every zone — `word_id` is zone-local (`0..Nw-1`) and `zone_id` disambiguates (the `LocationAddress` convention the Rust consumers and `docs/src/arch/zone-centric-concepts.md` already assume). The Python `ArchBuilder`/`build_arch` instead **concatenated** each zone's words and **offset `word_id` per zone** (zone 0 = `0..Nw0-1`, zone 1 = `Nw0..`), producing a non-canonical spec. It only coincided with the model because every zone reuses an identical template, so the offsets were pure round-tripping (local→global→local→global).

## Fix

- `ArchBuilder.build()` now validates that **all zones declare an identical word template** and emits that single `Nw`-length list — mismatched templates raise `ValueError("... same word template ...")`.
- Removed the offset machinery from `ArchBuilder` (`_word_id_offsets`/`_total_words`), `WordGrid`/`create_zone_words` (`word_id_offset`), and `build_arch` (the `w - offset` round-trips).
- `word_buses`, `entangling_pairs`, `zone_buses`, `modes.bitstring_order`, and AOD `paths` now carry **zone-local** word IDs.

## Behavioral impact

**The physical architecture is unchanged** — only `word_id` *labels* change (global → zone-local), so site positions and path geometry are identical. Concretely:

- Bundled **Gemini device specs are single-zone JSON** (`from_json`) and never touch the builder — unaffected.
- **Benchmarks** use those JSON specs, so deterministic metrics do **not** shift (no baseline regeneration needed).
- The multi-zone **builder** arches now report the shared-template word count: `generic_full` 96 → **32**, `gemini_full` 30 → **10** (and template site counts 768 → 256, 510 → 170).

## Tests

- Added `TestArchBuilderSharedTemplate` (single shared list, zone-local buses/pairs/zone-buses, identical templates across zones, mismatched-template rejection).
- Inverted the tests that had codified the concatenation convention across `test_arch_builder`, `test_builder`, `test_topology`, `test_word_factory`, `test_generic_full`, `test_gemini_full`, and `layout/test_path` to the shared-template contract.

## Verification

- `pytest python/tests`: **1815 passed**, 6 skipped, 1 xpassed, 0 failed
- `just test-rust`: **213 passed**, 0 failed (no Rust changes)
- black / isort / ruff / pyright: clean

## Notes for reviewers

The plan's original claim of "no bundled multi-zone specs" was inaccurate — `generic_full` and `gemini_full` are multi-zone builds via `build_arch`, so the test blast radius was larger than the plan enumerated (7 test files, not 1). All changes are relabeling to the documented convention; no routing behavior changes. The full rationale is in `docs/superpowers/plans/2026-07-29-word-id-shared-template-fix.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)