### PR TITLE
feat: added qalloc_at stdlib kernel

### DIFF
--- a/python/bloqade/gemini/logical/__init__.py
+++ b/python/bloqade/gemini/logical/__init__.py
@@ -7,5 +7,6 @@ from .group import kernel as kernel
 from .stdlib import (
     broadcast as broadcast,
     default_post_processing as default_post_processing,
+    qalloc_at as qalloc_at,
     star_rz as star_rz,
 )

--- a/python/bloqade/gemini/logical/stdlib/__init__.py
+++ b/python/bloqade/gemini/logical/stdlib/__init__.py
@@ -4,4 +4,5 @@ from .post_processing import (
     set_detector as set_detector,
     set_observable as set_observable,
 )
+from .qubit_allocation import qalloc_at as qalloc_at
 from .star import star_rz as star_rz

--- a/python/bloqade/gemini/logical/stdlib/qubit_allocation.py
+++ b/python/bloqade/gemini/logical/stdlib/qubit_allocation.py
@@ -1,22 +1,23 @@
-from typing import TypeVar
+from typing import Optional, TypeAlias, TypeVar
 
 from bloqade.types import Qubit
-from kirin import types
 from kirin.dialects import ilist
 
-from bloqade import squin
+from bloqade import qubit
 from bloqade.gemini.common.dialects.qubit import new_at
 
 from .. import kernel
 
 N = TypeVar("N")
 
-PositionIndex: Alias = int | None
+# Kirin preserves the static ``IList`` length through ``ilist.map`` for
+# ``typing.Optional`` but not the equivalent PEP 604 ``int | None`` spelling.
+PositionIndex: TypeAlias = Optional[int]  # noqa: UP045
 
 
 @kernel(aggressive_unroll=True, verify=False)
 def qalloc_at(
-    positions: ilist.IList[PositionIndex, N],  # pyright: ignore[reportInvalidTypeForm]
+    positions: ilist.IList[PositionIndex, N],
 ) -> ilist.IList[Qubit, N]:
     """Allocate logical qubits at optional linear logical positions.
 
@@ -28,7 +29,7 @@ def qalloc_at(
     """
 
     def position_to_new_at(
-        position: PositionIndex,  # pyright: ignore[reportInvalidTypeForm]
+        position: PositionIndex,
     ) -> Qubit:
         if position is None:
             q = qubit.new()

--- a/python/bloqade/gemini/logical/stdlib/qubit_allocation.py
+++ b/python/bloqade/gemini/logical/stdlib/qubit_allocation.py
@@ -11,7 +11,7 @@ from .. import kernel
 
 N = TypeVar("N")
 
-PositionIndex = types.Union(types.Int, types.NoneType)
+PositionIndex: Alias = int | None
 
 
 @kernel(aggressive_unroll=True, verify=False)
@@ -31,9 +31,9 @@ def qalloc_at(
         position: PositionIndex,  # pyright: ignore[reportInvalidTypeForm]
     ) -> Qubit:
         if position is None:
-            qubit = squin.qalloc(1)[0]
+            q = qubit.new()
         else:
-            qubit = new_at(0, position * 2, 0)
-        return qubit
+            q = new_at(0, position * 2, 0)
+        return q
 
     return ilist.map(position_to_new_at, positions)

--- a/python/bloqade/gemini/logical/stdlib/qubit_allocation.py
+++ b/python/bloqade/gemini/logical/stdlib/qubit_allocation.py
@@ -1,0 +1,39 @@
+from typing import TypeVar
+
+from bloqade.types import Qubit
+from kirin import types
+from kirin.dialects import ilist
+
+from bloqade import squin
+from bloqade.gemini.common.dialects.qubit import new_at
+
+from .. import kernel
+
+N = TypeVar("N")
+
+PositionIndex = types.Union(types.Int, types.NoneType)
+
+
+@kernel(aggressive_unroll=True, verify=False)
+def qalloc_at(
+    positions: ilist.IList[PositionIndex, N],  # pyright: ignore[reportInvalidTypeForm]
+) -> ilist.IList[Qubit, N]:
+    """Allocate logical qubits at optional linear logical positions.
+
+    An integer ``position`` pins the qubit to zone 0 at word ``2 * position``;
+    ``None`` allocates an unpinned qubit for the layout heuristic to place.
+    The input must be statically known, and the calling kernel must set
+    ``aggressive_unroll=True``, so the map can lower into individual
+    allocations.
+    """
+
+    def position_to_new_at(
+        position: PositionIndex,  # pyright: ignore[reportInvalidTypeForm]
+    ) -> Qubit:
+        if position is None:
+            qubit = squin.qalloc(1)[0]
+        else:
+            qubit = new_at(0, position * 2, 0)
+        return qubit
+
+    return ilist.map(position_to_new_at, positions)

--- a/python/tests/gemini/test_qalloc_at.py
+++ b/python/tests/gemini/test_qalloc_at.py
@@ -1,0 +1,54 @@
+"""Tests for logical position-based qubit allocation."""
+
+from kirin.dialects import ilist
+
+import bloqade.gemini as gemini
+from bloqade.gemini.device import GeminiLogicalSimulator
+from bloqade.lanes.bytecode.encoding import LocationAddress
+from bloqade.lanes.dialects import move
+from bloqade.lanes.heuristics.logical.placement import LogicalPlacementStrategyNoHome
+from bloqade.lanes.transform import LogicalPipeline
+
+
+def test_qalloc_at_mixes_pinned_and_unpinned_allocations():
+    """Integer positions pin their corresponding logical qubits; ``None`` does not."""
+
+    @gemini.logical.kernel(aggressive_unroll=True)
+    def kernel():
+        register = gemini.logical.qalloc_at(ilist.IList([None, 2, None, 4]))
+        gemini.logical.terminal_measure(register)
+
+    physical_move = LogicalPipeline(
+        placement_strategy=LogicalPlacementStrategyNoHome(),
+    ).emit(kernel, no_raise=False)
+
+    fill = next(
+        statement
+        for statement in physical_move.callable_region.walk()
+        if isinstance(statement, move.Fill)
+    )
+
+    assert fill.location_addresses[1] == LocationAddress(
+        zone_id=0,
+        word_id=4,
+        site_id=0,
+    )
+    assert fill.location_addresses[3] == LocationAddress(
+        zone_id=0,
+        word_id=8,
+        site_id=0,
+    )
+    assert len(set(fill.location_addresses)) == 4
+
+
+def test_logical_simulator_task_accepts_qalloc_at_kernel():
+    """The public simulator API compiles a kernel using the public helper."""
+
+    @gemini.logical.kernel(aggressive_unroll=True)
+    def kernel():
+        register = gemini.logical.qalloc_at(ilist.IList([0, None]))
+        gemini.logical.terminal_measure(register)
+
+    task = GeminiLogicalSimulator().task(kernel)
+
+    assert task.logical_squin_kernel.is_structurally_equal(kernel)


### PR DESCRIPTION
closes https://github.com/QuEraComputing/bloqade-lanes/issues/854

- Adds "qalloc_at" standard library kernel for the logical kernel to reduce syntax needed to allocate logical qubits at specific positions.