### PR TITLE
feat(search): add sound infeasibility detection for atom rearrangement

### DIFF
--- a/crates/bloqade-lanes-search/src/feasibility/decomposition.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/decomposition.rs
@@ -11,8 +11,12 @@
 //!    subgraphs; a cycle in it proves the instance unsolvable (Proposition 2).
 //!
 //! Throughout, `m` is the number of empty vertices, matching the paper's
-//! notation. Everything here assumes the ≥ 2 empty-vertex regime that
-//! Push and Rotate is complete for.
+//! notation — counted **per connected component**. A disconnected instance
+//! decomposes into independent pebble-motion instances (atoms cannot cross
+//! components, and an empty vertex in another component cannot help
+//! maneuvering), so each component is analysed with its own `m`, and only
+//! components in the ≥ 2 empty-vertex regime that Push and Rotate is
+//! complete for get subgraphs at all.
 //!
 //! ## Soundness bias
 //!
@@ -28,6 +32,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
+use crate::feasibility::MIN_EMPTY_VERTICES;
 use crate::feasibility::graph::{Biconnected, LaneGraph, VertexId};
 
 /// Sentinel for "this vertex belongs to no subgraph".
@@ -55,26 +60,46 @@ pub struct Decomposition {
     /// Qubit id → the subgraph it is confined to. Absent means the agent is
     /// confined to an isthmus and belongs to no subgraph.
     pub assignment: HashMap<u32, usize>,
-    /// Number of empty vertices, `m`.
+    /// Total number of empty vertices across the whole graph. The algorithms
+    /// never use this directly — they work with the per-component counts
+    /// below, since empties in another component cannot help maneuvering.
     pub empty_count: usize,
+    /// Vertex id → connected-component id.
+    pub component_of_vertex: Vec<usize>,
+    /// Component id → number of empty vertices in that component, `m`.
+    pub empties_in_component: Vec<usize>,
 }
 
 impl Decomposition {
     /// Build the full decomposition for an occupancy pattern.
     ///
-    /// `occupant[v]` is the qubit at vertex `v`, if any, and `empty_count` is
-    /// the number of empty vertices `m`. Assumes the `m ≥ 2` regime — callers
-    /// gate on [`crate::feasibility::MIN_EMPTY_VERTICES`].
-    pub fn build(graph: &LaneGraph, occupant: &[Option<u32>], empty_count: usize) -> Self {
+    /// `occupant[v]` is the qubit at vertex `v`, if any. Each connected
+    /// component is analysed with its own empty count `m`; components with
+    /// fewer than [`MIN_EMPTY_VERTICES`] empties are outside the Push and
+    /// Rotate regime and contribute no subgraphs.
+    pub fn build(graph: &LaneGraph, occupant: &[Option<u32>]) -> Self {
+        let (component_of_vertex, n_components) = graph.connected_components();
+        let mut empties_in_component = vec![0usize; n_components];
+        for v in graph.vertices() {
+            if occupant[v].is_none() {
+                empties_in_component[component_of_vertex[v]] += 1;
+            }
+        }
+        let m_of_vertex: Vec<usize> = graph
+            .vertices()
+            .map(|v| empties_in_component[component_of_vertex[v]])
+            .collect();
+        let empty_count = empties_in_component.iter().sum();
+
         let bcc = graph.biconnected();
-        let (subgraphs, subgraph_of_vertex) = find_subgraphs(graph, &bcc, empty_count);
-        let planks = find_planks(graph, &subgraphs, &subgraph_of_vertex, empty_count);
+        let (subgraphs, subgraph_of_vertex) = find_subgraphs(graph, &bcc, &m_of_vertex);
+        let planks = find_planks(graph, &subgraphs, &subgraph_of_vertex, &m_of_vertex);
         let assignment = assign_agents(
             graph,
             &subgraphs,
             &subgraph_of_vertex,
             occupant,
-            empty_count,
+            &m_of_vertex,
         );
         Self {
             subgraphs,
@@ -82,6 +107,8 @@ impl Decomposition {
             planks,
             assignment,
             empty_count,
+            component_of_vertex,
+            empties_in_component,
         }
     }
 
@@ -105,6 +132,10 @@ impl Decomposition {
 /// `m ≥ 2`, so vertex-sharing classes always merge in the regime this
 /// decomposition runs in.
 ///
+/// `m_of_vertex[v]` is the empty count of `v`'s connected component; classes
+/// in components below [`MIN_EMPTY_VERTICES`] are outside the Push and
+/// Rotate regime and are not created at all.
+///
 /// The merge loop is `O(rounds × |S| × (V + E))`. The result depends only on
 /// the architecture, the blocked set, and `m`, so callers that solve many
 /// layers against one architecture should cache it rather than recomputing
@@ -112,7 +143,7 @@ impl Decomposition {
 pub fn find_subgraphs(
     graph: &LaneGraph,
     bcc: &Biconnected,
-    empty_count: usize,
+    m_of_vertex: &[usize],
 ) -> (Vec<Vec<VertexId>>, Vec<usize>) {
     let n = graph.len();
     let mut owner = vec![NO_SUBGRAPH; n];
@@ -124,6 +155,9 @@ pub fn find_subgraphs(
             continue;
         }
         let verts = bcc.components[comp_id].clone();
+        if m_of_vertex[verts[0]] < MIN_EMPTY_VERTICES {
+            continue;
+        }
         let id = sets.len();
         for &v in &verts {
             owner[v] = id;
@@ -133,7 +167,7 @@ pub fn find_subgraphs(
 
     // Line 2: degree-≥3 vertices not already inside a nontrivial component.
     for v in graph.vertices() {
-        if graph.degree(v) >= 3 && owner[v] == NO_SUBGRAPH {
+        if graph.degree(v) >= 3 && owner[v] == NO_SUBGRAPH && m_of_vertex[v] >= MIN_EMPTY_VERTICES {
             let id = sets.len();
             owner[v] = id;
             sets.push(Some(vec![v]));
@@ -141,10 +175,10 @@ pub fn find_subgraphs(
     }
 
     // Lines 3–5: merge classes within `m - 2` hops of each other, pulling in
-    // the vertices of the connecting shortest path. `m < 2` makes the
-    // threshold vacuous, so the loop is skipped entirely.
-    if empty_count >= 2 {
-        let radius = empty_count - 2;
+    // the vertices of the connecting shortest path. The radius is per class,
+    // from its component's own empty count; a BFS never leaves the
+    // component, so the count is the right one for every vertex it visits.
+    {
         let mut changed = true;
         while changed {
             changed = false;
@@ -155,6 +189,7 @@ pub fn find_subgraphs(
                 // Multi-source BFS out of class `i`, bounded by `radius`,
                 // recording parents so the connecting path can be absorbed.
                 let sources = sets[i].as_ref().expect("checked above").clone();
+                let radius = m_of_vertex[sources[0]].saturating_sub(2);
                 let mut dist = vec![u32::MAX; n];
                 let mut parent = vec![usize::MAX; n];
                 let mut queue: VecDeque<VertexId> = VecDeque::new();
@@ -273,18 +308,19 @@ fn walk_plank(
 ///
 /// From each subgraph vertex with a neighbour outside the subgraph, walk
 /// outward along the forced continuation ([`walk_plank`]). Length is capped
-/// at `m - 1` edges.
+/// at `m - 1` edges, with `m` taken from the subgraph's own connected
+/// component (`m_of_vertex`).
 pub fn find_planks(
     graph: &LaneGraph,
     subgraphs: &[Vec<VertexId>],
     subgraph_of_vertex: &[usize],
-    empty_count: usize,
+    m_of_vertex: &[usize],
 ) -> Vec<Vec<Plank>> {
-    let max_len = empty_count.saturating_sub(1);
     let mut all = Vec::with_capacity(subgraphs.len());
 
     for (sub_id, verts) in subgraphs.iter().enumerate() {
         let mut planks = Vec::new();
+        let max_len = m_of_vertex[verts[0]].saturating_sub(1);
         if max_len == 0 {
             all.push(planks);
             continue;
@@ -349,18 +385,20 @@ fn count_unoccupied_reachable(
 /// Returns the map from qubit id to the subgraph that agent is confined to.
 /// Agents confined to an isthmus are absent from the map.
 ///
-/// `occupant[v]` is the qubit at vertex `v`, if any.
+/// `occupant[v]` is the qubit at vertex `v`, if any; `m_of_vertex[v]` is the
+/// empty count of `v`'s connected component.
 pub fn assign_agents(
     graph: &LaneGraph,
     subgraphs: &[Vec<VertexId>],
     subgraph_of_vertex: &[usize],
     occupant: &[Option<u32>],
-    empty_count: usize,
+    m_of_vertex: &[usize],
 ) -> HashMap<u32, usize> {
     let occupied: Vec<bool> = occupant.iter().map(|o| o.is_some()).collect();
     let mut assignment: HashMap<u32, usize> = HashMap::new();
 
     for (sub_id, verts) in subgraphs.iter().enumerate() {
+        let empty_count = m_of_vertex[verts[0]];
         for &v in verts {
             let outside: Vec<VertexId> = graph
                 .neighbors(v)
@@ -560,8 +598,12 @@ mod tests {
     }
 
     fn decompose(graph: &LaneGraph, occupant: &[Option<u32>]) -> Decomposition {
-        let empty_count = occupant.iter().filter(|o| o.is_none()).count();
-        Decomposition::build(graph, occupant, empty_count)
+        Decomposition::build(graph, occupant)
+    }
+
+    /// Uniform per-vertex `m` for direct calls on connected fixtures.
+    fn uniform_m(graph: &LaneGraph, m: usize) -> Vec<usize> {
+        vec![m; graph.len()]
     }
 
     /// Exhaustive BFS over the configuration space: for every agent, the set
@@ -725,11 +767,11 @@ mod tests {
         // Gap between the two triangles' join vertices (2 and 6) is 4 hops,
         // so they merge exactly when m - 2 >= 4, i.e. m >= 6.
         for m in 2..=5 {
-            let (subs, _) = find_subgraphs(&graph, &bcc, m);
+            let (subs, _) = find_subgraphs(&graph, &bcc, &uniform_m(&graph, m));
             assert_eq!(subs.len(), 2, "m={m} should keep the triangles separate");
         }
         for m in 6..=9 {
-            let (subs, _) = find_subgraphs(&graph, &bcc, m);
+            let (subs, _) = find_subgraphs(&graph, &bcc, &uniform_m(&graph, m));
             assert_eq!(subs.len(), 1, "m={m} should merge the triangles");
         }
     }
@@ -843,12 +885,64 @@ mod tests {
         );
         for m in 2..=6 {
             let bcc = graph.biconnected();
-            let (subs, sub_of_vertex) = find_subgraphs(&graph, &bcc, m);
+            let (subs, sub_of_vertex) = find_subgraphs(&graph, &bcc, &uniform_m(&graph, m));
             assert_eq!(subs.len(), 1, "m={m}: all three cycles must merge");
             assert!(
                 graph.vertices().all(|v| sub_of_vertex[v] == 0),
                 "m={m}: every vertex belongs to the merged subgraph"
             );
+        }
+    }
+
+    /// Empties stranded in a separate connected component must not change
+    /// the decomposition of another component: `m` is per component, so the
+    /// dumbbell's subgraphs, planks, and assignment are identical with and
+    /// without an extra all-empty component. Under a global `m` this fails —
+    /// the merge radius and plank caps inflate.
+    #[test]
+    fn stranded_empties_do_not_change_the_decomposition() {
+        let occupant_core: Vec<Option<u32>> = vec![
+            Some(0),
+            None,
+            Some(1),
+            Some(2),
+            Some(3),
+            Some(4),
+            Some(5),
+            None,
+            Some(6),
+        ];
+        let base = decompose(&dumbbell(), &occupant_core);
+
+        // Same dumbbell plus a disconnected 3-vertex path, all empty.
+        let mut edges = vec![
+            (0, 1),
+            (1, 2),
+            (2, 0),
+            (2, 3),
+            (3, 4),
+            (4, 5),
+            (5, 6),
+            (6, 7),
+            (7, 8),
+            (8, 6),
+        ];
+        edges.push((9, 10));
+        edges.push((10, 11));
+        let graph = LaneGraph::from_edges(12, &edges);
+        let mut occupant = occupant_core.clone();
+        occupant.extend([None, None, None]);
+        let extended = decompose(&graph, &occupant);
+
+        assert_eq!(base.subgraphs, extended.subgraphs);
+        assert_eq!(base.assignment, extended.assignment);
+        assert_eq!(base.planks.len(), extended.planks.len());
+        for (a, b) in base.planks.iter().zip(&extended.planks) {
+            let a: Vec<(VertexId, &[VertexId])> =
+                a.iter().map(|p| (p.start, p.vertices.as_slice())).collect();
+            let b: Vec<(VertexId, &[VertexId])> =
+                b.iter().map(|p| (p.start, p.vertices.as_slice())).collect();
+            assert_eq!(a, b);
         }
     }
 

--- a/crates/bloqade-lanes-search/src/feasibility/decomposition.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/decomposition.rs
@@ -1,0 +1,671 @@
+//! Kornhauser subgraph decomposition, as reconstructed by de Wilde, ter Mors
+//! & Witteveen (JAIR 51, 2014), §3.1.
+//!
+//! Three stages, matching Algorithms 1–3 of that paper:
+//!
+//! 1. [`find_subgraphs`] (Algorithm 1) — partition the graph into subgraphs
+//!    within which agents can reach any position.
+//! 2. [`assign_agents`] (Algorithm 2) — decide which agents are *confined* to
+//!    each subgraph and its planks.
+//! 3. [`subgraph_priorities`] (Algorithm 3) — the partial order over
+//!    subgraphs; a cycle in it proves the instance unsolvable (Proposition 2).
+//!
+//! Throughout, `m` is the number of empty vertices, matching the paper's
+//! notation. Everything here assumes the ≥ 2 empty-vertex regime that
+//! Push and Rotate is complete for.
+//!
+//! ## Soundness bias
+//!
+//! This module backs a *one-sided* infeasibility detector: it must never
+//! report a solvable instance as infeasible, but it is allowed to miss
+//! obstructions. Where the paper's pseudocode is ambiguous, we therefore take
+//! the reading that assigns *fewer* agents to subgraphs. Under-assignment is
+//! safe in both directions it matters: an unassigned agent is simply not
+//! goal-containment checked, and it contributes no precedence edges that
+//! could create a spurious cycle. Over-assignment would be unsound, since
+//! goal containment is only justified for agents Proposition 1 proves are
+//! confined.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use crate::feasibility::graph::{Biconnected, LaneGraph, VertexId};
+
+/// Sentinel for "this vertex belongs to no subgraph".
+pub const NO_SUBGRAPH: usize = usize::MAX;
+
+/// A plank of a subgraph (Definition 5): a unique, maximal path leaving the
+/// subgraph at a join vertex, of length at most `m - 1`.
+#[derive(Debug, Clone)]
+pub struct Plank {
+    /// The join vertex where the plank attaches. Belongs to the subgraph.
+    pub start: VertexId,
+    /// Plank vertices ordered outward from `start`, excluding `start`.
+    pub vertices: Vec<VertexId>,
+}
+
+/// The full decomposition of an instance.
+#[derive(Debug)]
+pub struct Decomposition {
+    /// Subgraph id → its vertex set, sorted.
+    pub subgraphs: Vec<Vec<VertexId>>,
+    /// Vertex id → owning subgraph, or [`NO_SUBGRAPH`].
+    pub subgraph_of_vertex: Vec<usize>,
+    /// Subgraph id → its planks.
+    pub planks: Vec<Vec<Plank>>,
+    /// Qubit id → the subgraph it is confined to. Absent means the agent is
+    /// confined to an isthmus and belongs to no subgraph.
+    pub assignment: HashMap<u32, usize>,
+    /// Number of empty vertices, `m`.
+    pub empty_count: usize,
+}
+
+impl Decomposition {
+    /// Whether `v` lies in subgraph `sub` or on one of its planks — the
+    /// region Proposition 1 confines an assigned agent to.
+    pub fn contains_in_subgraph_or_planks(&self, sub: usize, v: VertexId) -> bool {
+        if self.subgraph_of_vertex[v] == sub {
+            return true;
+        }
+        self.planks[sub].iter().any(|p| p.vertices.contains(&v))
+    }
+}
+
+/// Algorithm 1: `find_subgraphs(G, m)`.
+///
+/// Starts from the nontrivial biconnected components plus the isolated
+/// degree-≥3 vertices, then repeatedly merges any two classes whose vertex
+/// sets come within `m - 2` hops, absorbing the connecting shortest path
+/// (Definition 3 condition 3, and Definition 4 condition 3).
+///
+/// The merge loop is `O(rounds × |S| × (V + E))`. The result depends only on
+/// the architecture, the blocked set, and `m`, so callers that solve many
+/// layers against one architecture should cache it rather than recomputing
+/// per solve.
+pub fn find_subgraphs(
+    graph: &LaneGraph,
+    bcc: &Biconnected,
+    empty_count: usize,
+) -> (Vec<Vec<VertexId>>, Vec<usize>) {
+    let n = graph.len();
+    let mut owner = vec![NO_SUBGRAPH; n];
+    let mut sets: Vec<Option<Vec<VertexId>>> = Vec::new();
+
+    // Line 1: every nontrivial biconnected component becomes a class.
+    for comp_id in 0..bcc.components.len() {
+        if !bcc.is_nontrivial(comp_id) {
+            continue;
+        }
+        let verts = bcc.components[comp_id].clone();
+        let id = sets.len();
+        for &v in &verts {
+            owner[v] = id;
+        }
+        sets.push(Some(verts));
+    }
+
+    // Line 2: degree-≥3 vertices not already inside a nontrivial component.
+    for v in graph.vertices() {
+        if graph.degree(v) >= 3 && owner[v] == NO_SUBGRAPH {
+            let id = sets.len();
+            owner[v] = id;
+            sets.push(Some(vec![v]));
+        }
+    }
+
+    // Lines 3–5: merge classes within `m - 2` hops of each other, pulling in
+    // the vertices of the connecting shortest path. `m < 2` makes the
+    // threshold vacuous, so the loop is skipped entirely.
+    if empty_count >= 2 {
+        let radius = empty_count - 2;
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for i in 0..sets.len() {
+                if sets[i].is_none() {
+                    continue;
+                }
+                // Multi-source BFS out of class `i`, bounded by `radius`,
+                // recording parents so the connecting path can be absorbed.
+                let sources = sets[i].as_ref().expect("checked above").clone();
+                let mut dist = vec![u32::MAX; n];
+                let mut parent = vec![usize::MAX; n];
+                let mut queue: VecDeque<VertexId> = VecDeque::new();
+                for &s in &sources {
+                    dist[s] = 0;
+                    queue.push_back(s);
+                }
+                let mut hits: Vec<VertexId> = Vec::new();
+                while let Some(u) = queue.pop_front() {
+                    if dist[u] as usize >= radius {
+                        continue;
+                    }
+                    for &w in graph.neighbors(u) {
+                        if dist[w] != u32::MAX {
+                            continue;
+                        }
+                        dist[w] = dist[u] + 1;
+                        parent[w] = u;
+                        if owner[w] != NO_SUBGRAPH && owner[w] != i {
+                            hits.push(w);
+                        }
+                        queue.push_back(w);
+                    }
+                }
+
+                for hit in hits {
+                    let j = owner[hit];
+                    if j == NO_SUBGRAPH || j == i || sets[j].is_none() {
+                        continue;
+                    }
+                    // Absorb class `j` and the path connecting it to `i`.
+                    let other = sets[j].take().expect("checked above");
+                    let mut merged = sets[i].take().expect("class i is live");
+                    merged.extend(other);
+                    let mut step = hit;
+                    while step != usize::MAX && dist[step] > 0 {
+                        merged.push(step);
+                        step = parent[step];
+                    }
+                    merged.sort_unstable();
+                    merged.dedup();
+                    for &v in &merged {
+                        owner[v] = i;
+                    }
+                    sets[i] = Some(merged);
+                    changed = true;
+                }
+            }
+        }
+    }
+
+    // Compact: drop the merged-away holes and renumber.
+    let subgraphs: Vec<Vec<VertexId>> = sets.into_iter().flatten().collect();
+    let mut subgraph_of_vertex = vec![NO_SUBGRAPH; n];
+    for (new_id, verts) in subgraphs.iter().enumerate() {
+        for &v in verts {
+            subgraph_of_vertex[v] = new_id;
+        }
+    }
+
+    (subgraphs, subgraph_of_vertex)
+}
+
+/// Compute the planks of every subgraph (Definition 5).
+///
+/// From each subgraph vertex with a neighbour outside the subgraph, walk
+/// outward along the forced continuation — a plank is a *unique* path, so the
+/// walk stops as soon as it reaches a vertex of degree ≥ 3 (a branch) or a
+/// vertex belonging to a subgraph. Length is capped at `m - 1` edges.
+pub fn find_planks(
+    graph: &LaneGraph,
+    subgraphs: &[Vec<VertexId>],
+    subgraph_of_vertex: &[usize],
+    empty_count: usize,
+) -> Vec<Vec<Plank>> {
+    let max_len = empty_count.saturating_sub(1);
+    let mut all = Vec::with_capacity(subgraphs.len());
+
+    for (sub_id, verts) in subgraphs.iter().enumerate() {
+        let mut planks = Vec::new();
+        if max_len == 0 {
+            all.push(planks);
+            continue;
+        }
+        for &s in verts {
+            for &u in graph.neighbors(s) {
+                if subgraph_of_vertex[u] == sub_id {
+                    continue;
+                }
+                let mut path = Vec::new();
+                let mut prev = s;
+                let mut cur = u;
+                loop {
+                    path.push(cur);
+                    if path.len() >= max_len {
+                        break;
+                    }
+                    // A plank is a *unique* path: stop at any branch, and at
+                    // any vertex that belongs to a subgraph.
+                    if graph.degree(cur) != 2 || subgraph_of_vertex[cur] != NO_SUBGRAPH {
+                        break;
+                    }
+                    let Some(&next) = graph.neighbors(cur).iter().find(|&&w| w != prev) else {
+                        break;
+                    };
+                    prev = cur;
+                    cur = next;
+                }
+                planks.push(Plank {
+                    start: s,
+                    vertices: path,
+                });
+            }
+        }
+        all.push(planks);
+    }
+    all
+}
+
+/// Count unoccupied vertices reachable from `sources`, optionally with one
+/// vertex and one undirected edge deleted from the graph.
+fn count_unoccupied_reachable(
+    graph: &LaneGraph,
+    sources: &[VertexId],
+    occupied: &[bool],
+    skip_vertex: Option<VertexId>,
+    skip_edge: Option<(VertexId, VertexId)>,
+) -> usize {
+    let mut seen = vec![false; graph.len()];
+    let mut queue: VecDeque<VertexId> = VecDeque::new();
+    for &s in sources {
+        if Some(s) == skip_vertex || seen[s] {
+            continue;
+        }
+        seen[s] = true;
+        queue.push_back(s);
+    }
+    let mut count = 0usize;
+    while let Some(u) = queue.pop_front() {
+        if !occupied[u] {
+            count += 1;
+        }
+        for &w in graph.neighbors(u) {
+            if seen[w] || Some(w) == skip_vertex {
+                continue;
+            }
+            if let Some((a, b)) = skip_edge
+                && ((u == a && w == b) || (u == b && w == a))
+            {
+                continue;
+            }
+            seen[w] = true;
+            queue.push_back(w);
+        }
+    }
+    count
+}
+
+/// Algorithm 2: `assign_agents_to_subgraphs(G, A, A, S)`.
+///
+/// Returns the map from qubit id to the subgraph that agent is confined to.
+/// Agents confined to an isthmus are absent from the map.
+///
+/// `occupant[v]` is the qubit at vertex `v`, if any.
+pub fn assign_agents(
+    graph: &LaneGraph,
+    subgraphs: &[Vec<VertexId>],
+    subgraph_of_vertex: &[usize],
+    occupant: &[Option<u32>],
+    empty_count: usize,
+) -> HashMap<u32, usize> {
+    let occupied: Vec<bool> = occupant.iter().map(|o| o.is_some()).collect();
+    let mut assignment: HashMap<u32, usize> = HashMap::new();
+
+    for (sub_id, verts) in subgraphs.iter().enumerate() {
+        for &v in verts {
+            let outside: Vec<VertexId> = graph
+                .neighbors(v)
+                .iter()
+                .copied()
+                .filter(|&u| subgraph_of_vertex[u] != sub_id)
+                .collect();
+
+            // Line 11–12: an inner vertex (no neighbour outside the
+            // subgraph). Its occupant is confined outright.
+            if outside.is_empty() {
+                if let Some(a) = occupant[v] {
+                    assignment.insert(a, sub_id);
+                }
+                continue;
+            }
+
+            // Line 5: empties reachable from the subgraph without using `v`.
+            let m_dprime = count_unoccupied_reachable(graph, verts, &occupied, Some(v), None);
+
+            for &u in &outside {
+                // Line 7: empties reachable from `v` with edge (u, v) cut.
+                let m_prime =
+                    count_unoccupied_reachable(graph, &[v], &occupied, None, Some((u, v)));
+
+                // Line 8. Note the `A^-1(v) != ⊥` conjunct: the paper gates
+                // the whole body — including the plank walk on line 10 — on
+                // the join vertex being occupied. We implement that
+                // literally; see the module-level soundness note.
+                let gate = (m_prime >= 1 && m_prime < empty_count) || m_dprime >= 1;
+                let Some(join_agent) = occupant[v] else {
+                    continue;
+                };
+                if !gate {
+                    continue;
+                }
+                assignment.insert(join_agent, sub_id);
+
+                // Line 10: follow the plank outward from `u`, assigning the
+                // first `m' - 1` agents found along it.
+                let mut budget = m_prime.saturating_sub(1);
+                if budget == 0 {
+                    continue;
+                }
+                let mut prev = v;
+                let mut cur = u;
+                loop {
+                    if let Some(a) = occupant[cur] {
+                        assignment.insert(a, sub_id);
+                        budget -= 1;
+                        if budget == 0 {
+                            break;
+                        }
+                    }
+                    if graph.degree(cur) != 2 {
+                        break;
+                    }
+                    let Some(&next) = graph.neighbors(cur).iter().find(|&&w| w != prev) else {
+                        break;
+                    };
+                    prev = cur;
+                    cur = next;
+                }
+            }
+        }
+    }
+
+    assignment
+}
+
+/// A precedence edge `before ≺ after` between two subgraphs.
+pub type Precedence = (usize, usize);
+
+/// Algorithm 3: the partial order over subgraphs.
+///
+/// For an agent `r` assigned to `S_j` with goal `g`, add `S_i ≺ S_j` when
+/// either (1) `g` is the start vertex of a plank of `S_i`, or (2) `g` lies on
+/// a plank of `S_i` and every plank vertex between `g` and the plank start is
+/// the goal of an agent assigned to no subgraph.
+pub fn subgraph_priorities(
+    decomp: &Decomposition,
+    goals: &HashMap<u32, VertexId>,
+    unassigned_goal_vertices: &HashSet<VertexId>,
+) -> Vec<Precedence> {
+    let mut edges: HashSet<Precedence> = HashSet::new();
+
+    for (&agent, &sub_j) in &decomp.assignment {
+        let Some(&goal) = goals.get(&agent) else {
+            continue;
+        };
+        for (sub_i, planks) in decomp.planks.iter().enumerate() {
+            if sub_i == sub_j {
+                continue;
+            }
+            for plank in planks {
+                // Case 1: the goal is the plank's start vertex.
+                if plank.start == goal {
+                    edges.insert((sub_i, sub_j));
+                    continue;
+                }
+                // Case 2: the goal sits on the plank, and everything between
+                // it and the start is claimed by unassigned agents.
+                let Some(pos) = plank.vertices.iter().position(|&w| w == goal) else {
+                    continue;
+                };
+                let between_all_unassigned = plank.vertices[..pos]
+                    .iter()
+                    .all(|w| unassigned_goal_vertices.contains(w));
+                if between_all_unassigned {
+                    edges.insert((sub_i, sub_j));
+                }
+            }
+        }
+    }
+
+    let mut out: Vec<Precedence> = edges.into_iter().collect();
+    out.sort_unstable();
+    out
+}
+
+/// Find a cycle in the subgraph precedence relation, if one exists.
+///
+/// Proposition 2: a cyclic precedence relation proves the instance
+/// unsolvable. Returns the subgraph ids on the cycle, in order.
+pub fn find_precedence_cycle(n_subgraphs: usize, edges: &[Precedence]) -> Option<Vec<usize>> {
+    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n_subgraphs];
+    for &(a, b) in edges {
+        adj[a].push(b);
+    }
+
+    // Iterative DFS with an explicit colour marking: 0 = unvisited,
+    // 1 = on the current path, 2 = fully explored.
+    let mut colour = vec![0u8; n_subgraphs];
+    let mut path: Vec<usize> = Vec::new();
+
+    for start in 0..n_subgraphs {
+        if colour[start] != 0 {
+            continue;
+        }
+        let mut stack: Vec<(usize, usize)> = vec![(start, 0)];
+        colour[start] = 1;
+        path.push(start);
+        while let Some(&(u, i)) = stack.last() {
+            if i < adj[u].len() {
+                stack.last_mut().expect("stack is non-empty").1 += 1;
+                let w = adj[u][i];
+                match colour[w] {
+                    0 => {
+                        colour[w] = 1;
+                        path.push(w);
+                        stack.push((w, 0));
+                    }
+                    1 => {
+                        // Back edge — the cycle is the path suffix from `w`.
+                        let at = path
+                            .iter()
+                            .position(|&x| x == w)
+                            .expect("a grey vertex is on the current path");
+                        return Some(path[at..].to_vec());
+                    }
+                    _ => {}
+                }
+            } else {
+                colour[u] = 2;
+                path.pop();
+                stack.pop();
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two triangles joined by a corridor:
+    /// `{0,1,2}` — 2 – 3 – 4 – 5 – 6 — `{6,7,8}`.
+    ///
+    /// Atoms cannot pass each other in the corridor, so whether an atom can
+    /// cross between the triangles depends entirely on how many empty
+    /// vertices there are — exactly the regime the plank machinery encodes.
+    fn dumbbell() -> LaneGraph {
+        LaneGraph::from_edges(
+            9,
+            &[
+                (0, 1),
+                (1, 2),
+                (2, 0),
+                (2, 3),
+                (3, 4),
+                (4, 5),
+                (5, 6),
+                (6, 7),
+                (7, 8),
+                (8, 6),
+            ],
+        )
+    }
+
+    fn decompose(graph: &LaneGraph, occupant: &[Option<u32>]) -> Decomposition {
+        let empty_count = occupant.iter().filter(|o| o.is_none()).count();
+        let bcc = graph.biconnected();
+        let (subgraphs, subgraph_of_vertex) = find_subgraphs(graph, &bcc, empty_count);
+        let planks = find_planks(graph, &subgraphs, &subgraph_of_vertex, empty_count);
+        let assignment = assign_agents(
+            graph,
+            &subgraphs,
+            &subgraph_of_vertex,
+            occupant,
+            empty_count,
+        );
+        Decomposition {
+            subgraphs,
+            subgraph_of_vertex,
+            planks,
+            assignment,
+            empty_count,
+        }
+    }
+
+    /// Exhaustive BFS over the configuration space: can `agent` ever reach
+    /// `goal` from `occupant`, moving one atom at a time into an empty
+    /// neighbour? Ground truth for the confinement claims.
+    fn agent_can_reach(
+        graph: &LaneGraph,
+        occupant: &[Option<u32>],
+        agent: u32,
+        goal: VertexId,
+    ) -> bool {
+        let start: Vec<Option<u32>> = occupant.to_vec();
+        let mut seen: HashSet<Vec<Option<u32>>> = HashSet::new();
+        let mut queue: VecDeque<Vec<Option<u32>>> = VecDeque::new();
+        seen.insert(start.clone());
+        queue.push_back(start);
+        while let Some(state) = queue.pop_front() {
+            if state[goal] == Some(agent) {
+                return true;
+            }
+            for v in graph.vertices() {
+                let Some(q) = state[v] else { continue };
+                for &w in graph.neighbors(v) {
+                    if state[w].is_some() {
+                        continue;
+                    }
+                    let mut next = state.clone();
+                    next[v] = None;
+                    next[w] = Some(q);
+                    if seen.insert(next.clone()) {
+                        queue.push_back(next);
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// With two empty vertices the corridor is impassable, so an atom in the
+    /// left triangle is confined there — and the decomposition must say so.
+    /// Cross-checked against exhaustive search.
+    #[test]
+    fn confinement_matches_brute_force_when_corridor_is_blocked() {
+        let graph = dumbbell();
+        // 7 atoms, 2 empties (vertices 1 and 7 left free).
+        let occupant: Vec<Option<u32>> = vec![
+            Some(0), // v0, left triangle
+            None,    // v1
+            Some(1), // v2, join vertex
+            Some(2), // v3, corridor
+            Some(3), // v4, corridor
+            Some(4), // v5, corridor
+            Some(5), // v6, join vertex
+            None,    // v7
+            Some(6), // v8, right triangle
+        ];
+        assert_eq!(occupant.iter().filter(|o| o.is_none()).count(), 2);
+
+        let decomp = decompose(&graph, &occupant);
+        let sub_of_agent0 = decomp
+            .assignment
+            .get(&0)
+            .copied()
+            .expect("an atom on an inner vertex is always assigned");
+
+        // Ground truth: agent 0 genuinely cannot cross to the right triangle.
+        assert!(
+            !agent_can_reach(&graph, &occupant, 0, 8),
+            "brute force says v8 is reachable — the fixture is wrong"
+        );
+        // The decomposition must agree: v8 is outside agent 0's region.
+        assert!(
+            !decomp.contains_in_subgraph_or_planks(sub_of_agent0, 8),
+            "decomposition failed to detect confinement"
+        );
+
+        // And it must not over-claim: vertices it says are in range really
+        // are reachable.
+        for v in graph.vertices() {
+            if decomp.contains_in_subgraph_or_planks(sub_of_agent0, v) {
+                assert!(
+                    agent_can_reach(&graph, &occupant, 0, v),
+                    "claimed v{v} reachable for agent 0, brute force disagrees"
+                );
+            }
+        }
+    }
+
+    /// With enough empty vertices the corridor becomes passable, the two
+    /// triangles merge into one subgraph, and nothing is confined.
+    #[test]
+    fn corridor_merges_subgraphs_when_empties_allow() {
+        let graph = dumbbell();
+        // 2 atoms, 7 empties: m - 2 = 5 ≥ the 4-hop gap between triangles.
+        let mut occupant: Vec<Option<u32>> = vec![None; 9];
+        occupant[0] = Some(0);
+        occupant[8] = Some(1);
+
+        let decomp = decompose(&graph, &occupant);
+        assert_eq!(
+            decomp.subgraphs.len(),
+            1,
+            "triangles within m-2 hops must merge into one subgraph"
+        );
+        let sub = decomp
+            .assignment
+            .get(&0)
+            .copied()
+            .expect("agent 0 assigned");
+        assert!(decomp.contains_in_subgraph_or_planks(sub, 8));
+        assert!(agent_can_reach(&graph, &occupant, 0, 8));
+    }
+
+    /// Definition 3 condition 3 is a threshold on `m`: the same graph must
+    /// split or merge purely as a function of the empty count.
+    #[test]
+    fn subgraph_merging_is_a_threshold_in_empty_count() {
+        let graph = dumbbell();
+        let bcc = graph.biconnected();
+        // Gap between the two triangles' join vertices (2 and 6) is 4 hops,
+        // so they merge exactly when m - 2 >= 4, i.e. m >= 6.
+        for m in 2..=5 {
+            let (subs, _) = find_subgraphs(&graph, &bcc, m);
+            assert_eq!(subs.len(), 2, "m={m} should keep the triangles separate");
+        }
+        for m in 6..=9 {
+            let (subs, _) = find_subgraphs(&graph, &bcc, m);
+            assert_eq!(subs.len(), 1, "m={m} should merge the triangles");
+        }
+    }
+
+    #[test]
+    fn precedence_cycle_detected() {
+        let cycle = find_precedence_cycle(3, &[(0, 1), (1, 2), (2, 0)]);
+        let cycle = cycle.expect("0 → 1 → 2 → 0 is a cycle");
+        assert_eq!(cycle.len(), 3);
+    }
+
+    #[test]
+    fn precedence_dag_has_no_cycle() {
+        assert!(find_precedence_cycle(4, &[(0, 1), (0, 2), (1, 3), (2, 3)]).is_none());
+    }
+
+    #[test]
+    fn precedence_self_loop_is_a_cycle() {
+        assert_eq!(find_precedence_cycle(2, &[(1, 1)]), Some(vec![1]));
+    }
+}

--- a/crates/bloqade-lanes-search/src/feasibility/decomposition.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/decomposition.rs
@@ -60,6 +60,31 @@ pub struct Decomposition {
 }
 
 impl Decomposition {
+    /// Build the full decomposition for an occupancy pattern.
+    ///
+    /// `occupant[v]` is the qubit at vertex `v`, if any, and `empty_count` is
+    /// the number of empty vertices `m`. Assumes the `m ≥ 2` regime — callers
+    /// gate on [`crate::feasibility::MIN_EMPTY_VERTICES`].
+    pub fn build(graph: &LaneGraph, occupant: &[Option<u32>], empty_count: usize) -> Self {
+        let bcc = graph.biconnected();
+        let (subgraphs, subgraph_of_vertex) = find_subgraphs(graph, &bcc, empty_count);
+        let planks = find_planks(graph, &subgraphs, &subgraph_of_vertex, empty_count);
+        let assignment = assign_agents(
+            graph,
+            &subgraphs,
+            &subgraph_of_vertex,
+            occupant,
+            empty_count,
+        );
+        Self {
+            subgraphs,
+            subgraph_of_vertex,
+            planks,
+            assignment,
+            empty_count,
+        }
+    }
+
     /// Whether `v` lies in subgraph `sub` or on one of its planks — the
     /// region Proposition 1 confines an assigned agent to.
     pub fn contains_in_subgraph_or_planks(&self, sub: usize, v: VertexId) -> bool {
@@ -75,7 +100,10 @@ impl Decomposition {
 /// Starts from the nontrivial biconnected components plus the isolated
 /// degree-≥3 vertices, then repeatedly merges any two classes whose vertex
 /// sets come within `m - 2` hops, absorbing the connecting shortest path
-/// (Definition 3 condition 3, and Definition 4 condition 3).
+/// (Definition 3 condition 3, and Definition 4 condition 3). Distance 0 —
+/// two components sharing a cut vertex — is within `m - 2` hops for every
+/// `m ≥ 2`, so vertex-sharing classes always merge in the regime this
+/// decomposition runs in.
 ///
 /// The merge loop is `O(rounds × |S| × (V + E))`. The result depends only on
 /// the architecture, the blocked set, and `m`, so callers that solve many
@@ -130,11 +158,20 @@ pub fn find_subgraphs(
                 let mut dist = vec![u32::MAX; n];
                 let mut parent = vec![usize::MAX; n];
                 let mut queue: VecDeque<VertexId> = VecDeque::new();
+                let mut hits: Vec<VertexId> = Vec::new();
                 for &s in &sources {
                     dist[s] = 0;
+                    // Distance 0: a vertex this class shares with another
+                    // class (a cut vertex common to two nontrivial biconnected
+                    // components). The BFS below can only discover vertices at
+                    // distance ≥ 1, so shared vertices must be caught here —
+                    // missing them left vertex-sharing components unmerged and
+                    // produced provably wrong confinement claims at `m = 2`.
+                    if owner[s] != i && owner[s] != NO_SUBGRAPH {
+                        hits.push(s);
+                    }
                     queue.push_back(s);
                 }
-                let mut hits: Vec<VertexId> = Vec::new();
                 while let Some(u) = queue.pop_front() {
                     if dist[u] as usize >= radius {
                         continue;
@@ -190,12 +227,53 @@ pub fn find_subgraphs(
     (subgraphs, subgraph_of_vertex)
 }
 
+/// Walk the unique path leaving `start` through its neighbour `first`,
+/// collecting at most `max_len` vertices (`start` itself excluded).
+///
+/// A plank (Definition 5) is a *unique* path, so the walk stops after a
+/// branch vertex (degree ≠ 2 has no forced continuation) or a vertex that
+/// belongs to a subgraph; that terminal vertex is included in the result.
+/// This is the single definition of "the plank leaving `start` via `first`" —
+/// both [`find_planks`] and [`assign_agents`] traverse it, so the region an
+/// agent is confined to and the set of agents claimed by a subgraph cannot
+/// drift apart.
+fn walk_plank(
+    graph: &LaneGraph,
+    subgraph_of_vertex: &[usize],
+    start: VertexId,
+    first: VertexId,
+    max_len: usize,
+) -> Vec<VertexId> {
+    let mut path = Vec::new();
+    if max_len == 0 {
+        return path;
+    }
+    let mut prev = start;
+    let mut cur = first;
+    loop {
+        path.push(cur);
+        if path.len() >= max_len {
+            break;
+        }
+        // A plank is a *unique* path: stop at any branch, and at any vertex
+        // that belongs to a subgraph.
+        if graph.degree(cur) != 2 || subgraph_of_vertex[cur] != NO_SUBGRAPH {
+            break;
+        }
+        let Some(&next) = graph.neighbors(cur).iter().find(|&&w| w != prev) else {
+            break;
+        };
+        prev = cur;
+        cur = next;
+    }
+    path
+}
+
 /// Compute the planks of every subgraph (Definition 5).
 ///
 /// From each subgraph vertex with a neighbour outside the subgraph, walk
-/// outward along the forced continuation — a plank is a *unique* path, so the
-/// walk stops as soon as it reaches a vertex of degree ≥ 3 (a branch) or a
-/// vertex belonging to a subgraph. Length is capped at `m - 1` edges.
+/// outward along the forced continuation ([`walk_plank`]). Length is capped
+/// at `m - 1` edges.
 pub fn find_planks(
     graph: &LaneGraph,
     subgraphs: &[Vec<VertexId>],
@@ -216,28 +294,9 @@ pub fn find_planks(
                 if subgraph_of_vertex[u] == sub_id {
                     continue;
                 }
-                let mut path = Vec::new();
-                let mut prev = s;
-                let mut cur = u;
-                loop {
-                    path.push(cur);
-                    if path.len() >= max_len {
-                        break;
-                    }
-                    // A plank is a *unique* path: stop at any branch, and at
-                    // any vertex that belongs to a subgraph.
-                    if graph.degree(cur) != 2 || subgraph_of_vertex[cur] != NO_SUBGRAPH {
-                        break;
-                    }
-                    let Some(&next) = graph.neighbors(cur).iter().find(|&&w| w != prev) else {
-                        break;
-                    };
-                    prev = cur;
-                    cur = next;
-                }
                 planks.push(Plank {
                     start: s,
-                    vertices: path,
+                    vertices: walk_plank(graph, subgraph_of_vertex, s, u, max_len),
                 });
             }
         }
@@ -341,29 +400,27 @@ pub fn assign_agents(
                 assignment.insert(join_agent, sub_id);
 
                 // Line 10: follow the plank outward from `u`, assigning the
-                // first `m' - 1` agents found along it.
+                // first `m' - 1` agents found along it. Only vertices that
+                // belong to no subgraph count as plank vertices: an occupant
+                // of a neighbouring subgraph's vertex is that subgraph's to
+                // assign, and claiming it here would be over-assignment —
+                // the unsound direction (see the module-level note).
                 let mut budget = m_prime.saturating_sub(1);
                 if budget == 0 {
                     continue;
                 }
-                let mut prev = v;
-                let mut cur = u;
-                loop {
-                    if let Some(a) = occupant[cur] {
+                let max_len = empty_count.saturating_sub(1);
+                for &w in &walk_plank(graph, subgraph_of_vertex, v, u, max_len) {
+                    if subgraph_of_vertex[w] != NO_SUBGRAPH {
+                        break;
+                    }
+                    if let Some(a) = occupant[w] {
                         assignment.insert(a, sub_id);
                         budget -= 1;
                         if budget == 0 {
                             break;
                         }
                     }
-                    if graph.degree(cur) != 2 {
-                        break;
-                    }
-                    let Some(&next) = graph.neighbors(cur).iter().find(|&&w| w != prev) else {
-                        break;
-                    };
-                    prev = cur;
-                    cur = next;
                 }
             }
         }
@@ -504,23 +561,48 @@ mod tests {
 
     fn decompose(graph: &LaneGraph, occupant: &[Option<u32>]) -> Decomposition {
         let empty_count = occupant.iter().filter(|o| o.is_none()).count();
-        let bcc = graph.biconnected();
-        let (subgraphs, subgraph_of_vertex) = find_subgraphs(graph, &bcc, empty_count);
-        let planks = find_planks(graph, &subgraphs, &subgraph_of_vertex, empty_count);
-        let assignment = assign_agents(
-            graph,
-            &subgraphs,
-            &subgraph_of_vertex,
-            occupant,
-            empty_count,
-        );
-        Decomposition {
-            subgraphs,
-            subgraph_of_vertex,
-            planks,
-            assignment,
-            empty_count,
+        Decomposition::build(graph, occupant, empty_count)
+    }
+
+    /// Exhaustive BFS over the configuration space: for every agent, the set
+    /// of vertices it can ever occupy from `occupant`, moving one atom at a
+    /// time into an empty neighbour. Ground truth for the confinement claims.
+    fn reachable_vertices(
+        graph: &LaneGraph,
+        occupant: &[Option<u32>],
+    ) -> HashMap<u32, HashSet<VertexId>> {
+        let mut reach: HashMap<u32, HashSet<VertexId>> = HashMap::new();
+        let record = |reach: &mut HashMap<u32, HashSet<VertexId>>, state: &[Option<u32>]| {
+            for (v, o) in state.iter().enumerate() {
+                if let Some(q) = o {
+                    reach.entry(*q).or_default().insert(v);
+                }
+            }
+        };
+        let start: Vec<Option<u32>> = occupant.to_vec();
+        let mut seen: HashSet<Vec<Option<u32>>> = HashSet::new();
+        let mut queue: VecDeque<Vec<Option<u32>>> = VecDeque::new();
+        record(&mut reach, &start);
+        seen.insert(start.clone());
+        queue.push_back(start);
+        while let Some(state) = queue.pop_front() {
+            for v in graph.vertices() {
+                let Some(q) = state[v] else { continue };
+                for &w in graph.neighbors(v) {
+                    if state[w].is_some() {
+                        continue;
+                    }
+                    let mut next = state.clone();
+                    next[v] = None;
+                    next[w] = Some(q);
+                    if seen.insert(next.clone()) {
+                        record(&mut reach, &next);
+                        queue.push_back(next);
+                    }
+                }
+            }
         }
+        reach
     }
 
     /// Exhaustive BFS over the configuration space: can `agent` ever reach
@@ -667,5 +749,144 @@ mod tests {
     #[test]
     fn precedence_self_loop_is_a_cycle() {
         assert_eq!(find_precedence_cycle(2, &[(1, 1)]), Some(vec![1]));
+    }
+
+    /// Soundness invariants every decomposition must satisfy, checked against
+    /// exhaustive configuration-space search:
+    ///
+    /// 1. The subgraphs partition their vertices — no vertex in two subgraphs.
+    /// 2. Every confinement claim over-approximates reachability: an assigned
+    ///    agent must never be able to reach a vertex outside its claimed
+    ///    region, or goal containment would report a solvable instance as
+    ///    infeasible.
+    fn assert_confinement_sound(graph: &LaneGraph, occupant: &[Option<u32>], context: &str) {
+        let decomp = decompose(graph, occupant);
+
+        let mut owner_count = vec![0usize; graph.len()];
+        for verts in &decomp.subgraphs {
+            for &v in verts {
+                owner_count[v] += 1;
+            }
+        }
+        for (v, &count) in owner_count.iter().enumerate() {
+            assert!(
+                count <= 1,
+                "{context}: vertex {v} appears in {count} subgraphs — not a partition"
+            );
+        }
+
+        let reach = reachable_vertices(graph, occupant);
+        for (&agent, &sub) in &decomp.assignment {
+            for &v in &reach[&agent] {
+                assert!(
+                    decomp.contains_in_subgraph_or_planks(sub, v),
+                    "{context}: agent {agent} (assigned subgraph {sub}) can reach \
+                     v{v} by brute force, but the claimed region excludes it"
+                );
+            }
+        }
+    }
+
+    /// Regression test: two 4-cycles sharing a cut vertex, `m = 2`.
+    ///
+    /// Vertex-sharing nontrivial biconnected components are at distance 0 —
+    /// within `m - 2` hops for every `m ≥ 2` — so they must merge into one
+    /// subgraph. Before that merge existed, the decomposition kept the cycles
+    /// separate and confined the agent at v4 to the right cycle, while brute
+    /// force shows it can cross through the shared vertex — i.e. `check`
+    /// returned a false `Infeasible(GoalOutsideSubgraph)` for a solvable
+    /// instance.
+    #[test]
+    fn shared_cut_vertex_merges_and_confinement_is_sound() {
+        // Cycle A: 0-1-2-3-0. Cycle B: 0-4-5-6-0. Shared cut vertex 0.
+        let graph = LaneGraph::from_edges(
+            7,
+            &[
+                (0, 1),
+                (1, 2),
+                (2, 3),
+                (3, 0),
+                (0, 4),
+                (4, 5),
+                (5, 6),
+                (6, 0),
+            ],
+        );
+        // Atoms at 0, 1, 4, 5, 6; empties at 2, 3.
+        let occupant: Vec<Option<u32>> =
+            vec![Some(0), Some(1), None, None, Some(2), Some(3), Some(4)];
+        let decomp = decompose(&graph, &occupant);
+        assert_eq!(
+            decomp.subgraphs.len(),
+            1,
+            "cycles sharing a cut vertex must merge at m = 2"
+        );
+        assert_confinement_sound(&graph, &occupant, "shared cut vertex");
+    }
+
+    /// Three cycles sharing one cut vertex must merge transitively.
+    #[test]
+    fn three_cycles_sharing_a_vertex_merge_transitively() {
+        let graph = LaneGraph::from_edges(
+            7,
+            &[
+                (0, 1),
+                (1, 2),
+                (2, 0),
+                (0, 3),
+                (3, 4),
+                (4, 0),
+                (0, 5),
+                (5, 6),
+                (6, 0),
+            ],
+        );
+        for m in 2..=6 {
+            let bcc = graph.biconnected();
+            let (subs, sub_of_vertex) = find_subgraphs(&graph, &bcc, m);
+            assert_eq!(subs.len(), 1, "m={m}: all three cycles must merge");
+            assert!(
+                graph.vertices().all(|v| sub_of_vertex[v] == 0),
+                "m={m}: every vertex belongs to the merged subgraph"
+            );
+        }
+    }
+
+    /// Property test: on random small graphs, the decomposition's confinement
+    /// claims must over-approximate brute-force reachability. This is the
+    /// generalization of the hand-built fixtures above — it is what caught
+    /// the vertex-sharing merge bug.
+    #[test]
+    fn confinement_never_underestimates_reachability_on_random_graphs() {
+        use rand::rngs::SmallRng;
+        use rand::{Rng, SeedableRng};
+
+        for seed in 0..120u64 {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let n = rng.random_range(4..=8);
+            let mut edges: Vec<(VertexId, VertexId)> = Vec::new();
+            for a in 0..n {
+                for b in (a + 1)..n {
+                    if rng.random_bool(0.4) {
+                        edges.push((a, b));
+                    }
+                }
+            }
+            let graph = LaneGraph::from_edges(n, &edges);
+
+            // Scatter atoms over distinct vertices, leaving at least 2 empty.
+            let mut verts: Vec<VertexId> = (0..n).collect();
+            for i in (1..n).rev() {
+                let j = rng.random_range(0..=i);
+                verts.swap(i, j);
+            }
+            let n_atoms = rng.random_range(1..=(n - 2));
+            let mut occupant: Vec<Option<u32>> = vec![None; n];
+            for (q, &v) in verts.iter().take(n_atoms).enumerate() {
+                occupant[v] = Some(q as u32);
+            }
+
+            assert_confinement_sound(&graph, &occupant, &format!("seed {seed}"));
+        }
     }
 }

--- a/crates/bloqade-lanes-search/src/feasibility/graph.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/graph.rs
@@ -46,19 +46,18 @@ impl LaneGraph {
     /// intentionally absent; a location whose lanes have all been cut by
     /// blocking is retained as an isolated vertex.
     pub fn build(index: &LaneIndex, blocked: &HashSet<u64>) -> Self {
+        // Collect endpoints first, then assign vertex ids in sorted order.
+        //
+        // `LaneIndex::bus_groups` iterates a `HashMap`, so discovery order
+        // varies between processes. Numbering vertices as they are discovered
+        // would make the ids — and therefore every neighbour list, every
+        // BFS tie-break, and every downstream traversal order — differ run to
+        // run. The feasibility *verdict* is order-independent, but consumers
+        // that pick among equally-good options (a planner choosing which lane
+        // to take) would silently produce a different answer each run.
+        let mut endpoint_pairs: Vec<(u64, u64)> = Vec::new();
+        let mut seen: HashSet<u64> = HashSet::new();
         let mut locations: Vec<u64> = Vec::new();
-        let mut by_location: HashMap<u64, VertexId> = HashMap::new();
-        let mut edges: Vec<(VertexId, VertexId)> = Vec::new();
-
-        let intern = |loc: u64,
-                      locations: &mut Vec<u64>,
-                      by_location: &mut HashMap<u64, VertexId>|
-         -> VertexId {
-            *by_location.entry(loc).or_insert_with(|| {
-                locations.push(loc);
-                locations.len() - 1
-            })
-        };
 
         for (mt, bus_id, zone_id, dir) in index.bus_groups() {
             for lane in index.lanes_for(mt, bus_id, zone_id, dir) {
@@ -66,27 +65,34 @@ impl LaneGraph {
                     continue;
                 };
                 let (src_enc, dst_enc) = (src.encode(), dst.encode());
-                // Intern each unblocked endpoint even when the lane itself is
+                // Keep each unblocked endpoint even when the lane itself is
                 // dropped. A location whose every lane leads to a blocked
                 // site is still a location: an atom can sit on it, and it
                 // counts toward `m`. Dropping it would both misreport such an
                 // atom as "not on the graph" and understate the empty count.
-                let a = (!blocked.contains(&src_enc))
-                    .then(|| intern(src_enc, &mut locations, &mut by_location));
-                let b = (!blocked.contains(&dst_enc))
-                    .then(|| intern(dst_enc, &mut locations, &mut by_location));
-                if let (Some(a), Some(b)) = (a, b)
-                    && a != b
-                {
-                    edges.push((a, b));
+                for enc in [src_enc, dst_enc] {
+                    if !blocked.contains(&enc) && seen.insert(enc) {
+                        locations.push(enc);
+                    }
+                }
+                if !blocked.contains(&src_enc) && !blocked.contains(&dst_enc) {
+                    endpoint_pairs.push((src_enc, dst_enc));
                 }
             }
         }
+        locations.sort_unstable();
+
+        let by_location: HashMap<u64, VertexId> =
+            locations.iter().enumerate().map(|(i, &l)| (l, i)).collect();
 
         let mut adj: Vec<Vec<VertexId>> = vec![Vec::new(); locations.len()];
-        for (a, b) in edges {
-            adj[a].push(b);
-            adj[b].push(a);
+        for (src_enc, dst_enc) in endpoint_pairs {
+            let a = by_location[&src_enc];
+            let b = by_location[&dst_enc];
+            if a != b {
+                adj[a].push(b);
+                adj[b].push(a);
+            }
         }
         for list in &mut adj {
             list.sort_unstable();

--- a/crates/bloqade-lanes-search/src/feasibility/graph.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/graph.rs
@@ -67,9 +67,11 @@ impl LaneGraph {
                 let (src_enc, dst_enc) = (src.encode(), dst.encode());
                 // Keep each unblocked endpoint even when the lane itself is
                 // dropped. A location whose every lane leads to a blocked
-                // site is still a location: an atom can sit on it, and it
-                // counts toward `m`. Dropping it would both misreport such an
-                // atom as "not on the graph" and understate the empty count.
+                // site is still a location: an atom can sit on it. Dropping
+                // it would misreport such an atom as "not on the graph". As
+                // an isolated vertex it forms its own connected component, so
+                // it counts toward that component's `m` only — never toward
+                // anyone else's maneuvering room.
                 for enc in [src_enc, dst_enc] {
                     if !blocked.contains(&enc) && seen.insert(enc) {
                         locations.push(enc);

--- a/crates/bloqade-lanes-search/src/feasibility/graph.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/graph.rs
@@ -1,0 +1,424 @@
+//! Undirected view of the lane graph, plus biconnected-component
+//! decomposition.
+//!
+//! The feasibility analysis in [`super`] is a pebble-motion argument, and
+//! pebble motion is defined over a *simple undirected* graph. The lane graph
+//! is stored directionally ([`LaneAddr`] carries a
+//! [`Direction`](bloqade_lanes_bytecode_core::arch::addr::Direction)), but the
+//! direction field only selects which endpoint is reported as source vs
+//! destination — every lane is traversable both ways. [`LaneGraph`] collapses
+//! that into an undirected adjacency over compact vertex ids, dropping
+//! self-loops and duplicate edges so the result is simple.
+//!
+//! Blocked locations are removed from the graph entirely rather than marked
+//! occupied: an atom can never enter one, so for reachability purposes they
+//! are not vertices at all. Note the consequence — a blocked location is *not*
+//! an empty vertex, so it does not contribute to `m`.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::collections::VecDeque;
+
+use crate::primitives::lane_index::LaneIndex;
+
+/// Compact vertex identifier — an index into [`LaneGraph::locations`].
+pub type VertexId = usize;
+
+/// Undirected, simple view of the lane graph with blocked locations removed.
+#[derive(Debug)]
+pub struct LaneGraph {
+    /// Vertex id → encoded [`LocationAddr`](bloqade_lanes_bytecode_core::arch::addr::LocationAddr).
+    locations: Vec<u64>,
+    /// Encoded location → vertex id.
+    by_location: HashMap<u64, VertexId>,
+    /// Adjacency lists, sorted and deduplicated, without self-loops.
+    adj: Vec<Vec<VertexId>>,
+}
+
+impl LaneGraph {
+    /// Build the undirected lane graph, excluding every location in
+    /// `blocked`.
+    ///
+    /// Vertices are the unblocked lane endpoints reachable through
+    /// [`LaneIndex::bus_groups`] — the same location set that
+    /// [`LaneIndex::num_locations`] counts, minus `blocked`. A location that
+    /// is not an endpoint of any lane cannot participate in any move and is
+    /// intentionally absent; a location whose lanes have all been cut by
+    /// blocking is retained as an isolated vertex.
+    pub fn build(index: &LaneIndex, blocked: &HashSet<u64>) -> Self {
+        let mut locations: Vec<u64> = Vec::new();
+        let mut by_location: HashMap<u64, VertexId> = HashMap::new();
+        let mut edges: Vec<(VertexId, VertexId)> = Vec::new();
+
+        let intern = |loc: u64,
+                      locations: &mut Vec<u64>,
+                      by_location: &mut HashMap<u64, VertexId>|
+         -> VertexId {
+            *by_location.entry(loc).or_insert_with(|| {
+                locations.push(loc);
+                locations.len() - 1
+            })
+        };
+
+        for (mt, bus_id, zone_id, dir) in index.bus_groups() {
+            for lane in index.lanes_for(mt, bus_id, zone_id, dir) {
+                let Some((src, dst)) = index.endpoints(lane) else {
+                    continue;
+                };
+                let (src_enc, dst_enc) = (src.encode(), dst.encode());
+                // Intern each unblocked endpoint even when the lane itself is
+                // dropped. A location whose every lane leads to a blocked
+                // site is still a location: an atom can sit on it, and it
+                // counts toward `m`. Dropping it would both misreport such an
+                // atom as "not on the graph" and understate the empty count.
+                let a = (!blocked.contains(&src_enc))
+                    .then(|| intern(src_enc, &mut locations, &mut by_location));
+                let b = (!blocked.contains(&dst_enc))
+                    .then(|| intern(dst_enc, &mut locations, &mut by_location));
+                if let (Some(a), Some(b)) = (a, b)
+                    && a != b
+                {
+                    edges.push((a, b));
+                }
+            }
+        }
+
+        let mut adj: Vec<Vec<VertexId>> = vec![Vec::new(); locations.len()];
+        for (a, b) in edges {
+            adj[a].push(b);
+            adj[b].push(a);
+        }
+        for list in &mut adj {
+            list.sort_unstable();
+            list.dedup();
+        }
+
+        Self {
+            locations,
+            by_location,
+            adj,
+        }
+    }
+
+    /// Number of vertices.
+    pub fn len(&self) -> usize {
+        self.locations.len()
+    }
+
+    /// Whether the graph has no vertices.
+    pub fn is_empty(&self) -> bool {
+        self.locations.is_empty()
+    }
+
+    /// Vertex id for an encoded location, if present.
+    pub fn vertex_of(&self, encoded: u64) -> Option<VertexId> {
+        self.by_location.get(&encoded).copied()
+    }
+
+    /// Encoded location for a vertex id.
+    pub fn location_of(&self, v: VertexId) -> u64 {
+        self.locations[v]
+    }
+
+    /// Neighbours of `v`.
+    pub fn neighbors(&self, v: VertexId) -> &[VertexId] {
+        &self.adj[v]
+    }
+
+    /// Degree of `v`.
+    pub fn degree(&self, v: VertexId) -> usize {
+        self.adj[v].len()
+    }
+
+    /// Iterate every vertex id.
+    pub fn vertices(&self) -> impl Iterator<Item = VertexId> + '_ {
+        0..self.locations.len()
+    }
+
+    /// Connected-component id per vertex, and the component count.
+    pub fn connected_components(&self) -> (Vec<usize>, usize) {
+        let n = self.len();
+        let mut comp = vec![usize::MAX; n];
+        let mut count = 0;
+        let mut queue: VecDeque<VertexId> = VecDeque::new();
+        for start in 0..n {
+            if comp[start] != usize::MAX {
+                continue;
+            }
+            comp[start] = count;
+            queue.push_back(start);
+            while let Some(u) = queue.pop_front() {
+                for &w in &self.adj[u] {
+                    if comp[w] == usize::MAX {
+                        comp[w] = count;
+                        queue.push_back(w);
+                    }
+                }
+            }
+            count += 1;
+        }
+        (comp, count)
+    }
+
+    /// BFS hop distances from `from`. Unreachable vertices get [`u32::MAX`].
+    ///
+    /// `skip` is consulted per vertex; a vertex for which it returns `true`
+    /// is treated as absent from the graph (never entered, never expanded).
+    /// `from` itself is always entered regardless of `skip`.
+    pub fn distances_from(&self, from: VertexId, skip: impl Fn(VertexId) -> bool) -> Vec<u32> {
+        let mut dist = vec![u32::MAX; self.len()];
+        dist[from] = 0;
+        let mut queue = VecDeque::new();
+        queue.push_back(from);
+        while let Some(u) = queue.pop_front() {
+            let d = dist[u];
+            for &w in &self.adj[u] {
+                if dist[w] == u32::MAX && !skip(w) {
+                    dist[w] = d + 1;
+                    queue.push_back(w);
+                }
+            }
+        }
+        dist
+    }
+
+    /// Biconnected-component decomposition (Hopcroft–Tarjan), `O(V + E)`.
+    ///
+    /// Implemented iteratively: the recursive formulation would recurse to
+    /// the DFS depth, which is `O(V)` on a corridor-heavy architecture.
+    pub fn biconnected(&self) -> Biconnected {
+        let n = self.len();
+        let mut disc = vec![0u32; n];
+        let mut low = vec![0u32; n];
+        let mut timer: u32 = 1;
+        let mut edge_stack: Vec<(VertexId, VertexId)> = Vec::new();
+        let mut components: Vec<Vec<VertexId>> = Vec::new();
+        let mut edge_counts: Vec<usize> = Vec::new();
+        let mut by_vertex: Vec<Vec<usize>> = vec![Vec::new(); n];
+
+        // Drain `edge_stack` down to and including the edge `(p, u)`, and
+        // record the popped edges as one biconnected component.
+        let emit = |edge_stack: &mut Vec<(VertexId, VertexId)>,
+                    p: VertexId,
+                    u: VertexId,
+                    components: &mut Vec<Vec<VertexId>>,
+                    edge_counts: &mut Vec<usize>,
+                    by_vertex: &mut Vec<Vec<usize>>| {
+            let comp_id = components.len();
+            let mut verts: Vec<VertexId> = Vec::new();
+            let mut edges = 0usize;
+            while let Some((a, b)) = edge_stack.pop() {
+                verts.push(a);
+                verts.push(b);
+                edges += 1;
+                if (a, b) == (p, u) {
+                    break;
+                }
+            }
+            verts.sort_unstable();
+            verts.dedup();
+            for &v in &verts {
+                by_vertex[v].push(comp_id);
+            }
+            components.push(verts);
+            edge_counts.push(edges);
+        };
+
+        for start in 0..n {
+            if disc[start] != 0 {
+                continue;
+            }
+            disc[start] = timer;
+            low[start] = timer;
+            timer += 1;
+            // Frame: (vertex, parent, next index into adj[vertex]).
+            let mut stack: Vec<(VertexId, VertexId, usize)> = vec![(start, usize::MAX, 0)];
+
+            while let Some(&(u, parent, i)) = stack.last() {
+                if i < self.adj[u].len() {
+                    stack.last_mut().expect("stack is non-empty").2 += 1;
+                    let v = self.adj[u][i];
+                    if v == parent {
+                        continue;
+                    }
+                    if disc[v] == 0 {
+                        edge_stack.push((u, v));
+                        disc[v] = timer;
+                        low[v] = timer;
+                        timer += 1;
+                        stack.push((v, u, 0));
+                    } else if disc[v] < disc[u] {
+                        // Back edge to an ancestor.
+                        edge_stack.push((u, v));
+                        low[u] = low[u].min(disc[v]);
+                    }
+                } else {
+                    stack.pop();
+                    if let Some(&(p, _, _)) = stack.last() {
+                        low[p] = low[p].min(low[u]);
+                        if low[u] >= disc[p] {
+                            emit(
+                                &mut edge_stack,
+                                p,
+                                u,
+                                &mut components,
+                                &mut edge_counts,
+                                &mut by_vertex,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        Biconnected {
+            components,
+            edge_counts,
+            by_vertex,
+        }
+    }
+}
+
+#[cfg(test)]
+impl LaneGraph {
+    /// Build a graph directly from an edge list, bypassing the architecture.
+    ///
+    /// Lets the graph and decomposition tests use the small hand-checkable
+    /// examples the pebble-motion literature is stated over, and lets them
+    /// cross-check verdicts against brute-force reachability.
+    pub(crate) fn from_edges(n: usize, edges: &[(VertexId, VertexId)]) -> Self {
+        let mut adj = vec![Vec::new(); n];
+        for &(a, b) in edges {
+            adj[a].push(b);
+            adj[b].push(a);
+        }
+        for list in &mut adj {
+            list.sort_unstable();
+            list.dedup();
+        }
+        Self {
+            locations: (0..n as u64).collect(),
+            by_location: (0..n as u64).map(|i| (i, i as usize)).collect(),
+            adj,
+        }
+    }
+}
+
+/// Biconnected components of a [`LaneGraph`].
+#[derive(Debug)]
+pub struct Biconnected {
+    /// Component id → the vertices incident to that component's edges.
+    pub components: Vec<Vec<VertexId>>,
+    /// Component id → number of edges in the component.
+    pub edge_counts: Vec<usize>,
+    /// Vertex id → the component ids it belongs to.
+    pub by_vertex: Vec<Vec<usize>>,
+}
+
+impl Biconnected {
+    /// A component is *nontrivial* when it contains more than one edge —
+    /// equivalently, when it contains a cycle. Definition 1 of de Wilde et
+    /// al. (2014) calls single-edge components trivial; only nontrivial
+    /// components let agents exchange position.
+    pub fn is_nontrivial(&self, comp_id: usize) -> bool {
+        self.edge_counts[comp_id] > 1
+    }
+
+    /// Join vertices (Definition 2): degree ≥ 3 and common to at least two
+    /// biconnected components.
+    pub fn join_vertices(&self, graph: &LaneGraph) -> Vec<VertexId> {
+        graph
+            .vertices()
+            .filter(|&v| graph.degree(v) >= 3 && self.by_vertex[v].len() >= 2)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn from_edges(n: usize, edges: &[(VertexId, VertexId)]) -> LaneGraph {
+        LaneGraph::from_edges(n, edges)
+    }
+
+    #[test]
+    fn triangle_is_one_nontrivial_component() {
+        let g = from_edges(3, &[(0, 1), (1, 2), (2, 0)]);
+        let bcc = g.biconnected();
+        assert_eq!(bcc.components.len(), 1);
+        assert!(bcc.is_nontrivial(0));
+        assert_eq!(bcc.edge_counts[0], 3);
+    }
+
+    #[test]
+    fn path_is_all_trivial_components() {
+        // 0 — 1 — 2 — 3: three bridges, each its own trivial component.
+        let g = from_edges(4, &[(0, 1), (1, 2), (2, 3)]);
+        let bcc = g.biconnected();
+        assert_eq!(bcc.components.len(), 3);
+        assert!(bcc.components.iter().enumerate().all(|(i, _)| {
+            assert_eq!(bcc.edge_counts[i], 1);
+            !bcc.is_nontrivial(i)
+        }));
+    }
+
+    #[test]
+    fn two_triangles_joined_by_a_bridge() {
+        // Triangle {0,1,2} — bridge (2,3) — triangle {3,4,5}.
+        let g = from_edges(6, &[(0, 1), (1, 2), (2, 0), (2, 3), (3, 4), (4, 5), (5, 3)]);
+        let bcc = g.biconnected();
+        assert_eq!(bcc.components.len(), 3, "two triangles plus one bridge");
+        let nontrivial: Vec<usize> = (0..bcc.components.len())
+            .filter(|&i| bcc.is_nontrivial(i))
+            .collect();
+        assert_eq!(nontrivial.len(), 2);
+        // Vertices 2 and 3 are cut vertices, each in two components.
+        assert_eq!(bcc.by_vertex[2].len(), 2);
+        assert_eq!(bcc.by_vertex[3].len(), 2);
+        assert_eq!(bcc.by_vertex[0].len(), 1);
+    }
+
+    #[test]
+    fn join_vertices_need_degree_three_and_two_components() {
+        // Triangle {0,1,2} with a pendant path 2 — 3 — 4.
+        // Vertex 2 has degree 3 and sits in two components → join vertex.
+        // Vertex 3 has degree 2 → not a join vertex despite two components.
+        let g = from_edges(5, &[(0, 1), (1, 2), (2, 0), (2, 3), (3, 4)]);
+        let bcc = g.biconnected();
+        assert_eq!(bcc.join_vertices(&g), vec![2]);
+    }
+
+    #[test]
+    fn disconnected_graph_decomposes_per_component() {
+        // Triangle {0,1,2} and a separate edge (3,4).
+        let g = from_edges(5, &[(0, 1), (1, 2), (2, 0), (3, 4)]);
+        let bcc = g.biconnected();
+        assert_eq!(bcc.components.len(), 2);
+        let (comp, count) = g.connected_components();
+        assert_eq!(count, 2);
+        assert_eq!(comp[0], comp[1]);
+        assert_ne!(comp[0], comp[3]);
+    }
+
+    #[test]
+    fn deep_path_does_not_overflow_the_stack() {
+        // The recursive Hopcroft–Tarjan formulation would recurse 200k
+        // deep here; the iterative one must not.
+        let n = 200_000;
+        let edges: Vec<(VertexId, VertexId)> = (0..n - 1).map(|i| (i, i + 1)).collect();
+        let g = from_edges(n, &edges);
+        let bcc = g.biconnected();
+        assert_eq!(bcc.components.len(), n - 1);
+    }
+
+    #[test]
+    fn distances_from_respects_skip() {
+        // 0 — 1 — 2 — 3, with vertex 2 skipped: 3 becomes unreachable.
+        let g = from_edges(4, &[(0, 1), (1, 2), (2, 3)]);
+        let d = g.distances_from(0, |v| v == 2);
+        assert_eq!(d[1], 1);
+        assert_eq!(d[2], u32::MAX);
+        assert_eq!(d[3], u32::MAX);
+    }
+}

--- a/crates/bloqade-lanes-search/src/feasibility/mod.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/mod.rs
@@ -59,8 +59,7 @@ use std::collections::{HashMap, HashSet};
 use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
 
 use crate::feasibility::decomposition::{
-    Decomposition, assign_agents, find_planks, find_precedence_cycle, find_subgraphs,
-    subgraph_priorities,
+    Decomposition, find_precedence_cycle, subgraph_priorities,
 };
 use crate::feasibility::graph::{LaneGraph, VertexId};
 use crate::primitives::config::Config;
@@ -208,8 +207,9 @@ pub fn validate_bus_disjointness(arch: &ArchSpec) -> Vec<String> {
 /// Exposed because the Push and Rotate planner needs exactly this: the
 /// subgraphs drive its `swap` feasibility, and the precedence order drives its
 /// agent priorities. Returns `None` when there are fewer than
-/// [`MIN_EMPTY_VERTICES`] empty vertices, since the decomposition's guarantees
-/// do not hold there.
+/// [`MIN_EMPTY_VERTICES`] empty vertices (the decomposition's guarantees do
+/// not hold there), and for malformed input — an atom off the graph, or two
+/// atoms sharing a location — which [`check`] reports as its own obstruction.
 pub fn build_decomposition(
     index: &LaneIndex,
     initial: &Config,
@@ -217,41 +217,26 @@ pub fn build_decomposition(
 ) -> Option<(LaneGraph, Decomposition)> {
     let graph = LaneGraph::build(index, blocked);
     let occupant = occupancy(&graph, initial)?;
-    let atom_count = occupant.iter().filter(|o| o.is_some()).count();
-    let empty_count = graph.len().checked_sub(atom_count)?;
+    let empty_count = graph.len().checked_sub(initial.len())?;
     if empty_count < MIN_EMPTY_VERTICES {
         return None;
     }
 
-    let bcc = graph.biconnected();
-    let (subgraphs, subgraph_of_vertex) = find_subgraphs(&graph, &bcc, empty_count);
-    let planks = find_planks(&graph, &subgraphs, &subgraph_of_vertex, empty_count);
-    let assignment = assign_agents(
-        &graph,
-        &subgraphs,
-        &subgraph_of_vertex,
-        &occupant,
-        empty_count,
-    );
-
-    let decomp = Decomposition {
-        subgraphs,
-        subgraph_of_vertex,
-        planks,
-        assignment,
-        empty_count,
-    };
+    let decomp = Decomposition::build(&graph, &occupant, empty_count);
     Some((graph, decomp))
 }
 
 /// Map each graph vertex to the qubit occupying it, or `None`.
 ///
-/// Returns `None` if any atom sits off the graph — the caller reports that as
-/// its own obstruction.
+/// Returns `None` if any atom sits off the graph or two atoms share a
+/// location — the caller reports those as its own obstructions.
 fn occupancy(graph: &LaneGraph, initial: &Config) -> Option<Vec<Option<u32>>> {
     let mut occupant = vec![None; graph.len()];
     for (qubit, loc) in initial.iter() {
         let v = graph.vertex_of(loc.encode())?;
+        if occupant[v].is_some() {
+            return None;
+        }
         occupant[v] = Some(qubit);
     }
     Some(occupant)
@@ -260,8 +245,10 @@ fn occupancy(graph: &LaneGraph, initial: &Config) -> Option<Vec<Option<u32>>> {
 /// Check an instance for a proven obstruction.
 ///
 /// `targets` is the desired `(qubit, encoded location)` assignment; qubits
-/// absent from it are unconstrained. `blocked` locations are treated as
-/// removed from the graph entirely.
+/// absent from it are unconstrained. A target for a qubit that is not in
+/// `initial` is checked for well-formedness but otherwise ignored — there is
+/// no atom to move. `blocked` locations are treated as removed from the
+/// graph entirely.
 pub fn check(
     index: &LaneIndex,
     initial: &Config,
@@ -339,23 +326,7 @@ pub fn check(
         return Feasibility::NoObstructionFound;
     }
 
-    let bcc = graph.biconnected();
-    let (subgraphs, subgraph_of_vertex) = find_subgraphs(&graph, &bcc, empty_count);
-    let planks = find_planks(&graph, &subgraphs, &subgraph_of_vertex, empty_count);
-    let assignment = assign_agents(
-        &graph,
-        &subgraphs,
-        &subgraph_of_vertex,
-        &occupant,
-        empty_count,
-    );
-    let decomp = Decomposition {
-        subgraphs,
-        subgraph_of_vertex,
-        planks,
-        assignment,
-        empty_count,
-    };
+    let decomp = Decomposition::build(&graph, &occupant, empty_count);
 
     // Goal containment: Proposition 1 confines an assigned agent to its
     // subgraph and planks, so a goal outside that region is unreachable.
@@ -373,9 +344,14 @@ pub fn check(
     }
 
     // Proposition 2: a cyclic precedence relation proves unsolvability.
+    // A target for a qubit absent from `initial` constrains nothing — there
+    // is no atom to move. It is well-formedness-checked above, but excluded
+    // here so a phantom goal cannot fabricate precedence edges (and, in the
+    // worst case, a spurious cycle).
+    let initial_qubits: HashSet<u32> = initial.iter().map(|(q, _)| q).collect();
     let unassigned_goal_vertices: HashSet<VertexId> = target_vertex
         .iter()
-        .filter(|(q, _)| !decomp.assignment.contains_key(q))
+        .filter(|(q, _)| initial_qubits.contains(q) && !decomp.assignment.contains_key(q))
         .map(|(_, &v)| v)
         .collect();
     let edges = subgraph_priorities(&decomp, &target_vertex, &unassigned_goal_vertices);
@@ -475,6 +451,28 @@ mod tests {
             verdict,
             Feasibility::Infeasible(Obstruction::DuplicateOccupancy { .. })
         ));
+    }
+
+    #[test]
+    fn build_decomposition_rejects_duplicate_occupancy() {
+        let index = index_from(example_arch_json());
+        // `Config` only rejects duplicate qubit ids, not duplicate locations;
+        // rather than silently dropping an atom, decline to decompose.
+        let initial = Config::new([(0, loc(0, 0)), (1, loc(0, 0))]).expect("config");
+        assert!(build_decomposition(&index, &initial, &HashSet::new()).is_none());
+    }
+
+    #[test]
+    fn target_for_absent_qubit_is_ignored() {
+        let index = index_from(example_arch_json());
+        let initial = Config::new([(0, loc(0, 0))]).expect("config");
+        // Qubit 7 is not in `initial`: its target is well-formedness checked
+        // but must not constrain feasibility (there is no atom to move).
+        let targets = [(7u32, loc(0, 5).encode())];
+        assert_eq!(
+            check(&index, &initial, &targets, &HashSet::new()),
+            Feasibility::NoObstructionFound
+        );
     }
 
     #[test]

--- a/crates/bloqade-lanes-search/src/feasibility/mod.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/mod.rs
@@ -76,9 +76,12 @@ use crate::feasibility::graph::{LaneGraph, VertexId};
 use crate::primitives::config::Config;
 use crate::primitives::lane_index::LaneIndex;
 
-/// Minimum number of empty vertices for the decomposition-based obstructions
-/// to apply. Push and Rotate is complete only at or above this threshold, and
-/// below it Wilson's parity exceptions come into play.
+/// Minimum number of empty vertices — per connected component — for the
+/// decomposition-based obstructions to apply to that component. Push and
+/// Rotate is complete only at or above this threshold, and below it Wilson's
+/// parity exceptions come into play. Empties are counted per component
+/// because a disconnected instance is a product of independent pebble-motion
+/// instances: an empty vertex in another component cannot help maneuvering.
 pub const MIN_EMPTY_VERTICES: usize = 2;
 
 /// A proven reason the instance cannot be solved.
@@ -240,10 +243,12 @@ fn debug_assert_valid_arch(_index: &LaneIndex) {
 ///
 /// Exposed because the Push and Rotate planner needs exactly this: the
 /// subgraphs drive its `swap` feasibility, and the precedence order drives its
-/// agent priorities. Returns `None` when there are fewer than
-/// [`MIN_EMPTY_VERTICES`] empty vertices (the decomposition's guarantees do
-/// not hold there), and for malformed input — an atom off the graph, or two
-/// atoms sharing a location — which [`check`] reports as its own obstruction.
+/// agent priorities. Each connected component is analysed with its own empty
+/// count; components below [`MIN_EMPTY_VERTICES`] contribute no subgraphs.
+/// Returns `None` when the whole graph has fewer than [`MIN_EMPTY_VERTICES`]
+/// empty vertices (no component can qualify), and for malformed input — an
+/// atom off the graph, or two atoms sharing a location — which [`check`]
+/// reports as its own obstruction.
 pub fn build_decomposition(
     index: &LaneIndex,
     initial: &Config,
@@ -257,7 +262,7 @@ pub fn build_decomposition(
         return None;
     }
 
-    let decomp = Decomposition::build(&graph, &occupant, empty_count);
+    let decomp = Decomposition::build(&graph, &occupant);
     Some((graph, decomp))
 }
 
@@ -360,19 +365,36 @@ pub fn check(
     }
 
     // ── Decomposition-based obstructions ────────────────────────────
-    let atom_count = initial.len();
-    let Some(empty_count) = graph.len().checked_sub(atom_count) else {
-        // More atoms than vertices is caught by DuplicateOccupancy above,
-        // so this is unreachable in practice; stay conservative anyway.
-        return Feasibility::NoObstructionFound;
-    };
+    match decomposition_obstruction(&graph, &occupant, &target_vertex) {
+        Some(obstruction) => Feasibility::Infeasible(obstruction),
+        None => Feasibility::NoObstructionFound,
+    }
+}
+
+/// Decomposition-phase obstructions (goal containment and Proposition 2) on
+/// a well-formed instance.
+///
+/// `occupant` must be injective over the graph's vertices, and
+/// `target_vertex` must map only qubits that occupy a vertex — [`check`]
+/// establishes both before calling. Kept separate from [`check`] so the
+/// brute-force soundness tests can exercise the decomposition verdict on
+/// synthetic [`LaneGraph`]s directly.
+fn decomposition_obstruction(
+    graph: &LaneGraph,
+    occupant: &[Option<u32>],
+    target_vertex: &HashMap<u32, VertexId>,
+) -> Option<Obstruction> {
+    let atom_count = occupant.iter().filter(|o| o.is_some()).count();
+    let empty_count = graph.len().saturating_sub(atom_count);
     if empty_count < MIN_EMPTY_VERTICES {
-        // Below the Push and Rotate regime the decomposition's guarantees do
-        // not hold, so we report only what the cheap checks established.
-        return Feasibility::NoObstructionFound;
+        // No component can be in the Push and Rotate regime, so only the
+        // cheap checks stand. Fast path — `build` would produce an empty
+        // decomposition anyway, since components below the threshold get no
+        // subgraphs.
+        return None;
     }
 
-    let decomp = Decomposition::build(&graph, &occupant, empty_count);
+    let decomp = Decomposition::build(graph, occupant);
 
     // Goal containment: Proposition 1 confines an assigned agent to its
     // subgraph and planks, so a goal outside that region is unreachable.
@@ -381,7 +403,7 @@ pub fn check(
             continue;
         };
         if !decomp.contains_in_subgraph_or_planks(sub, goal_v) {
-            return Feasibility::Infeasible(Obstruction::GoalOutsideSubgraph {
+            return Some(Obstruction::GoalOutsideSubgraph {
                 qubit,
                 subgraph: sub,
                 goal: graph.location_of(goal_v),
@@ -390,19 +412,17 @@ pub fn check(
     }
 
     // Proposition 2: a cyclic precedence relation proves unsolvability.
-    // `target_vertex` only holds qubits present in `initial` (phantom
-    // targets were dropped up front), so every goal here is a real one.
     let unassigned_goal_vertices: HashSet<VertexId> = target_vertex
         .iter()
         .filter(|(q, _)| !decomp.assignment.contains_key(q))
         .map(|(_, &v)| v)
         .collect();
-    let edges = subgraph_priorities(&decomp, &target_vertex, &unassigned_goal_vertices);
+    let edges = subgraph_priorities(&decomp, target_vertex, &unassigned_goal_vertices);
     if let Some(cycle) = find_precedence_cycle(decomp.subgraphs.len(), &edges) {
-        return Feasibility::Infeasible(Obstruction::CyclicPrecedence { subgraphs: cycle });
+        return Some(Obstruction::CyclicPrecedence { subgraphs: cycle });
     }
 
-    Feasibility::NoObstructionFound
+    None
 }
 
 #[cfg(test)]
@@ -410,6 +430,182 @@ mod tests {
     use super::*;
     use crate::test_utils::{example_arch_json, loc};
     use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+
+    /// Brute force over the configuration space: is there a reachable state
+    /// where every targeted agent sits on its goal simultaneously? Ground
+    /// truth for the decomposition verdict.
+    fn instance_solvable(
+        graph: &LaneGraph,
+        occupant: &[Option<u32>],
+        targets: &HashMap<u32, VertexId>,
+    ) -> bool {
+        use std::collections::VecDeque;
+        let satisfied =
+            |state: &[Option<u32>]| targets.iter().all(|(&q, &goal)| state[goal] == Some(q));
+        let start: Vec<Option<u32>> = occupant.to_vec();
+        if satisfied(&start) {
+            return true;
+        }
+        let mut seen: HashSet<Vec<Option<u32>>> = HashSet::new();
+        let mut queue: VecDeque<Vec<Option<u32>>> = VecDeque::new();
+        seen.insert(start.clone());
+        queue.push_back(start);
+        while let Some(state) = queue.pop_front() {
+            for v in graph.vertices() {
+                let Some(q) = state[v] else { continue };
+                for &w in graph.neighbors(v) {
+                    if state[w].is_some() {
+                        continue;
+                    }
+                    let mut next = state.clone();
+                    next[v] = None;
+                    next[w] = Some(q);
+                    if satisfied(&next) {
+                        return true;
+                    }
+                    if seen.insert(next.clone()) {
+                        queue.push_back(next);
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// End-to-end soundness property: whenever the decomposition phase
+    /// reports an obstruction, exhaustive search must confirm the instance
+    /// unsolvable. Random graphs are frequently disconnected, and half the
+    /// seeds append an extra all-empty component — probing that empties
+    /// stranded in one component cannot weaken or fabricate verdicts in
+    /// another.
+    #[test]
+    fn decomposition_verdicts_match_brute_force_on_random_graphs() {
+        use rand::rngs::SmallRng;
+        use rand::{Rng, SeedableRng};
+
+        let mut fired = 0usize;
+        for seed in 0..400u64 {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let n_core = rng.random_range(4..=8);
+            let density = if seed % 2 == 0 { 0.25 } else { 0.4 };
+            let mut edges: Vec<(VertexId, VertexId)> = Vec::new();
+            for a in 0..n_core {
+                for b in (a + 1)..n_core {
+                    if rng.random_bool(density) {
+                        edges.push((a, b));
+                    }
+                }
+            }
+            // Half the seeds: strand extra empties in a separate component.
+            let stranded = if seed % 2 == 0 { 3 } else { 0 };
+            let n = n_core + stranded;
+            if stranded > 0 {
+                edges.push((n_core, n_core + 1));
+                edges.push((n_core + 1, n_core + 2));
+            }
+            let graph = LaneGraph::from_edges(n, &edges);
+
+            // Atoms only on core vertices, ≥ 2 empties among them.
+            let mut verts: Vec<VertexId> = (0..n_core).collect();
+            for i in (1..n_core).rev() {
+                let j = rng.random_range(0..=i);
+                verts.swap(i, j);
+            }
+            let n_atoms = rng.random_range(1..=(n_core - 2));
+            let mut occupant: Vec<Option<u32>> = vec![None; n];
+            for (q, &v) in verts.iter().take(n_atoms).enumerate() {
+                occupant[v] = Some(q as u32);
+            }
+
+            // Arbitrary targets (not necessarily solvable): a random subset
+            // of agents onto random distinct core vertices.
+            let n_targets = rng.random_range(1..=n_atoms);
+            let mut goal_verts: Vec<VertexId> = (0..n_core).collect();
+            for i in (1..n_core).rev() {
+                let j = rng.random_range(0..=i);
+                goal_verts.swap(i, j);
+            }
+            let target_vertex: HashMap<u32, VertexId> =
+                (0..n_targets as u32).zip(goal_verts.into_iter()).collect();
+
+            if let Some(obstruction) = decomposition_obstruction(&graph, &occupant, &target_vertex)
+            {
+                fired += 1;
+                assert!(
+                    !instance_solvable(&graph, &occupant, &target_vertex),
+                    "seed {seed}: {obstruction:?} claimed for a brute-force-solvable \
+                     instance (occupant {occupant:?}, targets {target_vertex:?})"
+                );
+            }
+        }
+        // The property is vacuous if obstructions rarely fire; keep the
+        // fixture generator honest.
+        eprintln!("obstructions fired on {fired}/400 seeds");
+        assert!(
+            fired > 0,
+            "no seed produced an obstruction — weaken density"
+        );
+    }
+
+    /// Adversarial per-component-m fixture: a dumbbell with 2 local empties
+    /// plus 3 empties stranded in a separate component. Goals sit on plank
+    /// positions that only exist if `m` were counted globally — under a
+    /// global `m` this produced a precedence cycle; under per-component `m`
+    /// the same instance is caught by goal containment instead. Either way
+    /// the verdict must agree with exhaustive search (the instance is
+    /// genuinely unsolvable: crossing the corridor needs more than the two
+    /// local empties).
+    #[test]
+    fn stranded_empties_verdict_agrees_with_brute_force() {
+        let graph = LaneGraph::from_edges(
+            12,
+            &[
+                // dumbbell: triangles {0,1,2} and {6,7,8}, corridor 3-4-5
+                (0, 1),
+                (1, 2),
+                (2, 0),
+                (2, 3),
+                (3, 4),
+                (4, 5),
+                (5, 6),
+                (6, 7),
+                (7, 8),
+                (8, 6),
+                // stranded all-empty component
+                (9, 10),
+                (10, 11),
+            ],
+        );
+        // Atoms at 0(B),2,3,4(X),5,6,8(A); empties 1,7 locally + 9,10,11.
+        let occupant: Vec<Option<u32>> = vec![
+            Some(0), // B
+            None,
+            Some(1),
+            Some(2),
+            Some(3), // X
+            Some(4),
+            Some(5),
+            None,
+            Some(6), // A
+            None,
+            None,
+            None,
+        ];
+        // B: 0→6 (case-1 precedence edge S1≺S0, m-independent).
+        // A: 8→4 (on S0's plank only under inflated m → edge S0≺S1).
+        // X: 4→3 (unassigned goal filling the 'between' slot for A's edge).
+        let target_vertex: HashMap<u32, VertexId> =
+            [(0u32, 6usize), (6u32, 4usize), (3u32, 3usize)]
+                .into_iter()
+                .collect();
+        let verdict = decomposition_obstruction(&graph, &occupant, &target_vertex);
+        let solvable = instance_solvable(&graph, &occupant, &target_vertex);
+        assert!(!solvable, "fixture must be unsolvable — corridor too tight");
+        assert!(
+            verdict.is_some(),
+            "the decomposition should catch this unsolvable instance"
+        );
+    }
 
     fn index_from(json: &str) -> LaneIndex {
         let spec: ArchSpec = serde_json::from_str(json).expect("arch json parses");

--- a/crates/bloqade-lanes-search/src/feasibility/mod.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/mod.rs
@@ -281,9 +281,11 @@ fn occupancy(graph: &LaneGraph, initial: &Config) -> Option<Vec<Option<u32>>> {
 ///
 /// `targets` is the desired `(qubit, encoded location)` assignment; qubits
 /// absent from it are unconstrained. A target for a qubit that is not in
-/// `initial` is checked for well-formedness but otherwise ignored — there is
-/// no atom to move. `blocked` locations are treated as removed from the
-/// graph entirely.
+/// `initial` is ignored entirely — there is no atom to move, so it cannot
+/// constrain anything, and it must not be able to produce an obstruction
+/// (a duplicate target, an off-graph target, or a precedence edge) for an
+/// otherwise solvable instance. `blocked` locations are treated as removed
+/// from the graph entirely.
 pub fn check(
     index: &LaneIndex,
     initial: &Config,
@@ -312,9 +314,17 @@ pub fn check(
         occupant[v] = Some(qubit);
     }
 
+    // Targets for qubits absent from `initial` are dropped before any check:
+    // there is no atom to move, so such a target is vacuous, and letting it
+    // reach the duplicate/off-graph checks below (or the precedence relation
+    // later) could manufacture an obstruction for a solvable instance.
+    let initial_qubits: HashSet<u32> = initial.iter().map(|(q, _)| q).collect();
     let mut target_vertex: HashMap<u32, VertexId> = HashMap::new();
     let mut target_seen: HashMap<u64, u32> = HashMap::new();
     for &(qubit, enc) in targets {
+        if !initial_qubits.contains(&qubit) {
+            continue;
+        }
         let Some(v) = graph.vertex_of(enc) else {
             return Feasibility::Infeasible(Obstruction::TargetNotOnGraph {
                 qubit,
@@ -380,14 +390,11 @@ pub fn check(
     }
 
     // Proposition 2: a cyclic precedence relation proves unsolvability.
-    // A target for a qubit absent from `initial` constrains nothing — there
-    // is no atom to move. It is well-formedness-checked above, but excluded
-    // here so a phantom goal cannot fabricate precedence edges (and, in the
-    // worst case, a spurious cycle).
-    let initial_qubits: HashSet<u32> = initial.iter().map(|(q, _)| q).collect();
+    // `target_vertex` only holds qubits present in `initial` (phantom
+    // targets were dropped up front), so every goal here is a real one.
     let unassigned_goal_vertices: HashSet<VertexId> = target_vertex
         .iter()
-        .filter(|(q, _)| initial_qubits.contains(q) && !decomp.assignment.contains_key(q))
+        .filter(|(q, _)| !decomp.assignment.contains_key(q))
         .map(|(_, &v)| v)
         .collect();
     let edges = subgraph_priorities(&decomp, &target_vertex, &unassigned_goal_vertices);
@@ -518,12 +525,18 @@ mod tests {
     }
 
     #[test]
-    fn target_for_absent_qubit_is_ignored() {
+    fn targets_for_absent_qubits_are_ignored_entirely() {
         let index = index_from(example_arch_json());
         let initial = Config::new([(0, loc(0, 0))]).expect("config");
-        // Qubit 7 is not in `initial`: its target is well-formedness checked
-        // but must not constrain feasibility (there is no atom to move).
-        let targets = [(7u32, loc(0, 5).encode())];
+        // Qubits 7 and 8 are not in `initial`: their targets are vacuous and
+        // must not produce an obstruction of any kind — not a collision with
+        // a real target (qubit 0's), and not an off-graph location. The
+        // instance is solvable without moving anything for them.
+        let targets = [
+            (0u32, loc(0, 5).encode()),
+            (7u32, loc(0, 5).encode()),  // collides with qubit 0's target
+            (8u32, loc(99, 0).encode()), // word 99 is off the graph
+        ];
         assert_eq!(
             check(&index, &initial, &targets, &HashSet::new()),
             Feasibility::NoObstructionFound

--- a/crates/bloqade-lanes-search/src/feasibility/mod.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/mod.rs
@@ -1,0 +1,690 @@
+//! Sound infeasibility detection for atom rearrangement.
+//!
+//! Answers the question the solvers cannot: *is this rearrangement possible at
+//! all?* Today a solver that drains its frontier reports
+//! [`SolveStatus::Unsolvable`](crate::search::result::SolveStatus::Unsolvable),
+//! but for the entropy/DFS/IDS drivers — which run a pruning generator and are
+//! not exhaustive — that is a guess, not a proof. This module supplies the
+//! proof side, so callers can distinguish "the hardware cannot do this" from
+//! "the heuristic gave up".
+//!
+//! ## Why pebble motion applies
+//!
+//! Atom rearrangement here is *exactly* classical pebble motion on an
+//! undirected graph, for two reasons specific to this architecture:
+//!
+//! 1. A single-lane [`MoveSet`](crate::primitives::graph::MoveSet) is always a
+//!    legal AOD operation — `ArchSpec::check_lanes` only applies the
+//!    complete-rectangle geometry constraint to groups of more than one lane.
+//!    So single-pebble moves are available.
+//! 2. Every bus is a matching between *disjoint* source and destination sets,
+//!    so a multi-lane move is a set of vertex-disjoint edges whose
+//!    destinations must all already be empty. Such a move serializes into
+//!    independent single-pebble moves in any order, and no move can rotate a
+//!    cycle of atoms with no empty vertex.
+//!
+//! Together these mean the set of reachable configurations under AOD moves is
+//! identical to the set reachable under one-atom-at-a-time pebble motion —
+//! AOD parallelism changes the schedule, not what is reachable. Point 2 is a
+//! property of the shipped architecture specs rather than of the format, so
+//! [`validate_bus_disjointness`] checks it explicitly; if it ever fails, the
+//! reduction in this module is invalid.
+//!
+//! ## What this does and does not prove
+//!
+//! The verdict is **one-sided**. [`Feasibility::Infeasible`] is a proof.
+//! [`Feasibility::NoObstructionFound`] is *not* a proof of feasibility — it
+//! means none of the implemented obstructions fired.
+//!
+//! The obstructions come from the Kornhauser subgraph decomposition as
+//! reconstructed by de Wilde, ter Mors & Witteveen (JAIR 51, 2014, §3.1):
+//! goal containment (p. 457, "individual subgraphs are solvable in case the
+//! goal positions of the agents assigned to a subgraph are inside the
+//! subgraph or its planks") and Proposition 2 (p. 461, "if the priority
+//! relation between subgraphs is cyclic, then the instance is not solvable").
+//! Whether those two are jointly *sufficient* at `m ≥ 2` is not claimed by
+//! the paper, and is not claimed here. A complete oracle requires running the
+//! Push and Rotate planner itself, which returns `false` exactly when the
+//! instance is unsolvable (Theorem 1) — that is follow-up work.
+//!
+//! Note also that Wilson's parity exceptions (cycle graphs and θ₀) only arise
+//! with a *single* empty vertex. At `m ≥ 2` the group-theoretic obstruction
+//! disappears, which is why nothing here computes permutation parity.
+
+pub mod decomposition;
+pub mod graph;
+
+use std::collections::{HashMap, HashSet};
+
+use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+
+use crate::feasibility::decomposition::{
+    Decomposition, assign_agents, find_planks, find_precedence_cycle, find_subgraphs,
+    subgraph_priorities,
+};
+use crate::feasibility::graph::{LaneGraph, VertexId};
+use crate::primitives::config::Config;
+use crate::primitives::lane_index::LaneIndex;
+
+/// Minimum number of empty vertices for the decomposition-based obstructions
+/// to apply. Push and Rotate is complete only at or above this threshold, and
+/// below it Wilson's parity exceptions come into play.
+pub const MIN_EMPTY_VERTICES: usize = 2;
+
+/// A proven reason the instance cannot be solved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Obstruction {
+    /// An atom sits on a location that is not a vertex of the lane graph —
+    /// either blocked, or not an endpoint of any lane.
+    AtomNotOnGraph { qubit: u32, location: u64 },
+    /// A target location is not a vertex of the lane graph.
+    TargetNotOnGraph { qubit: u32, location: u64 },
+    /// Two atoms occupy the same location. The move semantics assume an
+    /// injective placement; [`Config`] only rejects duplicate *qubit ids*.
+    DuplicateOccupancy { location: u64, qubits: (u32, u32) },
+    /// Two atoms are assigned the same target location.
+    DuplicateTarget { location: u64, qubits: (u32, u32) },
+    /// An atom's target lies in a different connected component of the lane
+    /// graph — no sequence of moves can ever cross between them.
+    TargetUnreachable { qubit: u32, from: u64, to: u64 },
+    /// An agent confined to a subgraph (Proposition 1) has a goal outside
+    /// that subgraph and its planks.
+    GoalOutsideSubgraph {
+        qubit: u32,
+        subgraph: usize,
+        goal: u64,
+    },
+    /// The subgraph precedence relation is cyclic (Proposition 2).
+    CyclicPrecedence { subgraphs: Vec<usize> },
+}
+
+impl std::fmt::Display for Obstruction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AtomNotOnGraph { qubit, location } => write!(
+                f,
+                "qubit {qubit} sits at location {location:#x}, which is blocked or not on any lane"
+            ),
+            Self::TargetNotOnGraph { qubit, location } => write!(
+                f,
+                "target {location:#x} for qubit {qubit} is blocked or not on any lane"
+            ),
+            Self::DuplicateOccupancy { location, qubits } => write!(
+                f,
+                "qubits {} and {} both occupy location {location:#x}",
+                qubits.0, qubits.1
+            ),
+            Self::DuplicateTarget { location, qubits } => write!(
+                f,
+                "qubits {} and {} share target location {location:#x}",
+                qubits.0, qubits.1
+            ),
+            Self::TargetUnreachable { qubit, from, to } => write!(
+                f,
+                "qubit {qubit} cannot reach {to:#x} from {from:#x}: different connected components"
+            ),
+            Self::GoalOutsideSubgraph {
+                qubit,
+                subgraph,
+                goal,
+            } => write!(
+                f,
+                "qubit {qubit} is confined to subgraph {subgraph}, but its goal {goal:#x} lies outside it and its planks"
+            ),
+            Self::CyclicPrecedence { subgraphs } => {
+                write!(f, "cyclic subgraph precedence: {subgraphs:?}")
+            }
+        }
+    }
+}
+
+/// One-sided feasibility verdict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Feasibility {
+    /// The instance is provably unsolvable.
+    Infeasible(Obstruction),
+    /// No implemented obstruction fired. **Not** a proof of feasibility.
+    NoObstructionFound,
+}
+
+impl Feasibility {
+    /// Whether this verdict proves the instance unsolvable.
+    pub fn is_infeasible(&self) -> bool {
+        matches!(self, Self::Infeasible(_))
+    }
+
+    /// The obstruction, if the verdict is a proof.
+    pub fn obstruction(&self) -> Option<&Obstruction> {
+        match self {
+            Self::Infeasible(o) => Some(o),
+            Self::NoObstructionFound => None,
+        }
+    }
+}
+
+/// Verify that every bus maps a source set disjoint from its destination set.
+///
+/// The whole pebble-motion reduction rests on this: it is what rules out an
+/// AOD move rotating a cycle of atoms with no empty vertex. Returns one
+/// message per violating bus; an empty vector means the property holds.
+pub fn validate_bus_disjointness(arch: &ArchSpec) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    for (zone_id, zone) in arch.zones.iter().enumerate() {
+        for (bus_id, bus) in zone.site_buses.iter().enumerate() {
+            let src: HashSet<u16> = bus.src.iter().map(|s| s.0).collect();
+            if bus.dst.iter().any(|d| src.contains(&d.0)) {
+                errors.push(format!(
+                    "zone {zone_id} site_bus {bus_id}: src and dst sets overlap"
+                ));
+            }
+        }
+        for (bus_id, bus) in zone.word_buses.iter().enumerate() {
+            let src: HashSet<u16> = bus.src.iter().map(|s| s.0).collect();
+            if bus.dst.iter().any(|d| src.contains(&d.0)) {
+                errors.push(format!(
+                    "zone {zone_id} word_bus {bus_id}: src and dst sets overlap"
+                ));
+            }
+        }
+    }
+    for (bus_id, bus) in arch.zone_buses.iter().enumerate() {
+        let src: HashSet<(u8, u16)> = bus.src.iter().map(|s| (s.zone_id, s.word_id)).collect();
+        if bus
+            .dst
+            .iter()
+            .any(|d| src.contains(&(d.zone_id, d.word_id)))
+        {
+            errors.push(format!("zone_bus {bus_id}: src and dst sets overlap"));
+        }
+    }
+
+    errors
+}
+
+/// Build the undirected graph and the Kornhauser decomposition for an
+/// instance, without evaluating any obstruction.
+///
+/// Exposed because the Push and Rotate planner needs exactly this: the
+/// subgraphs drive its `swap` feasibility, and the precedence order drives its
+/// agent priorities. Returns `None` when there are fewer than
+/// [`MIN_EMPTY_VERTICES`] empty vertices, since the decomposition's guarantees
+/// do not hold there.
+pub fn build_decomposition(
+    index: &LaneIndex,
+    initial: &Config,
+    blocked: &HashSet<u64>,
+) -> Option<(LaneGraph, Decomposition)> {
+    let graph = LaneGraph::build(index, blocked);
+    let occupant = occupancy(&graph, initial)?;
+    let atom_count = occupant.iter().filter(|o| o.is_some()).count();
+    let empty_count = graph.len().checked_sub(atom_count)?;
+    if empty_count < MIN_EMPTY_VERTICES {
+        return None;
+    }
+
+    let bcc = graph.biconnected();
+    let (subgraphs, subgraph_of_vertex) = find_subgraphs(&graph, &bcc, empty_count);
+    let planks = find_planks(&graph, &subgraphs, &subgraph_of_vertex, empty_count);
+    let assignment = assign_agents(
+        &graph,
+        &subgraphs,
+        &subgraph_of_vertex,
+        &occupant,
+        empty_count,
+    );
+
+    let decomp = Decomposition {
+        subgraphs,
+        subgraph_of_vertex,
+        planks,
+        assignment,
+        empty_count,
+    };
+    Some((graph, decomp))
+}
+
+/// Map each graph vertex to the qubit occupying it, or `None`.
+///
+/// Returns `None` if any atom sits off the graph — the caller reports that as
+/// its own obstruction.
+fn occupancy(graph: &LaneGraph, initial: &Config) -> Option<Vec<Option<u32>>> {
+    let mut occupant = vec![None; graph.len()];
+    for (qubit, loc) in initial.iter() {
+        let v = graph.vertex_of(loc.encode())?;
+        occupant[v] = Some(qubit);
+    }
+    Some(occupant)
+}
+
+/// Check an instance for a proven obstruction.
+///
+/// `targets` is the desired `(qubit, encoded location)` assignment; qubits
+/// absent from it are unconstrained. `blocked` locations are treated as
+/// removed from the graph entirely.
+pub fn check(
+    index: &LaneIndex,
+    initial: &Config,
+    targets: &[(u32, u64)],
+    blocked: &HashSet<u64>,
+) -> Feasibility {
+    let graph = LaneGraph::build(index, blocked);
+
+    // ── Well-formedness ────────────────────────────────────────────
+    let mut occupant: Vec<Option<u32>> = vec![None; graph.len()];
+    for (qubit, loc) in initial.iter() {
+        let enc = loc.encode();
+        let Some(v) = graph.vertex_of(enc) else {
+            return Feasibility::Infeasible(Obstruction::AtomNotOnGraph {
+                qubit,
+                location: enc,
+            });
+        };
+        if let Some(other) = occupant[v] {
+            return Feasibility::Infeasible(Obstruction::DuplicateOccupancy {
+                location: enc,
+                qubits: (other.min(qubit), other.max(qubit)),
+            });
+        }
+        occupant[v] = Some(qubit);
+    }
+
+    let mut target_vertex: HashMap<u32, VertexId> = HashMap::new();
+    let mut target_seen: HashMap<u64, u32> = HashMap::new();
+    for &(qubit, enc) in targets {
+        let Some(v) = graph.vertex_of(enc) else {
+            return Feasibility::Infeasible(Obstruction::TargetNotOnGraph {
+                qubit,
+                location: enc,
+            });
+        };
+        if let Some(&other) = target_seen.get(&enc) {
+            return Feasibility::Infeasible(Obstruction::DuplicateTarget {
+                location: enc,
+                qubits: (other.min(qubit), other.max(qubit)),
+            });
+        }
+        target_seen.insert(enc, qubit);
+        target_vertex.insert(qubit, v);
+    }
+
+    // ── Connectivity: a target in another component is unreachable ──
+    let (component, _n_components) = graph.connected_components();
+    for (qubit, loc) in initial.iter() {
+        let Some(&goal_v) = target_vertex.get(&qubit) else {
+            continue;
+        };
+        let from_v = graph
+            .vertex_of(loc.encode())
+            .expect("atom vertices were resolved above");
+        if component[from_v] != component[goal_v] {
+            return Feasibility::Infeasible(Obstruction::TargetUnreachable {
+                qubit,
+                from: loc.encode(),
+                to: graph.location_of(goal_v),
+            });
+        }
+    }
+
+    // ── Decomposition-based obstructions ────────────────────────────
+    let atom_count = initial.len();
+    let Some(empty_count) = graph.len().checked_sub(atom_count) else {
+        // More atoms than vertices is caught by DuplicateOccupancy above,
+        // so this is unreachable in practice; stay conservative anyway.
+        return Feasibility::NoObstructionFound;
+    };
+    if empty_count < MIN_EMPTY_VERTICES {
+        // Below the Push and Rotate regime the decomposition's guarantees do
+        // not hold, so we report only what the cheap checks established.
+        return Feasibility::NoObstructionFound;
+    }
+
+    let bcc = graph.biconnected();
+    let (subgraphs, subgraph_of_vertex) = find_subgraphs(&graph, &bcc, empty_count);
+    let planks = find_planks(&graph, &subgraphs, &subgraph_of_vertex, empty_count);
+    let assignment = assign_agents(
+        &graph,
+        &subgraphs,
+        &subgraph_of_vertex,
+        &occupant,
+        empty_count,
+    );
+    let decomp = Decomposition {
+        subgraphs,
+        subgraph_of_vertex,
+        planks,
+        assignment,
+        empty_count,
+    };
+
+    // Goal containment: Proposition 1 confines an assigned agent to its
+    // subgraph and planks, so a goal outside that region is unreachable.
+    for (&qubit, &sub) in &decomp.assignment {
+        let Some(&goal_v) = target_vertex.get(&qubit) else {
+            continue;
+        };
+        if !decomp.contains_in_subgraph_or_planks(sub, goal_v) {
+            return Feasibility::Infeasible(Obstruction::GoalOutsideSubgraph {
+                qubit,
+                subgraph: sub,
+                goal: graph.location_of(goal_v),
+            });
+        }
+    }
+
+    // Proposition 2: a cyclic precedence relation proves unsolvability.
+    let unassigned_goal_vertices: HashSet<VertexId> = target_vertex
+        .iter()
+        .filter(|(q, _)| !decomp.assignment.contains_key(q))
+        .map(|(_, &v)| v)
+        .collect();
+    let edges = subgraph_priorities(&decomp, &target_vertex, &unassigned_goal_vertices);
+    if let Some(cycle) = find_precedence_cycle(decomp.subgraphs.len(), &edges) {
+        return Feasibility::Infeasible(Obstruction::CyclicPrecedence { subgraphs: cycle });
+    }
+
+    Feasibility::NoObstructionFound
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{example_arch_json, loc};
+    use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+
+    fn index_from(json: &str) -> LaneIndex {
+        let spec: ArchSpec = serde_json::from_str(json).expect("arch json parses");
+        LaneIndex::new(spec)
+    }
+
+    fn gemini_physical() -> LaneIndex {
+        index_from(include_str!(
+            "../../../../python/bloqade/lanes/arch/gemini/physical/_physical_spec.json"
+        ))
+    }
+
+    #[test]
+    fn shipped_gemini_specs_have_disjoint_bus_endpoints() {
+        // The pebble-motion reduction is only valid while this holds.
+        for (name, json) in [
+            (
+                "physical",
+                include_str!(
+                    "../../../../python/bloqade/lanes/arch/gemini/physical/_physical_spec.json"
+                ),
+            ),
+            (
+                "logical",
+                include_str!(
+                    "../../../../python/bloqade/lanes/arch/gemini/logical/_logical_spec.json"
+                ),
+            ),
+        ] {
+            let spec: ArchSpec = serde_json::from_str(json).expect("arch json parses");
+            assert_eq!(
+                validate_bus_disjointness(&spec),
+                Vec::<String>::new(),
+                "{name} spec must have src/dst-disjoint buses"
+            );
+        }
+    }
+
+    #[test]
+    fn trivial_instance_has_no_obstruction() {
+        let index = index_from(example_arch_json());
+        let initial = Config::new([(0, loc(0, 0))]).expect("config");
+        let targets = [(0u32, loc(0, 5).encode())];
+        assert_eq!(
+            check(&index, &initial, &targets, &HashSet::new()),
+            Feasibility::NoObstructionFound
+        );
+    }
+
+    #[test]
+    fn atom_on_blocked_site_is_infeasible() {
+        let index = index_from(example_arch_json());
+        let initial = Config::new([(0, loc(0, 0))]).expect("config");
+        let blocked: HashSet<u64> = [loc(0, 0).encode()].into_iter().collect();
+        let verdict = check(&index, &initial, &[], &blocked);
+        assert!(matches!(
+            verdict,
+            Feasibility::Infeasible(Obstruction::AtomNotOnGraph { qubit: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn target_off_the_graph_is_infeasible() {
+        let index = index_from(example_arch_json());
+        let initial = Config::new([(0, loc(0, 0))]).expect("config");
+        // Word 99 does not exist in the example architecture.
+        let targets = [(0u32, loc(99, 0).encode())];
+        let verdict = check(&index, &initial, &targets, &HashSet::new());
+        assert!(matches!(
+            verdict,
+            Feasibility::Infeasible(Obstruction::TargetNotOnGraph { qubit: 0, .. })
+        ));
+    }
+
+    #[test]
+    fn two_atoms_sharing_a_location_is_infeasible() {
+        let index = index_from(example_arch_json());
+        // `Config` only rejects duplicate qubit ids, not duplicate locations.
+        let initial = Config::new([(0, loc(0, 0)), (1, loc(0, 0))]).expect("config");
+        let verdict = check(&index, &initial, &[], &HashSet::new());
+        assert!(matches!(
+            verdict,
+            Feasibility::Infeasible(Obstruction::DuplicateOccupancy { .. })
+        ));
+    }
+
+    #[test]
+    fn two_atoms_sharing_a_target_is_infeasible() {
+        let index = index_from(example_arch_json());
+        let initial = Config::new([(0, loc(0, 0)), (1, loc(0, 1))]).expect("config");
+        let targets = [(0u32, loc(0, 5).encode()), (1u32, loc(0, 5).encode())];
+        let verdict = check(&index, &initial, &targets, &HashSet::new());
+        assert!(matches!(
+            verdict,
+            Feasibility::Infeasible(Obstruction::DuplicateTarget { .. })
+        ));
+    }
+
+    #[test]
+    fn blocking_a_corridor_makes_the_target_unreachable() {
+        // Cut every lane out of the atom's site by blocking its neighbours,
+        // stranding it in a component that excludes the target.
+        let index = index_from(example_arch_json());
+        let start = loc(0, 0);
+        let graph_all = LaneGraph::build(&index, &HashSet::new());
+        let v = graph_all
+            .vertex_of(start.encode())
+            .expect("start is on the graph");
+        let blocked: HashSet<u64> = graph_all
+            .neighbors(v)
+            .iter()
+            .map(|&w| graph_all.location_of(w))
+            .collect();
+        assert!(!blocked.is_empty(), "fixture needs a non-isolated start");
+
+        let initial = Config::new([(0, start)]).expect("config");
+        // Any target that survives the blocking but is in another component.
+        let graph_cut = LaneGraph::build(&index, &blocked);
+        let (component, _) = graph_cut.connected_components();
+        let start_v = graph_cut
+            .vertex_of(start.encode())
+            .expect("start survives blocking");
+        let far = graph_cut
+            .vertices()
+            .find(|&w| component[w] != component[start_v]);
+        let Some(far) = far else {
+            // Architecture stayed connected — nothing to assert here.
+            return;
+        };
+        let targets = [(0u32, graph_cut.location_of(far))];
+        let verdict = check(&index, &initial, &targets, &blocked);
+        assert!(
+            matches!(
+                verdict,
+                Feasibility::Infeasible(Obstruction::TargetUnreachable { qubit: 0, .. })
+            ),
+            "expected unreachable target, got {verdict:?}"
+        );
+    }
+
+    #[test]
+    fn gemini_physical_decomposes_and_finds_no_obstruction() {
+        // A realistic sparse instance on the shipped architecture must not
+        // be reported infeasible — a false positive here would gate real
+        // compilations.
+        let index = gemini_physical();
+        let graph = LaneGraph::build(&index, &HashSet::new());
+        assert!(!graph.is_empty(), "gemini physical has lane endpoints");
+
+        let verts: Vec<VertexId> = graph.vertices().take(8).collect();
+        let initial = Config::new(
+            verts
+                .iter()
+                .enumerate()
+                .map(|(i, &v)| {
+                    (
+                        i as u32,
+                        bloqade_lanes_bytecode_core::arch::addr::LocationAddr::decode(
+                            graph.location_of(v),
+                        ),
+                    )
+                })
+                .collect::<Vec<_>>(),
+        )
+        .expect("config");
+
+        let verdict = check(&index, &initial, &[], &HashSet::new());
+        assert_eq!(verdict, Feasibility::NoObstructionFound);
+
+        let built = build_decomposition(&index, &initial, &HashSet::new());
+        let (_, decomp) = built.expect("gemini physical has ≥ 2 empty vertices");
+        assert!(
+            !decomp.subgraphs.is_empty(),
+            "expected at least one subgraph"
+        );
+        assert!(decomp.empty_count >= MIN_EMPTY_VERTICES);
+    }
+
+    /// Soundness: an instance built by *replaying legal single-atom moves*
+    /// is reachable by construction, so the checker must never call it
+    /// infeasible. A false positive here would gate a real compilation.
+    ///
+    /// Single-atom moves are the right generator: a one-lane `MoveSet` is
+    /// always a legal AOD operation, so every configuration produced by this
+    /// walk is genuinely reachable from `initial` on hardware.
+    fn assert_no_false_positive(index: &LaneIndex, n_atoms: usize, n_moves: usize, seed: u64) {
+        use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
+        use rand::rngs::SmallRng;
+        use rand::{Rng, SeedableRng};
+
+        let graph = LaneGraph::build(index, &HashSet::new());
+        assert!(
+            graph.len() > n_atoms + MIN_EMPTY_VERTICES,
+            "fixture needs room for {n_atoms} atoms plus empties"
+        );
+        let mut rng = SmallRng::seed_from_u64(seed);
+
+        // Scatter atoms over distinct vertices.
+        let mut placement: Vec<Option<u32>> = vec![None; graph.len()];
+        let mut position: Vec<VertexId> = Vec::with_capacity(n_atoms);
+        let mut placed = 0u32;
+        while (placed as usize) < n_atoms {
+            let v = rng.random_range(0..graph.len());
+            if placement[v].is_some() || graph.degree(v) == 0 {
+                continue;
+            }
+            placement[v] = Some(placed);
+            position.push(v);
+            placed += 1;
+        }
+        let initial = Config::new(
+            position
+                .iter()
+                .enumerate()
+                .map(|(q, &v)| (q as u32, LocationAddr::decode(graph.location_of(v))))
+                .collect::<Vec<_>>(),
+        )
+        .expect("distinct vertices give a valid config");
+
+        // Random walk: repeatedly slide one atom into an empty neighbour.
+        for _ in 0..n_moves {
+            let q = rng.random_range(0..n_atoms);
+            let from = position[q];
+            let empty: Vec<VertexId> = graph
+                .neighbors(from)
+                .iter()
+                .copied()
+                .filter(|&w| placement[w].is_none())
+                .collect();
+            if empty.is_empty() {
+                continue;
+            }
+            let to = empty[rng.random_range(0..empty.len())];
+            placement[from] = None;
+            placement[to] = Some(q as u32);
+            position[q] = to;
+        }
+
+        let targets: Vec<(u32, u64)> = position
+            .iter()
+            .enumerate()
+            .map(|(q, &v)| (q as u32, graph.location_of(v)))
+            .collect();
+
+        let verdict = check(index, &initial, &targets, &HashSet::new());
+        assert_eq!(
+            verdict,
+            Feasibility::NoObstructionFound,
+            "reachable-by-construction instance reported infeasible (seed {seed})"
+        );
+    }
+
+    #[test]
+    fn never_reports_reachable_instances_infeasible_on_example_arch() {
+        let index = index_from(example_arch_json());
+        for seed in 0..25 {
+            assert_no_false_positive(&index, 3, 40, seed);
+        }
+    }
+
+    #[test]
+    fn never_reports_reachable_instances_infeasible_on_gemini_physical() {
+        let index = gemini_physical();
+        for seed in 0..5 {
+            assert_no_false_positive(&index, 24, 300, seed);
+        }
+    }
+
+    #[test]
+    fn no_empty_vertices_skips_the_decomposition() {
+        // Fill the graph completely: `m = 0` is outside the Push and Rotate
+        // regime, so we must fall back to the cheap checks only.
+        let index = index_from(example_arch_json());
+        let graph = LaneGraph::build(&index, &HashSet::new());
+        let initial = Config::new(
+            graph
+                .vertices()
+                .enumerate()
+                .map(|(i, v)| {
+                    (
+                        i as u32,
+                        bloqade_lanes_bytecode_core::arch::addr::LocationAddr::decode(
+                            graph.location_of(v),
+                        ),
+                    )
+                })
+                .collect::<Vec<_>>(),
+        )
+        .expect("config");
+
+        assert!(build_decomposition(&index, &initial, &HashSet::new()).is_none());
+        assert_eq!(
+            check(&index, &initial, &[], &HashSet::new()),
+            Feasibility::NoObstructionFound
+        );
+    }
+}

--- a/crates/bloqade-lanes-search/src/feasibility/mod.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/mod.rs
@@ -28,7 +28,18 @@
 //! AOD parallelism changes the schedule, not what is reachable. Point 2 is a
 //! property of the shipped architecture specs rather than of the format, so
 //! [`validate_bus_disjointness`] checks it explicitly; if it ever fails, the
-//! reduction in this module is invalid.
+//! reduction in this module is invalid. In debug builds, [`check`] and
+//! [`build_decomposition`] assert it on entry (together with
+//! `ArchSpec::validate`); release builds skip the check and trust the caller
+//! to pass a validated spec.
+//!
+//! Strictly, the reduction needs less than disjointness: a bus is by
+//! definition a set of explicit transports along graph edges, never a
+//! permutation, so the load-bearing property is that no bus's src→dst
+//! relation contains a cycle (a chain `x→y, y→z` serializes in reverse
+//! topological order and is pebble-equivalent; only a rotation is not).
+//! Overlapping-but-acyclic buses, and relaxing this module's guard
+//! accordingly, are tracked in issue #866.
 //!
 //! ## What this does and does not prove
 //!
@@ -201,6 +212,29 @@ pub fn validate_bus_disjointness(arch: &ArchSpec) -> Vec<String> {
     errors
 }
 
+/// Debug-build guard for the assumptions the pebble-motion reduction rests
+/// on: a structurally valid architecture whose buses keep their source and
+/// destination sets disjoint (see the module docs).
+///
+/// Release builds skip this entirely — callers are expected to pass a
+/// validated spec (e.g. loaded via `ArchSpec::from_json_validated`). The
+/// disjointness requirement relaxes to per-bus acyclicity once that becomes
+/// a validated format invariant (issue #866).
+fn debug_assert_valid_arch(_index: &LaneIndex) {
+    #[cfg(debug_assertions)]
+    {
+        if let Err(errors) = _index.arch_spec().validate() {
+            panic!("feasibility requires a structurally valid ArchSpec: {errors:?}");
+        }
+        let overlaps = validate_bus_disjointness(_index.arch_spec());
+        assert!(
+            overlaps.is_empty(),
+            "feasibility reduction requires src/dst-disjoint buses \
+             (relaxation to acyclicity tracked in issue #866): {overlaps:?}"
+        );
+    }
+}
+
 /// Build the undirected graph and the Kornhauser decomposition for an
 /// instance, without evaluating any obstruction.
 ///
@@ -215,6 +249,7 @@ pub fn build_decomposition(
     initial: &Config,
     blocked: &HashSet<u64>,
 ) -> Option<(LaneGraph, Decomposition)> {
+    debug_assert_valid_arch(index);
     let graph = LaneGraph::build(index, blocked);
     let occupant = occupancy(&graph, initial)?;
     let empty_count = graph.len().checked_sub(initial.len())?;
@@ -255,6 +290,7 @@ pub fn check(
     targets: &[(u32, u64)],
     blocked: &HashSet<u64>,
 ) -> Feasibility {
+    debug_assert_valid_arch(index);
     let graph = LaneGraph::build(index, blocked);
 
     // ── Well-formedness ────────────────────────────────────────────
@@ -403,6 +439,25 @@ mod tests {
                 "{name} spec must have src/dst-disjoint buses"
             );
         }
+    }
+
+    /// The debug-build guard must refuse a spec whose bus endpoints overlap:
+    /// the reduction is not justified there, so silently returning verdicts
+    /// would be unsound. Relaxing this to per-bus acyclicity is issue #866.
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "src/dst-disjoint")]
+    fn debug_guard_rejects_overlapping_bus() {
+        let mut spec: ArchSpec =
+            serde_json::from_str(example_arch_json()).expect("arch json parses");
+        // Point the first destination back at the first source. Structural
+        // validation still passes (lengths and index ranges are unchanged);
+        // disjointness does not.
+        let bus = &mut spec.zones[0].site_buses[0];
+        bus.dst[0] = bus.src[0];
+        let index = LaneIndex::new(spec);
+        let initial = Config::new([(0, loc(0, 0))]).expect("config");
+        let _ = check(&index, &initial, &[], &HashSet::new());
     }
 
     #[test]

--- a/crates/bloqade-lanes-search/src/lib.rs
+++ b/crates/bloqade-lanes-search/src/lib.rs
@@ -24,6 +24,7 @@
 pub mod cost;
 pub mod drivers;
 pub mod dsl;
+pub mod feasibility;
 pub mod generators;
 pub mod goals;
 pub mod heuristics;
@@ -39,6 +40,7 @@ pub mod traits;
 
 pub use cost::UniformCost;
 pub use drivers::result::SearchResult;
+pub use feasibility::{Feasibility, Obstruction, check as check_feasibility};
 pub use generators::{
     DeadlockPolicy, ExhaustiveGenerator, GreedyGenerator, HeuristicGenerator, LooseTargetGenerator,
 };


### PR DESCRIPTION
## Summary

Adds a `feasibility` module to `bloqade-lanes-search`: a **one-sided infeasibility oracle** for atom rearrangement instances. Today a solver that drains its frontier reports `Unsolvable`, but for the pruning drivers (entropy/DFS/IDS) that is a guess. This module supplies the proof side, so callers can distinguish "the hardware cannot do this" from "the heuristic gave up".

`Feasibility::Infeasible(obstruction)` is a proof; `NoObstructionFound` is **not** a proof of feasibility — it only means no implemented obstruction fired.

## How it works

Atom rearrangement on this architecture reduces to classical **pebble motion** on an undirected graph:

1. a single-lane `MoveSet` is always a legal AOD operation (`check_lanes` only applies group geometry to >1 lane), and
2. every bus maps a source set disjoint from its destination set, so a multi-lane move serializes into independent single-pebble moves — AOD parallelism changes the schedule, not what is reachable.

On top of that reduction the module implements:

- **Well-formedness obstructions**: atom/target off the lane graph, duplicate occupancy, duplicate targets (`Config` only rejects duplicate qubit ids, not duplicate locations).
- **Connectivity**: a target in another connected component is unreachable.
- **Kornhauser subgraph decomposition** (de Wilde, ter Mors & Witteveen, JAIR 51, 2014, §3.1 — Algorithms 1–3): goal containment (an agent confined to a subgraph with a goal outside it and its planks) and Proposition 2 (cyclic subgraph precedence). Applies only in the `m ≥ 2` empty-vertex regime; below that the cheap checks still run but the decomposition is skipped (Wilson's parity exceptions live there).

`build_decomposition` is exposed separately because the planned Push and Rotate planner (follow-up, `feat/push-rotate-router`) consumes exactly the subgraphs and precedence order.

## Soundness

The module must never call a solvable instance infeasible. That contract is enforced several ways:

- **Brute-force cross-checks**: decomposition confinement claims are compared against exhaustive configuration-space search on hand-built fixtures *and* on ~120 random small graphs (property test). This caught and now pins a real bug: vertex-sharing biconnected components must merge at `m ≥ 2` (fixed in 03dc64e1).
- **Reachable-by-construction tests**: instances generated by replaying legal single-atom moves on the example arch and the shipped Gemini physical spec must never be reported infeasible.
- **Debug-build guard**: `check()` / `build_decomposition()` assert `ArchSpec::validate()` + bus src/dst disjointness on entry, so a custom spec that violates the reduction's assumption fails loudly instead of yielding unsound verdicts. Release builds skip the guard.
- The bundled Gemini specs are pinned disjoint by a test.

Strictly, the reduction needs less than disjointness — a bus is by definition a set of explicit edge transports, never a permutation, so the load-bearing property is per-bus *acyclicity* (chains serialize; only rotations break pebble equivalence). Relaxing the guard and codifying that definition in `ArchSpec::validate()` is tracked in #866 together with the `AtomStateData::apply_moves` ordering fix.

## Determinism

`LaneGraph` numbers vertices in sorted encoded-location order rather than `HashMap` discovery order, so neighbour lists, BFS tie-breaks, and every downstream traversal are stable run-to-run (9892ec96).

## Notes for review

- New module + two `lib.rs` re-exports only; no existing solver path is touched, so the routing benchmark baselines are unchanged.
- Non-breaking (purely additive API).
- `Feasibility`/`Obstruction`/`check` are re-exported at the crate root as `check_feasibility`.

## Test plan

- `cargo test -p bloqade-lanes-search` (330 tests, includes the new property tests and a `should_panic` test for the debug guard)
- `cargo clippy -p bloqade-lanes-search --all-targets` clean in debug and release profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)