### PR TITLE
ci: auto-generate & organize GitHub release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,40 @@
+# Configuration for GitHub's automatically generated release notes.
+# Consumed by `gh release create --generate-notes` (and the generate-notes API)
+# in .github/workflows/release.yml. Categories are matched top-to-bottom; each
+# PR lands in the first section whose labels it carries.
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - "status: duplicate"
+      - "status: invalid"
+      - "category: wont fix"
+  categories:
+    - title: ⚠️ Breaking Changes
+      labels:
+        - "category: breaking change"
+    - title: 🚀 Features
+      labels:
+        - "category: feature"
+    - title: 🐛 Bug Fixes
+      labels:
+        - "category: bug"
+    - title: ⚡ Performance
+      labels:
+        - "performance: optimization"
+    - title: 📖 Documentation
+      labels:
+        - "category: documentation"
+    - title: 🎨 Visualization
+      labels:
+        - "category: visualization"
+    - title: 🛠️ DevOps & CI
+      labels:
+        - "devops: core"
+    - title: ⬆️ Dependencies
+      labels:
+        - "category: dependencies"
+    # Catch-all for anything not matched above.
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -92,6 +92,11 @@ jobs:
               core.info(`PR #${prNum} matched backport versions: ${versions.join(', ')}`);
             }
             core.setOutput('versions', versions.join('\n'));
+            // Carry the original PR's title + non-backport labels to the create
+            // step so each backport PR is a faithful proxy of the original in the
+            // release notes generated on the release branch (see .github/release.yml).
+            core.setOutput('orig_title', pr.data.title);
+            core.setOutput('orig_labels', JSON.stringify(labels.filter(l => !/backport/i.test(l))));
         env:
           PR_NUM: ${{ steps.prnum.outputs.pr_num }}
       - name: Cherry-pick and create PRs
@@ -103,6 +108,8 @@ jobs:
             const versions = process.env.VERSIONS.split('\n').filter(Boolean);
             const commit = process.env.GITHUB_SHA;
             const prNum = process.env.PR_NUM;
+            const origTitle = process.env.ORIG_TITLE || '';
+            const carryLabels = JSON.parse(process.env.ORIG_LABELS || '[]');
 
             execSync('git config user.name "github-actions[bot]"');
             execSync('git config user.email "github-actions[bot]@users.noreply.github.com"');
@@ -161,15 +168,31 @@ jobs:
                 // Commit, push, and create PR
                 execSync(`git commit -m "Backport PR #${prNum} (${commit}) to ${branch}"`);
                 execSync(`git push --force-with-lease origin ${backportBranch}`);
+                // Lead with the original (Conventional Commit) title so the
+                // release notes on the release branch read well and stay
+                // categorizable; mark it as a backport for the PR list.
+                const backportTitle = origTitle
+                  ? `${origTitle} (backport of #${prNum})`
+                  : `Backport PR #${prNum} to ${branch}`;
                 const pr = await github.rest.pulls.create({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  title: `Backport PR #${prNum} to ${branch}`,
+                  title: backportTitle,
                   head: backportBranch,
                   base: branch,
                   body: `Automated backport of PR #${prNum} (${commit}) to \`${branch}\`.`
                 });
                 core.info(`Created backport PR #${pr.data.number} for ${branch}`);
+                // Carry the original PR's labels so the backport is categorized
+                // into the right release-notes section on the release branch.
+                if (carryLabels.length) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.data.number,
+                    labels: carryLabels,
+                  });
+                }
                 successes.push({ version, branch, backportPrNum: pr.data.number });
 
               } catch (e) {
@@ -234,3 +257,7 @@ jobs:
           VERSIONS: ${{ steps.versions.outputs.versions }}
           GITHUB_SHA: ${{ github.sha }}
           PR_NUM: ${{ steps.prnum.outputs.pr_num }}
+          # Passed via env (not inline ${{ }} in the script) so a PR title can
+          # never inject into the github-script body.
+          ORIG_TITLE: ${{ steps.versions.outputs.orig_title }}
+          ORIG_LABELS: ${{ steps.versions.outputs.orig_labels }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,90 @@
+name: PR Conventional Labeler
+
+# Mirrors a PR's Conventional Commit title prefix into a `category:` label so
+# the automatically generated release notes (see .github/release.yml) group it
+# into the right section. Labeling is additive-only — it never removes labels,
+# so a maintainer's manual re-categorization is never overwritten.
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Apply category labels from PR title
+    runs-on: ubuntu-latest
+    steps:
+      # pull_request_target is used (not pull_request) so fork PRs still get a
+      # write-capable token. This is safe here: the PR head is never checked out
+      # and no PR-provided code runs — the title/body are read only as strings
+      # for regex matching, never interpolated into a shell.
+      - name: Label from Conventional Commit title
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr.title || "";
+            const body = pr.body || "";
+            const author = (pr.user && pr.user.login || "").toLowerCase();
+
+            // type(scope)!: description  — https://www.conventionalcommits.org
+            const m = title.match(/^(?<type>[a-z]+)(?:\((?<scope>[^)]*)\))?(?<breaking>!)?:/i);
+
+            const TYPE_TO_LABEL = {
+              feat: "category: feature",
+              fix: "category: bug",
+              perf: "performance: optimization",
+              docs: "category: documentation",
+              build: "devops: core",
+              ci: "devops: core",
+              chore: "devops: core",
+            };
+
+            const add = new Set();
+
+            if (m) {
+              const type = m.groups.type.toLowerCase();
+              const scope = (m.groups.scope || "").toLowerCase();
+              // A `deps` scope (e.g. build(deps), chore(deps)) is a dependency
+              // bump regardless of the leading type.
+              if (scope.includes("deps")) {
+                add.add("category: dependencies");
+              } else if (TYPE_TO_LABEL[type]) {
+                add.add(TYPE_TO_LABEL[type]);
+              }
+              // `feat!:` / `fix!:` — add both the type label and breaking; the
+              // release.yml order (Breaking first) resolves which section wins.
+              if (m.groups.breaking) add.add("category: breaking change");
+            }
+
+            if (author.includes("dependabot")) add.add("category: dependencies");
+
+            // Conventional Commits also signals breaking via a body footer.
+            if (/(^|\n)BREAKING[ -]CHANGE/i.test(body) || /BREAKING[ -]CHANGE/i.test(title)) {
+              add.add("category: breaking change");
+            }
+
+            if (add.size === 0) {
+              core.info(`No category label inferred from title: "${title}"`);
+              return;
+            }
+
+            // Only add labels not already present, to avoid needless label events.
+            const existing = new Set((pr.labels || []).map((l) => l.name));
+            const missing = [...add].filter((l) => !existing.has(l));
+
+            if (missing.length === 0) {
+              core.info("All inferred labels already present.");
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: missing,
+            });
+            core.info(`Added labels: ${missing.join(", ")}`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,9 @@ jobs:
             ./dist/*.tar.gz
             ./dist/*.whl
 
+      # --generate-notes calls GitHub's "generate release notes" API to build
+      # the body from merged PRs since the previous tag, grouped per the
+      # categories defined in .github/release.yml.
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -171,7 +174,7 @@ jobs:
           gh release create
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
-          --notes ""
+          --generate-notes
 
       - name: Upload artifacts to GitHub Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,12 @@ jobs:
       id-token: write
 
     steps:
+      # Full history + tags are needed to compute the previous-tag comparison
+      # base below; the release job otherwise has no checkout.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
       - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
@@ -164,17 +170,43 @@ jobs:
             ./dist/*.tar.gz
             ./dist/*.whl
 
-      # --generate-notes calls GitHub's "generate release notes" API to build
-      # the body from merged PRs since the previous tag, grouped per the
-      # categories defined in .github/release.yml.
+      # Generate the release body from GitHub's "generate release notes" API
+      # (grouped per .github/release.yml), but pin the comparison base to the
+      # previous tag on this release line and strip author attribution before
+      # publishing.
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          gh release create
-          '${{ github.ref_name }}'
-          --repo '${{ github.repository }}'
-          --generate-notes
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Deterministic comparison base = the previous tag on this release
+          # line. Tier 1: the newest tag that is an ancestor of the released
+          # commit (the previous patch on a release branch). Tier 2: for a .0
+          # release with no earlier tag on its own branch, the global
+          # version-sorted predecessor.
+          PREV_TAG="$(git tag --sort=-v:refname --merged HEAD | grep -vFx "$TAG" | head -n1 || true)"
+          if [ -z "$PREV_TAG" ]; then
+            PREV_TAG="$(git tag --sort=-v:refname | awk -v t="$TAG" 'found{print; exit} $0==t{found=1}')"
+          fi
+
+          # Generate notes for TAG (respecting .github/release.yml categories),
+          # pinned to PREV_TAG so the range never drifts to an unrelated tag.
+          if [ -n "$PREV_TAG" ]; then
+            echo "Generating notes for ${PREV_TAG}..${TAG}"
+            gh api --method POST "repos/${REPO}/releases/generate-notes" \
+              -f tag_name="$TAG" -f previous_tag_name="$PREV_TAG" --jq '.body' > notes.raw.md
+          else
+            echo "No previous tag found; generating notes from repository start"
+            gh api --method POST "repos/${REPO}/releases/generate-notes" \
+              -f tag_name="$TAG" --jq '.body' > notes.raw.md
+          fi
+
+          python3 scripts/clean_release_notes.py < notes.raw.md > notes.md
+
+          gh release create "$TAG" --repo "$REPO" --title "$TAG" --notes-file notes.md
 
       - name: Upload artifacts to GitHub Release
         env:

--- a/AGENT.md
+++ b/AGENT.md
@@ -336,5 +336,6 @@ Breaking changes map to SemVer MAJOR.
 
 ### Pull Request Labels
 
-- Tag PRs with the `breaking` label when they contain breaking changes
-- Tag non-breaking PRs with `backport v0.10` label for cherry-picking into the current release branch (`release-0-10`)
+- Tag PRs with the `category: breaking change` label when they contain breaking changes. A Conventional Commit title (`feat!:` / `fix!:` or a `BREAKING CHANGE` footer) applies this label automatically via the PR labeler workflow.
+- The PR labeler mirrors a Conventional Commit title prefix into the matching `category:` label (`feat:` → `category: feature`, `fix:` → `category: bug`, `perf:` → `performance: optimization`, `docs:` → `category: documentation`, `deps` scope → `category: dependencies`, `ci:`/`build:`/`chore:` → `devops: core`). These labels drive the release-notes sections defined in `.github/release.yml`; add them by hand when a title doesn't follow the convention.
+- Tag non-breaking PRs with the appropriate `status: backport` label for cherry-picking into the current release branch (`release-0-11`).

--- a/scripts/clean_release_notes.py
+++ b/scripts/clean_release_notes.py
@@ -1,0 +1,42 @@
+"""Strip author attribution from GitHub's auto-generated release notes.
+
+``gh api .../releases/generate-notes`` returns a body whose entries read
+``* <title> by @<author> in <pr-url>`` and which ends with a purely
+author-based "New Contributors" section. Release notes cut from a release
+branch are built from backport PRs authored by the automation bot, so the
+per-line attribution and the contributors list are noise.
+
+Reads the raw body on stdin and writes a cleaned body (no per-line authors,
+no "New Contributors" section) to stdout. The category structure from
+``.github/release.yml`` and the "Full Changelog" footer are left intact.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+
+def clean(body: str) -> str:
+    # Remove the trailing, purely author-based "New Contributors" section,
+    # keeping any following heading or the "Full Changelog" footer.
+    body = re.sub(
+        r"\n#+\s+New Contributors\n.*?(?=\n#+\s|\n\*\*Full Changelog\*\*|\Z)",
+        "\n",
+        body,
+        flags=re.DOTALL,
+    )
+    # Drop " by @<author>" from each entry. Anchored on the trailing " in " so a
+    # title that merely contains "by @..." is left intact.
+    body = re.sub(r" by @[A-Za-z0-9-]+(?:\[bot\])? in ", " in ", body)
+    # Collapse any blank-line run the section removal introduced.
+    body = re.sub(r"\n{3,}", "\n\n", body)
+    return body
+
+
+def main() -> None:
+    sys.stdout.write(clean(sys.stdin.read()))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Make releases publish organized, deterministic, author-free auto-generated notes — working on **both** `main`-line and release-branch tags.

### 1. Generate & organize (`release.yml`, `.github/release.yml`)
Build the release body from GitHub's [generate-notes API](https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release) and group it into ordered sections (⚠️ Breaking → 🚀 Features → 🐛 Fixes → ⚡ Perf → 📖 Docs → 🎨 Visualization → 🛠️ DevOps → ⬆️ Deps → Other) via a `.github/release.yml` label map. GitHub categorizes **only by PR label**, matched top-to-bottom, excluding `duplicate`/`invalid`/`wont fix`.

### 2. Ensure PRs are labeled (`pr-labeler.yml`, new)
Categorization needs `category:` labels on merged PRs. Since the repo enforces Conventional Commits, a `pull_request_target` workflow mirrors the title prefix into the matching label (`feat:`→feature, `fix:`→bug, `perf:`→performance, `docs:`→documentation, `*(deps)`/dependabot→dependencies, `ci:`/`build:`/`chore:`→devops, `feat!:`/`BREAKING CHANGE`→breaking). Additive-only; reads title/body only as strings (safe under `pull_request_target`).

### 3. Backports become faithful proxies (`backport.yml`)
Release notes on a release branch are built from the *backport* PRs. Those were titled `Backport PR #N to release-0-11` with no labels → generic text, all in "Other Changes." Now the backport PR carries the original **title** (`"<title> (backport of #N)"` — restores the CC prefix) and **labels** (minus `*backport*` control labels). Passed via step `env`, not inline `${{ }}`.

### 4. Pin the comparison range (`release.yml`)
`--generate-notes` auto-picks the previous tag by an **undocumented** algorithm. Replaced with an explicit generate+publish that computes the base:
- **Tier 1** — newest tag that is an *ancestor* of the released commit → the previous patch on a release branch.
- **Tier 2** — for a `.0` with no earlier tag on its own branch, the global version-sorted predecessor.

Verified against real history: `v0.11.1`→`v0.11.0` (tier 1), `v0.11.0`→`v0.10.7` (tier 2, correctly excluding the descendant `v0.11.1`), oldest→none. Note: this repo tags releases on `release-*` branches (no release tag is an ancestor of `main`), so the release job always runs from a release line — exactly where tier 1 applies. Adds a `checkout` (`fetch-depth: 0`) since the release job had no git history.

### 5. Drop author attribution (`release.yml`, `scripts/clean_release_notes.py`)
`.github/release.yml` can't change line format, so the generated body is post-processed: strip `" by @author"` (anchored on the trailing `" in "` so titles are untouched) and remove the author-only "New Contributors" section, keeping categories + "Full Changelog". Unit-tested; passes ruff/black/pyright.

### 6. Docs (`AGENT.md`)
Fix the stale "Pull Request Labels" section (no plain `breaking` label; backport line referenced `release-0-10`).

## Caveats
- `.github/release.yml` + the workflows must exist on the commit a tag points at → **backport this PR to active `release-*` branches** to cover tags cut there.
- Non-conventional PR titles (`refactor:`/`style:`/`test:`/free-form) get no label → "Other Changes"; label by hand if needed.
- Already-merged backports on `release-0-11` predate the proxy change (per request, not backfilled) — self-corrects from the next backport.

## Test plan
- All YAML parses; `backport.yml` script blocks pass `node --check`; release shell block passes `bash -n`.
- Previous-tag logic validated against real tags (see §4).
- Labeler logic unit-tested across 13 title shapes; note cleaner unit-tested (authors + New Contributors removed, categories/footer intact).
- Pre-commit hooks (incl. ruff/black/pyright on the script) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)