### PR TITLE
feat(search): add Push and Rotate as a complete router and opt-in fallback

### DIFF
--- a/crates/bloqade-lanes-bytecode-python/src/search_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/search_python.rs
@@ -71,6 +71,8 @@ pub enum PySearchStrategy {
     CascadeEntropy = 7,
     #[pyo3(name = "ENTROPY")]
     Entropy = 8,
+    #[pyo3(name = "PUSH_ROTATE")]
+    PushRotate = 9,
 }
 
 #[pymethods]
@@ -87,6 +89,7 @@ impl PySearchStrategy {
             Self::CascadeDfs => "CASCADE_DFS",
             Self::CascadeEntropy => "CASCADE_ENTROPY",
             Self::Entropy => "ENTROPY",
+            Self::PushRotate => "PUSH_ROTATE",
         }
     }
 }
@@ -109,6 +112,7 @@ impl PySearchStrategy {
                 inner: InnerStrategy::Entropy,
             } => Self::CascadeEntropy,
             Strategy::Entropy => Self::Entropy,
+            Strategy::PushRotate => Self::PushRotate,
         }
     }
 
@@ -129,6 +133,7 @@ impl PySearchStrategy {
                 inner: InnerStrategy::Entropy,
             },
             Self::Entropy => Strategy::Entropy,
+            Self::PushRotate => Strategy::PushRotate,
         }
     }
 }
@@ -777,7 +782,7 @@ pub struct PySolveOptions {
 #[pymethods]
 impl PySolveOptions {
     #[new]
-    #[pyo3(signature = (strategy=PySearchStrategy::AStar, weight=1.0, restarts=1, deadlock_policy=PyDeadlockPolicy::Skip, lookahead=false, top_c=None))]
+    #[pyo3(signature = (strategy=PySearchStrategy::AStar, weight=1.0, restarts=1, deadlock_policy=PyDeadlockPolicy::Skip, lookahead=false, top_c=None, fallback_push_rotate=false))]
     fn new(
         strategy: PySearchStrategy,
         weight: f64,
@@ -785,6 +790,7 @@ impl PySolveOptions {
         deadlock_policy: PyDeadlockPolicy,
         lookahead: bool,
         top_c: Option<usize>,
+        fallback_push_rotate: bool,
     ) -> PyResult<Self> {
         if !weight.is_finite() || weight <= 0.0 {
             return Err(PyValueError::new_err(
@@ -804,6 +810,7 @@ impl PySolveOptions {
                 deadlock_policy: deadlock_policy.to_rs(),
                 lookahead,
                 top_c,
+                fallback_push_rotate,
             },
         })
     }

--- a/crates/bloqade-lanes-search/examples/headroom.rs
+++ b/crates/bloqade-lanes-search/examples/headroom.rs
@@ -1,0 +1,74 @@
+//! How much parallelism is the rectangle constraint costing us?
+//!
+//! Compares three numbers for Push and Rotate's output:
+//!
+//! * `moves` — the sequential plan length; what pnr costs with no batching.
+//! * `DAG_depth` — the longest path through the dependency graph. This is the
+//!   operation count the scheduler would reach if *any* set of independent
+//!   moves could share an operation, i.e. the AOD rectangle constraint were
+//!   free. A hard lower bound.
+//! * `scheduler_ops` — what the real scheduler achieves, rectangles and all.
+//!
+//! The gap between `DAG_depth` and `scheduler_ops` is the cost of geometry
+//! alone: moves that are ready simultaneously but whose source positions do
+//! not form a complete X×Y grid on one bus. `max_level_width` shows how many
+//! moves are typically ready at once, so a wide level with few merges means
+//! the candidates are there and only alignment is missing.
+//!
+//! Run: `cargo run --release -p bloqade-lanes-search --example headroom`
+
+use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+use bloqade_lanes_search::feasibility::graph::{LaneGraph, VertexId};
+use bloqade_lanes_search::primitives::lane_index::LaneIndex;
+use bloqade_lanes_search::push_rotate::instances::generate;
+use bloqade_lanes_search::push_rotate::{plan, schedule::schedule};
+use std::collections::HashMap;
+const PHYSICAL: &str =
+    include_str!("../../../python/bloqade/lanes/arch/gemini/physical/_physical_spec.json");
+fn main() {
+    let spec: ArchSpec = serde_json::from_str(PHYSICAL).unwrap();
+    let index = LaneIndex::new(spec);
+    let g = LaneGraph::build(&index, &Default::default());
+    for k in [4usize, 8, 16] {
+        let (mut mv, mut depth, mut ops, mut maxready) = (0usize, 0usize, 0usize, 0usize);
+        for seed in 0..5u64 {
+            let i = generate("x".into(), PHYSICAL, k, 4 * k, seed).unwrap();
+            let tov = |v: &[(u32, u64)]| {
+                v.iter()
+                    .map(|&(q, l)| (q, g.vertex_of(l).unwrap()))
+                    .collect::<Vec<(u32, VertexId)>>()
+            };
+            let p = plan(&index, &g, &tov(&i.initial), &tov(&i.target), 500_000).unwrap();
+            let b = schedule(&index, &g, &p.moves).unwrap();
+            mv += p.moves.len();
+            ops += b.len();
+            // DAG longest path: lower bound on ops if rectangles were free
+            let n = p.moves.len();
+            let mut lvl = vec![0usize; n];
+            let mut last_v: HashMap<VertexId, usize> = HashMap::new();
+            let mut last_a: HashMap<u32, usize> = HashMap::new();
+            let mut level_count: HashMap<usize, usize> = HashMap::new();
+            for (idx, m) in p.moves.iter().enumerate() {
+                let mut l = 0;
+                for v in [m.from, m.to] {
+                    if let Some(&pr) = last_v.get(&v) {
+                        l = l.max(lvl[pr] + 1);
+                    }
+                }
+                if let Some(&pr) = last_a.get(&m.agent) {
+                    l = l.max(lvl[pr] + 1);
+                }
+                lvl[idx] = l;
+                last_v.insert(m.from, idx);
+                last_v.insert(m.to, idx);
+                last_a.insert(m.agent, idx);
+                *level_count.entry(l).or_default() += 1;
+            }
+            depth += lvl.iter().map(|&x| x + 1).max().unwrap_or(0);
+            maxready += level_count.values().copied().max().unwrap_or(0);
+        }
+        println!(
+            "k={k:>2}: moves={mv:>4}  DAG_depth={depth:>4}  scheduler_ops={ops:>4}  max_level_width={maxready:>3}"
+        );
+    }
+}

--- a/crates/bloqade-lanes-search/examples/router_comparison.rs
+++ b/crates/bloqade-lanes-search/examples/router_comparison.rs
@@ -1,0 +1,191 @@
+//! Head-to-head comparison of every fixed-target routing strategy.
+//!
+//! ```text
+//! cargo run --release -p bloqade-lanes-search --example router_comparison
+//! cargo run --release -p bloqade-lanes-search --example router_comparison -- --csv
+//! ```
+//!
+//! Complements the Python benchmark harness, which measures whole-kernel
+//! compilation. This isolates the *router*: same instance, same budget, one
+//! strategy at a time, so a difference is attributable to routing rather than
+//! to target selection or circuit structure.
+//!
+//! ## What is measured
+//!
+//! Every instance is **reachable by construction** — atoms are scattered, then
+//! a random walk of legal single-atom slides produces the target. So a
+//! solution provably exists and a failure is a real deficiency of the router,
+//! not a hard problem. That is what makes the success rate meaningful.
+//!
+//! | column | meaning |
+//! |---|---|
+//! | `solved` | instances routed, of those attempted |
+//! | `ops` | AOD operations — the primary cost metric |
+//! | `xfer_us` | transport time: per operation the slowest lane, summed |
+//! | `lanes` | total single-atom moves — **informational only** |
+//! | `ms` | wall time of the solve |
+//!
+//! `lanes` is not a quality measure. One operation moves a whole rectangle, so
+//! packing more atoms per operation raises the lane count while lowering the
+//! real cost — optimising for fewer lanes optimises for serialisation.
+//!
+//! Cost columns are summed over *solved* instances only, so they are
+//! comparable only between strategies with the same solved count, which is why
+//! that count is printed alongside. Everything except `ms` is deterministic.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use bloqade_lanes_bytecode_core::arch::addr::{LaneAddr, LocationAddr};
+use bloqade_lanes_search::primitives::lane_index::LaneIndex;
+use bloqade_lanes_search::push_rotate::instances::{Instance, generate};
+use bloqade_lanes_search::search::engine::SearchEngine;
+use bloqade_lanes_search::search::move_search::MoveSearch;
+use bloqade_lanes_search::search::options::{SolveOptions, Strategy};
+use bloqade_lanes_search::search::result::SolveStatus;
+use bloqade_lanes_search::search::target_solver::TargetSolver;
+
+const PHYSICAL: &str =
+    include_str!("../../../python/bloqade/lanes/arch/gemini/physical/_physical_spec.json");
+const LOGICAL: &str =
+    include_str!("../../../python/bloqade/lanes/arch/gemini/logical/_logical_spec.json");
+
+/// Expansion budget every search strategy gets, held equal so the comparison
+/// is not a budget comparison.
+const MAX_EXPANSIONS: u32 = 5_000;
+
+struct Outcome {
+    solved: bool,
+    ops: usize,
+    lanes: usize,
+    xfer_us: f64,
+    micros: u128,
+}
+
+/// Duration of one AOD operation: its slowest lane, since the atoms move
+/// concurrently and the operation ends when the last one arrives.
+fn layer_duration(index: &LaneIndex, lanes: &[LaneAddr]) -> f64 {
+    lanes
+        .iter()
+        .filter_map(|l| index.lane_duration_us(l))
+        .fold(0.0f64, f64::max)
+}
+
+fn run(engine: &Arc<SearchEngine>, instance: &Instance, strategy: Strategy) -> Outcome {
+    let search = MoveSearch::default().with_options(SolveOptions {
+        strategy,
+        ..Default::default()
+    });
+    let solver = TargetSolver::new(Arc::clone(engine), search);
+    let decode = |v: &[(u32, u64)]| -> Vec<(u32, LocationAddr)> {
+        v.iter()
+            .map(|&(q, l)| (q, LocationAddr::decode(l)))
+            .collect()
+    };
+
+    let start = Instant::now();
+    let result = solver.solve(
+        decode(&instance.initial),
+        decode(&instance.target),
+        Vec::new(),
+        Some(MAX_EXPANSIONS),
+    );
+    let micros = start.elapsed().as_micros();
+
+    match result {
+        Ok(r) => Outcome {
+            solved: r.status == SolveStatus::Solved,
+            ops: r.move_layers.len(),
+            lanes: r.move_layers.iter().map(|m| m.decode().len()).sum(),
+            xfer_us: r
+                .move_layers
+                .iter()
+                .map(|m| layer_duration(engine.index(), &m.decode()))
+                .sum(),
+            micros,
+        },
+        Err(_) => Outcome {
+            solved: false,
+            ops: 0,
+            lanes: 0,
+            xfer_us: 0.0,
+            micros,
+        },
+    }
+}
+
+fn main() {
+    let csv = std::env::args().any(|a| a == "--csv");
+    let strategies = [
+        ("astar", Strategy::AStar),
+        ("ids", Strategy::Ids),
+        ("dfs", Strategy::HeuristicDfs),
+        ("entropy", Strategy::Entropy),
+        ("push-rotate", Strategy::PushRotate),
+    ];
+
+    if csv {
+        println!("instance,arch,atoms,strategy,solved,ops,lanes,xfer_us,micros");
+    } else {
+        println!(
+            "\n{:<16} {:<13} {:>9} {:>7} {:>10} {:>8} {:>9}",
+            "group", "strategy", "solved", "ops", "xfer_us", "lanes", "ms"
+        );
+        println!("{}", "-".repeat(78));
+    }
+
+    for (arch_name, arch) in [("physical", PHYSICAL), ("logical", LOGICAL)] {
+        let engine = Arc::new(SearchEngine::from_json(arch).expect("spec parses"));
+        for &k in &[1usize, 2, 4, 8, 16] {
+            let mut totals = vec![(0usize, 0usize, 0usize, 0.0f64, 0u128); strategies.len()];
+            for seed in 0..5u64 {
+                let id = format!("{arch_name}/k{k}/seed{seed}");
+                let Some(instance) = generate(id.clone(), arch, k, 4 * k, seed) else {
+                    continue;
+                };
+                for (si, (name, strategy)) in strategies.iter().enumerate() {
+                    let o = run(&engine, &instance, *strategy);
+                    if csv {
+                        println!(
+                            "{id},{arch_name},{k},{name},{},{},{},{:.1},{}",
+                            o.solved, o.ops, o.lanes, o.xfer_us, o.micros
+                        );
+                    }
+                    let t = &mut totals[si];
+                    if o.solved {
+                        t.0 += 1;
+                        t.1 += o.ops;
+                        t.2 += o.lanes;
+                        t.3 += o.xfer_us;
+                    }
+                    t.4 += o.micros;
+                }
+            }
+            if !csv {
+                for (si, (name, _)) in strategies.iter().enumerate() {
+                    let (solved, ops, lanes, xfer, micros) = totals[si];
+                    println!(
+                        "{:<16} {:<13} {:>4}/{:<4} {:>7} {:>10.0} {:>8} {:>9.1}",
+                        format!("{arch_name}/k{k}"),
+                        name,
+                        solved,
+                        5,
+                        ops,
+                        xfer,
+                        lanes,
+                        micros as f64 / 1000.0
+                    );
+                }
+                println!();
+            }
+        }
+    }
+
+    if !csv {
+        println!(
+            "ops = AOD operations (primary cost). lanes is informational: more atoms\n\
+             per operation raises it while LOWERING cost. Summed over SOLVED instances\n\
+             only, so compare only between strategies with the same solved count."
+        );
+    }
+}

--- a/crates/bloqade-lanes-search/src/drivers/entropy.rs
+++ b/crates/bloqade-lanes-search/src/drivers/entropy.rs
@@ -16,6 +16,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 
 use crate::drivers::result::SearchResult;
+use crate::feasibility::graph::LaneGraph;
 use crate::observer::{SearchEvent, SearchObserver};
 use crate::ops::aod_grid::BusGridContext;
 use crate::primitives::config::Config;
@@ -28,6 +29,7 @@ use crate::primitives::ordering::{
     cmp_triplet_entry_tiebreak,
 };
 use crate::primitives::path::find_path_occupied;
+use crate::push_rotate::{DEFAULT_MOVE_BUDGET, plan as push_rotate_plan};
 use crate::traits::Goal;
 use bloqade_lanes_bytecode_core::arch::addr::{LaneAddr, LocationAddr};
 use rand::rngs::SmallRng;
@@ -1301,6 +1303,96 @@ fn fire_fallback_start_event(
     });
 }
 
+/// Budget-exhaustion fallback: Push and Rotate first, greedy sequential as
+/// the out-of-regime tertiary.
+///
+/// The planner is complete for instances with ≥ 2 empties per moving
+/// component and can displace atoms out of each other's way, so it solves
+/// everything the greedy router can and more (permutations, congestion).
+/// The greedy router's residual value is narrow and worth stating exactly:
+/// it cannot enter an occupied vertex, so at `m = 0` it never succeeds, and
+/// at `m = 1` it can only realize direct slides into the unique hole (any
+/// longer path would need a second empty). That single-hole slide is the
+/// one case the planner refuses (`TooFewEmpty`) that remains solvable here,
+/// so keeping the tertiary makes this a strict behavioural superset of the
+/// old greedy-only fallback.
+fn budget_exhaustion_fallback(
+    graph: &mut SearchGraph,
+    start: NodeId,
+    ctx: &SearchContext,
+    goal: &impl Goal,
+) -> (Option<NodeId>, u32) {
+    let config = graph.config(start).clone();
+    let lane_graph = LaneGraph::build(ctx.index, ctx.blocked);
+
+    // Any location off the carved graph makes the instance inexpressible for
+    // the planner; let the greedy router report what it can.
+    let initial_v: Option<Vec<(u32, usize)>> = config
+        .iter()
+        .map(|(q, loc)| lane_graph.vertex_of(loc.encode()).map(|v| (q, v)))
+        .collect();
+    let target_v: Option<Vec<(u32, usize)>> = ctx
+        .targets
+        .iter()
+        .map(|&(q, enc)| lane_graph.vertex_of(enc).map(|v| (q, v)))
+        .collect();
+    let (Some(initial_v), Some(target_v)) = (initial_v, target_v) else {
+        return sequential_fallback(graph, start, ctx, goal);
+    };
+
+    let Ok(p) = push_rotate_plan(
+        ctx.index,
+        &lane_graph,
+        &initial_v,
+        &target_v,
+        DEFAULT_MOVE_BUDGET,
+    ) else {
+        return sequential_fallback(graph, start, ctx, goal);
+    };
+
+    // Graft the plan onto the search graph as a chain of single-lane moves —
+    // the same currency the greedy router emits.
+    let mut current = start;
+    let mut nodes_expanded: u32 = 0;
+    for mv in &p.moves {
+        let src = LocationAddr::decode(lane_graph.location_of(mv.from));
+        let dst_enc = lane_graph.location_of(mv.to);
+        // Any lane realizing this edge works; one exists because the plan
+        // only steps along lane-graph adjacencies. Take the smallest
+        // encoding so the choice is deterministic.
+        let Some(lane) = ctx
+            .index
+            .outgoing_lanes(src)
+            .iter()
+            .filter(|l| {
+                ctx.index
+                    .endpoints(l)
+                    .is_some_and(|(_, d)| d.encode() == dst_enc)
+            })
+            .min_by_key(|l| l.encode_u64())
+            .copied()
+        else {
+            return (None, nodes_expanded);
+        };
+
+        let cur_config = graph.config(current).clone();
+        let Some(moving_qid) = cur_config.qubit_at(src) else {
+            return (None, nodes_expanded);
+        };
+        let new_config = cur_config.with_moves(&[(moving_qid, LocationAddr::decode(dst_enc))]);
+        let new_g = graph.g_score(current) + 1.0;
+        let (child_id, _) = graph.insert(current, MoveSet::new([lane]), new_config, new_g);
+        nodes_expanded += 1;
+        current = child_id;
+    }
+
+    if goal.is_goal(graph.config(current)) {
+        (Some(current), nodes_expanded)
+    } else {
+        (None, nodes_expanded)
+    }
+}
+
 /// Greedy sequential fallback: move each unresolved qubit along its shortest path.
 fn sequential_fallback(
     graph: &mut SearchGraph,
@@ -1753,7 +1845,7 @@ pub fn entropy_search(
 
     if found_goals.is_empty() && budget_exhausted {
         fire_fallback_start_event(observer, &graph, root_id, ctx, &resume_buffer);
-        let (goal_id, fb_expanded) = sequential_fallback(&mut graph, root_id, ctx, goal);
+        let (goal_id, fb_expanded) = budget_exhaustion_fallback(&mut graph, root_id, ctx, goal);
         nodes_expanded += fb_expanded;
         if let Some(gid) = goal_id {
             found_goals.push(gid);
@@ -2163,12 +2255,50 @@ mod tests {
     }
 
     #[test]
-    fn budget_exhaustion_runs_sequential_fallback() {
+    fn budget_exhaustion_runs_fallback() {
         let r = run_entropy([(0, loc(0, 0))], [(0, loc(0, 5))], Some(0));
+        let goal = r.goal.expect("fallback should find reachable target");
+        assert_eq!(r.graph.config(goal).location_of(0), Some(loc(0, 5)));
+    }
+
+    /// Interference the greedy sequential fallback cannot handle: qubit 0's
+    /// only route runs through qubit 1's current site, so a path avoiding
+    /// every occupied vertex does not exist — the atom in the way must be
+    /// displaced ahead, which is exactly what Push and Rotate does. (The
+    /// example arch's components are 4-vertex paths `(0,0)-(0,5)-(1,5)-(1,0)`,
+    /// so the targets preserve the atoms' order — a true swap would be
+    /// genuinely unsolvable here.)
+    #[test]
+    fn budget_exhaustion_fallback_solves_interference() {
+        let r = run_entropy(
+            [(0, loc(0, 0)), (1, loc(0, 5))],
+            [(0, loc(1, 5)), (1, loc(1, 0))],
+            Some(0),
+        );
         let goal = r
             .goal
-            .expect("sequential fallback should find reachable target");
-        assert_eq!(r.graph.config(goal).location_of(0), Some(loc(0, 5)));
+            .expect("the planner fallback should displace the blocker");
+        assert_eq!(r.graph.config(goal).location_of(0), Some(loc(1, 5)));
+        assert_eq!(r.graph.config(goal).location_of(1), Some(loc(1, 0)));
+    }
+
+    /// The greedy tertiary's one residual case: a component with a single
+    /// hole where an unresolved qubit slides directly into it. `m = 1` is
+    /// outside the planner's regime (`TooFewEmpty`), and the greedy router
+    /// can do nothing more than this — it cannot enter occupied vertices,
+    /// so at `m = 1` only direct slides into the hole are realizable.
+    #[test]
+    fn budget_exhaustion_fallback_out_of_regime_hole_slide() {
+        // Component (0,0)-(0,5)-(1,5)-(1,0), three atoms, hole at (1,0).
+        let r = run_entropy(
+            [(0, loc(0, 0)), (1, loc(0, 5)), (2, loc(1, 5))],
+            [(2, loc(1, 0))],
+            Some(0),
+        );
+        let goal = r
+            .goal
+            .expect("the greedy tertiary should slide into the hole");
+        assert_eq!(r.graph.config(goal).location_of(2), Some(loc(1, 0)));
     }
 
     #[test]

--- a/crates/bloqade-lanes-search/src/feasibility/mod.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/mod.rs
@@ -526,7 +526,7 @@ mod tests {
                 goal_verts.swap(i, j);
             }
             let target_vertex: HashMap<u32, VertexId> =
-                (0..n_targets as u32).zip(goal_verts.into_iter()).collect();
+                (0..n_targets as u32).zip(goal_verts).collect();
 
             if let Some(obstruction) = decomposition_obstruction(&graph, &occupant, &target_vertex)
             {

--- a/crates/bloqade-lanes-search/src/feasibility/mod.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/mod.rs
@@ -95,7 +95,10 @@ pub enum Obstruction {
     /// Two atoms occupy the same location. The move semantics assume an
     /// injective placement; [`Config`] only rejects duplicate *qubit ids*.
     DuplicateOccupancy { location: u64, qubits: (u32, u32) },
-    /// Two atoms are assigned the same target location.
+    /// Two atoms are assigned the same target location. The solve entry
+    /// points reject such requests as errors before any pass runs
+    /// (`validate_target_assignment`); this obstruction remains as defence
+    /// in depth for direct callers of [`check`].
     DuplicateTarget { location: u64, qubits: (u32, u32) },
     /// An atom's target lies in a different connected component of the lane
     /// graph — no sequence of moves can ever cross between them.

--- a/crates/bloqade-lanes-search/src/lib.rs
+++ b/crates/bloqade-lanes-search/src/lib.rs
@@ -32,6 +32,7 @@ pub mod observer;
 pub mod ops;
 pub mod placement;
 pub mod primitives;
+pub mod push_rotate;
 pub mod scorers;
 pub mod search;
 #[cfg(test)]
@@ -62,6 +63,7 @@ pub use primitives::context::{MoveCandidate, SearchContext, SearchState};
 pub use primitives::distance::PairDistanceHeuristic;
 pub use primitives::graph::{MoveSet, NodeId, SearchGraph};
 pub use primitives::lane_index::LaneIndex;
+pub use push_rotate::{solve_push_rotate, solve_push_rotate_with};
 pub use scorers::{DistanceScorer, EntropyScorer};
 pub use search::engine::SearchEngine;
 pub use search::move_search::MoveSearch;

--- a/crates/bloqade-lanes-search/src/primitives/config.rs
+++ b/crates/bloqade-lanes-search/src/primitives/config.rs
@@ -10,20 +10,69 @@ use std::hash::{Hash, Hasher};
 
 use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
 
-/// Error returned when a [`Config`] cannot be constructed.
-#[derive(Debug, Clone)]
-pub struct ConfigError {
-    /// The qubit ID that appeared more than once.
-    pub duplicate_qubit_id: u32,
+/// A malformed solve request.
+///
+/// These are rejected at the solver entry points — before feasibility,
+/// search, or planning runs — because they are nonsensical for *any*
+/// architecture and any occupancy. They are caller errors, never verdicts:
+/// a request that cannot be well-posed must not produce `Unsolvable` (which
+/// is documented as a proof about a well-posed instance) or, worse, a
+/// fabricated success.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigError {
+    /// A qubit ID appeared more than once in a placement.
+    DuplicateQubitId { qubit_id: u32 },
+    /// Two qubits were assigned the same target location.
+    DuplicateTargetLocation { location: u64, qubits: (u32, u32) },
+    /// One qubit was assigned two target locations.
+    DuplicateTargetQubit { qubit_id: u32 },
 }
 
 impl fmt::Display for ConfigError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "duplicate qubit_id: {}", self.duplicate_qubit_id)
+        match self {
+            Self::DuplicateQubitId { qubit_id } => {
+                write!(f, "duplicate qubit_id: {qubit_id}")
+            }
+            Self::DuplicateTargetLocation { location, qubits } => write!(
+                f,
+                "invalid request: qubits {} and {} are both assigned target location {location:#x}",
+                qubits.0, qubits.1
+            ),
+            Self::DuplicateTargetQubit { qubit_id } => write!(
+                f,
+                "invalid request: qubit {qubit_id} is assigned more than one target location"
+            ),
+        }
     }
 }
 
 impl std::error::Error for ConfigError {}
+
+/// Reject a target assignment that is not injective in both directions:
+/// two qubits on one location, or one qubit with two locations.
+///
+/// Runs at the solve entry points, ahead of every feasibility, search, or
+/// planning pass — such an assignment is an invalid request, not an
+/// instance to produce a verdict about.
+pub fn validate_target_assignment(targets: &[(u32, LocationAddr)]) -> Result<(), ConfigError> {
+    let mut by_location: std::collections::HashMap<u64, u32> = std::collections::HashMap::new();
+    let mut seen_qubits: std::collections::HashSet<u32> = std::collections::HashSet::new();
+    for &(qubit, loc) in targets {
+        if !seen_qubits.insert(qubit) {
+            return Err(ConfigError::DuplicateTargetQubit { qubit_id: qubit });
+        }
+        let enc = loc.encode();
+        if let Some(&other) = by_location.get(&enc) {
+            return Err(ConfigError::DuplicateTargetLocation {
+                location: enc,
+                qubits: (other.min(qubit), other.max(qubit)),
+            });
+        }
+        by_location.insert(enc, qubit);
+    }
+    Ok(())
+}
 
 /// Compute a hash for a sorted entries slice.
 ///
@@ -76,8 +125,8 @@ impl Config {
         // Check for duplicates (adjacent after sort).
         for window in entries.windows(2) {
             if window[0].0 == window[1].0 {
-                return Err(ConfigError {
-                    duplicate_qubit_id: window[0].0,
+                return Err(ConfigError::DuplicateQubitId {
+                    qubit_id: window[0].0,
                 });
             }
         }
@@ -287,7 +336,28 @@ mod tests {
     #[test]
     fn duplicate_qubit_id_returns_error() {
         let err = Config::new([(0, loc(0, 0)), (0, loc(0, 1))]).unwrap_err();
-        assert_eq!(err.duplicate_qubit_id, 0);
+        assert_eq!(err, ConfigError::DuplicateQubitId { qubit_id: 0 });
+    }
+
+    #[test]
+    fn target_assignment_rejects_shared_location() {
+        let err = validate_target_assignment(&[(0, loc(0, 5)), (1, loc(0, 5))]).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::DuplicateTargetLocation { qubits: (0, 1), .. }
+        ));
+    }
+
+    #[test]
+    fn target_assignment_rejects_double_assignment() {
+        let err = validate_target_assignment(&[(3, loc(0, 1)), (3, loc(0, 2))]).unwrap_err();
+        assert_eq!(err, ConfigError::DuplicateTargetQubit { qubit_id: 3 });
+    }
+
+    #[test]
+    fn target_assignment_accepts_injective_maps() {
+        assert!(validate_target_assignment(&[(0, loc(0, 1)), (1, loc(0, 2))]).is_ok());
+        assert!(validate_target_assignment(&[]).is_ok());
     }
 
     #[test]

--- a/crates/bloqade-lanes-search/src/primitives/config.rs
+++ b/crates/bloqade-lanes-search/src/primitives/config.rs
@@ -26,6 +26,8 @@ pub enum ConfigError {
     DuplicateTargetLocation { location: u64, qubits: (u32, u32) },
     /// One qubit was assigned two target locations.
     DuplicateTargetQubit { qubit_id: u32 },
+    /// Two qubits were placed on the same initial location.
+    DuplicateOccupancy { location: u64, qubits: (u32, u32) },
 }
 
 impl fmt::Display for ConfigError {
@@ -42,6 +44,11 @@ impl fmt::Display for ConfigError {
             Self::DuplicateTargetQubit { qubit_id } => write!(
                 f,
                 "invalid request: qubit {qubit_id} is assigned more than one target location"
+            ),
+            Self::DuplicateOccupancy { location, qubits } => write!(
+                f,
+                "invalid request: qubits {} and {} are both placed at location {location:#x}",
+                qubits.0, qubits.1
             ),
         }
     }
@@ -65,6 +72,26 @@ pub fn validate_target_assignment(targets: &[(u32, LocationAddr)]) -> Result<(),
         let enc = loc.encode();
         if let Some(&other) = by_location.get(&enc) {
             return Err(ConfigError::DuplicateTargetLocation {
+                location: enc,
+                qubits: (other.min(qubit), other.max(qubit)),
+            });
+        }
+        by_location.insert(enc, qubit);
+    }
+    Ok(())
+}
+
+/// Reject an initial placement with two qubits on one location.
+///
+/// Qubit-id uniqueness is already enforced by [`Config::new`]; this checks
+/// the other direction of injectivity, symmetric with
+/// [`validate_target_assignment`], and runs at the same solve entry points.
+pub fn validate_initial_placement(config: &Config) -> Result<(), ConfigError> {
+    let mut by_location: std::collections::HashMap<u64, u32> = std::collections::HashMap::new();
+    for (qubit, loc) in config.iter() {
+        let enc = loc.encode();
+        if let Some(&other) = by_location.get(&enc) {
+            return Err(ConfigError::DuplicateOccupancy {
                 location: enc,
                 qubits: (other.min(qubit), other.max(qubit)),
             });
@@ -352,6 +379,22 @@ mod tests {
     fn target_assignment_rejects_double_assignment() {
         let err = validate_target_assignment(&[(3, loc(0, 1)), (3, loc(0, 2))]).unwrap_err();
         assert_eq!(err, ConfigError::DuplicateTargetQubit { qubit_id: 3 });
+    }
+
+    #[test]
+    fn initial_placement_rejects_shared_location() {
+        let config = Config::new([(0, loc(0, 0)), (1, loc(0, 0))]).expect("qubit ids distinct");
+        let err = validate_initial_placement(&config).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::DuplicateOccupancy { qubits: (0, 1), .. }
+        ));
+    }
+
+    #[test]
+    fn initial_placement_accepts_injective_maps() {
+        let config = Config::new([(0, loc(0, 0)), (1, loc(0, 1))]).expect("config");
+        assert!(validate_initial_placement(&config).is_ok());
     }
 
     #[test]

--- a/crates/bloqade-lanes-search/src/push_rotate/context.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/context.rs
@@ -52,6 +52,9 @@ pub struct PlanCtx<'a> {
     pub decomp: &'a Decomposition,
     /// Goal vertex per agent, indexed by dense agent id.
     pub goal: &'a [VertexId],
+    /// Qubit id per agent, indexed by dense agent id. Errors report qubit
+    /// ids — the caller's vocabulary — never the internal dense index.
+    pub qubits: &'a [u32],
     /// The strategy in force for this solve.
     pub heuristics: &'a dyn PlanHeuristics,
     edges: HashMap<(VertexId, VertexId), EdgeInfo>,
@@ -63,6 +66,7 @@ impl<'a> PlanCtx<'a> {
         index: &'a LaneIndex,
         decomp: &'a Decomposition,
         goal: &'a [VertexId],
+        qubits: &'a [u32],
         heuristics: &'a dyn PlanHeuristics,
     ) -> Self {
         let mut edges = HashMap::new();
@@ -95,6 +99,7 @@ impl<'a> PlanCtx<'a> {
             index,
             decomp,
             goal,
+            qubits,
             heuristics,
             edges,
         }

--- a/crates/bloqade-lanes-search/src/push_rotate/context.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/context.rs
@@ -1,0 +1,119 @@
+//! Read-only context threaded through planning.
+//!
+//! Bundles everything a heuristic may consult so that adding a decision point
+//! does not mean changing the signature of every operation in `ops`.
+//!
+//! ## Why geometry is here
+//!
+//! The planner proper works on a [`LaneGraph`], which knows adjacency and
+//! nothing else. That is sufficient to *route* — Push and Rotate only ever
+//! asks "is there an edge" — but it is not sufficient to route *for
+//! parallelism*. An AOD operation batches lanes that share a bus group and
+//! whose source positions form a complete X×Y rectangle, so any heuristic
+//! trying to align moves needs the bus group and the (x, y) of each edge.
+//!
+//! [`EdgeInfo`] is precomputed for every edge once per solve rather than
+//! resolved on demand: `LaneIndex::outgoing_lanes` is a linear scan, and an
+//! alignment heuristic queries it in its inner loop.
+
+use std::collections::HashMap;
+
+use crate::feasibility::decomposition::Decomposition;
+use crate::feasibility::graph::{LaneGraph, VertexId};
+use crate::primitives::lane_index::LaneIndex;
+use bloqade_lanes_bytecode_core::arch::addr::{LaneAddr, LocationAddr};
+
+use crate::push_rotate::heuristics::PlanHeuristics;
+
+/// Bus-group identity: `(move_type, bus_id, zone_id, direction)`.
+///
+/// Two lanes can share an AOD operation only if these match. Mirrors
+/// `LaneIndex`'s own grouping.
+pub type GroupKey = (u8, u32, u32, u8);
+
+/// What a heuristic needs to know about a graph edge.
+#[derive(Debug, Clone, Copy)]
+pub struct EdgeInfo {
+    /// The lane realising this edge.
+    pub lane: LaneAddr,
+    /// Which AOD bus group it belongs to.
+    pub group: GroupKey,
+    /// Source position, as raw f64 bits so it can be compared and hashed.
+    /// Rectangle membership is an exact-coordinate question, so bit equality
+    /// is the right comparison — these are grid coordinates read from the
+    /// spec, not computed values that might drift by an ulp.
+    pub src_pos: (u64, u64),
+}
+
+/// Everything planning reads but never writes.
+pub struct PlanCtx<'a> {
+    pub graph: &'a LaneGraph,
+    pub index: &'a LaneIndex,
+    pub decomp: &'a Decomposition,
+    /// Goal vertex per agent, indexed by dense agent id.
+    pub goal: &'a [VertexId],
+    /// The strategy in force for this solve.
+    pub heuristics: &'a dyn PlanHeuristics,
+    edges: HashMap<(VertexId, VertexId), EdgeInfo>,
+}
+
+impl<'a> PlanCtx<'a> {
+    pub fn new(
+        graph: &'a LaneGraph,
+        index: &'a LaneIndex,
+        decomp: &'a Decomposition,
+        goal: &'a [VertexId],
+        heuristics: &'a dyn PlanHeuristics,
+    ) -> Self {
+        let mut edges = HashMap::new();
+        for from in graph.vertices() {
+            let src = LocationAddr::decode(graph.location_of(from));
+            let Some(src_pos) = index.position(src).map(|(x, y)| (x.to_bits(), y.to_bits())) else {
+                continue;
+            };
+            for lane in index.outgoing_lanes(src) {
+                let Some((_, dst)) = index.endpoints(lane) else {
+                    continue;
+                };
+                let Some(to) = graph.vertex_of(dst.encode()) else {
+                    continue;
+                };
+                edges.entry((from, to)).or_insert(EdgeInfo {
+                    lane: *lane,
+                    group: (
+                        lane.move_type as u8,
+                        lane.bus_id,
+                        lane.zone_id,
+                        lane.direction as u8,
+                    ),
+                    src_pos,
+                });
+            }
+        }
+        Self {
+            graph,
+            index,
+            decomp,
+            goal,
+            heuristics,
+            edges,
+        }
+    }
+
+    /// Lane, bus group and source position for an edge, if one exists.
+    pub fn edge(&self, from: VertexId, to: VertexId) -> Option<&EdgeInfo> {
+        self.edges.get(&(from, to))
+    }
+
+    /// Whether two edges could ever share an AOD operation.
+    ///
+    /// Necessary but not sufficient: sharing a bus group is required, but the
+    /// sources must also form a complete rectangle, which depends on the whole
+    /// batch rather than a pair.
+    pub fn same_group(&self, a: (VertexId, VertexId), b: (VertexId, VertexId)) -> bool {
+        match (self.edge(a.0, a.1), self.edge(b.0, b.1)) {
+            (Some(x), Some(y)) => x.group == y.group,
+            _ => false,
+        }
+    }
+}

--- a/crates/bloqade-lanes-search/src/push_rotate/heuristics.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/heuristics.rs
@@ -1,0 +1,279 @@
+//! Swappable decision points in the planner.
+//!
+//! Push and Rotate has no objective function — it is a completeness algorithm.
+//! §5 of de Wilde, ter Mors & Witteveen identifies the four places where a
+//! choice is free and affects solution quality, and this trait is exactly
+//! those four:
+//!
+//! | § | Decision | Method |
+//! |---|---|---|
+//! | 1 | which empty vertex `clear_vertex` drains into | [`PlanHeuristics::rank_clear_target`] |
+//! | 2 | which degree-≥3 vertex `swap` uses | [`PlanHeuristics::rank_swap_vertex`] |
+//! | 3 | the order agents are planned in | [`PlanHeuristics::agent_order`] |
+//! | 4 | which shortest path an agent takes | [`PlanHeuristics::score_step`] |
+//!
+//! The paper's authors explored only 3 and 4, and noted that agent ordering
+//! "can be very important to solution quality". [`DefaultHeuristics`] does
+//! neither — it is the unoptimised baseline the current benchmark numbers come
+//! from.
+//!
+//! ## Why scores rather than choices
+//!
+//! Every method returns a *ranking key* instead of making the choice, and the
+//! caller applies it as a tie-break on top of the existing rule. That keeps a
+//! heuristic from breaking correctness: it can reorder equally-good options
+//! but cannot select an illegal one or lengthen a path. A heuristic that
+//! returns a constant is exactly the default.
+//!
+//! ## The one that matters next
+//!
+//! [`PlanHeuristics::score_step`] is where AOD alignment goes. `headroom`
+//! shows the dependency DAG admits ~5x more parallelism than the scheduler
+//! extracts, and the gap is entirely geometric: moves that are ready together
+//! do not share a bus group or do not form a rectangle. Preferring steps that
+//! align with other pending moves is what closes it, and [`PlanCtx::edge`]
+//! exposes the bus group and source position needed to judge that.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use crate::feasibility::graph::VertexId;
+
+use crate::push_rotate::context::{GroupKey, PlanCtx};
+use crate::push_rotate::state::PlanState;
+
+/// Strategy for the planner's free choices.
+///
+/// All methods have defaults reproducing the current behaviour, so an
+/// implementation need only override what it cares about.
+pub trait PlanHeuristics {
+    /// Order in which agents are planned.
+    ///
+    /// Must contain every agent exactly once. Subgraph precedence still
+    /// applies on top: agents assigned to no subgraph are planned last
+    /// regardless (§3.1.3).
+    fn agent_order(&self, ctx: &PlanCtx, state: &PlanState) -> Vec<u32> {
+        let _ = state;
+        let n = ctx.goal.len();
+        let mut assigned: Vec<u32> = Vec::new();
+        let mut unassigned: Vec<u32> = Vec::new();
+        for a in 0..n as u32 {
+            match ctx.decomp.assignment.get(&a) {
+                Some(_) => assigned.push(a),
+                None => unassigned.push(a),
+            }
+        }
+        assigned.sort_by_key(|a| {
+            (
+                ctx.decomp.assignment.get(a).copied().unwrap_or(usize::MAX),
+                *a,
+            )
+        });
+        assigned.extend(unassigned);
+        assigned
+    }
+
+    /// Preference for `agent` stepping `from -> to`, used to break ties
+    /// between equally short paths. **Higher is better.**
+    ///
+    /// Only consulted among steps that are already on a shortest path, so it
+    /// cannot lengthen a route.
+    fn score_step(
+        &self,
+        ctx: &PlanCtx,
+        state: &PlanState,
+        agent: u32,
+        from: VertexId,
+        to: VertexId,
+    ) -> f64 {
+        let _ = (ctx, state, agent, from, to);
+        0.0
+    }
+
+    /// Ranking key for an empty vertex that `clear_vertex` could drain into.
+    /// **Lower is better.** `hops` is its distance from the vertex being
+    /// cleared.
+    fn rank_clear_target(
+        &self,
+        ctx: &PlanCtx,
+        state: &PlanState,
+        clearing: VertexId,
+        candidate: VertexId,
+        hops: u32,
+    ) -> i64 {
+        let _ = (ctx, state, clearing, candidate);
+        hops as i64
+    }
+
+    /// Ranking key for a candidate swap vertex. **Lower is better.**
+    /// `hops` is its distance from the agent initiating the swap.
+    fn rank_swap_vertex(
+        &self,
+        ctx: &PlanCtx,
+        state: &PlanState,
+        r: u32,
+        s: u32,
+        candidate: VertexId,
+        hops: u32,
+    ) -> i64 {
+        let _ = (ctx, state, r, s, candidate);
+        hops as i64
+    }
+}
+
+/// The unoptimised baseline: nearest-first everywhere, arbitrary agent order.
+///
+/// Every method is the trait default, so this is the behaviour all current
+/// benchmark numbers were measured with. Keep it as the control when
+/// evaluating anything else.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DefaultHeuristics;
+
+impl PlanHeuristics for DefaultHeuristics {}
+
+/// Alignment-aware strategy: steer concurrent moves onto a *shared bus*.
+///
+/// ## What the measurement said
+///
+/// The first version of this biased atoms towards shared rows, on the theory
+/// that same-y atoms form a 1xN rectangle. It bought almost nothing, and
+/// instrumenting the scheduler showed why. At k=16, with ~6.8 moves ready
+/// simultaneously, the largest subset sharing a bus group averaged **1.57**,
+/// and the largest same-row subset within a group averaged 1.18. The
+/// histogram of "largest same-group subset in the ready set" was
+/// `1 -> 73 steps, 2 -> 72, 3 -> 7`.
+///
+/// So rectangle *shape* was never the binding constraint. Concurrent moves
+/// were simply on different buses, and two moves on different buses can never
+/// share an operation whatever their geometry.
+///
+/// ## What this does instead
+///
+/// A bus moves a whole family of word pairs at once — Gemini's word bus 0
+/// carries 0->1, 4->5, 8->9 and so on — so atoms making the *same relative
+/// move* can batch even when far apart. This scores a step by how many **other
+/// unfinished atoms could also make progress on that same bus right now**, and
+/// so pulls concurrent moves onto shared buses.
+///
+/// ## Cost
+///
+/// Distance-to-goal per agent is a graph property and does not change as atoms
+/// move, so it is computed once per solve. The per-bus support counts do
+/// change, and are rebuilt only when the placement advances —
+/// `PlanState::moves().len()` is a monotonic clock for that. A rebuild is
+/// `O(agents x degree)`, a few hundred operations, against the thousands of
+/// `score_step` calls a single BFS makes.
+pub struct AlignmentHeuristics {
+    /// Weight on routing onto a bus other atoms can also use.
+    pub bus_weight: f64,
+    /// Weight on preferring word buses, where most parallelism lives.
+    pub word_bus_weight: f64,
+    cache: RefCell<Cache>,
+}
+
+#[derive(Default)]
+struct Cache {
+    /// `state.moves().len()` when `support` was built.
+    clock: usize,
+    /// Hop distance to its goal for every agent, indexed by agent then vertex.
+    /// Occupancy-independent, so computed once.
+    goal_dist: Vec<Vec<u32>>,
+    /// Bus group → how many unfinished atoms could make progress on it now.
+    support: HashMap<GroupKey, u32>,
+}
+
+impl Default for AlignmentHeuristics {
+    fn default() -> Self {
+        Self {
+            bus_weight: 1.0,
+            word_bus_weight: 0.25,
+            cache: RefCell::new(Cache {
+                clock: usize::MAX,
+                ..Default::default()
+            }),
+        }
+    }
+}
+
+impl AlignmentHeuristics {
+    pub fn new(bus_weight: f64, word_bus_weight: f64) -> Self {
+        Self {
+            bus_weight,
+            word_bus_weight,
+            ..Default::default()
+        }
+    }
+
+    fn refresh(&self, ctx: &PlanCtx, state: &PlanState) {
+        let clock = state.moves().len();
+        let mut cache = self.cache.borrow_mut();
+        if cache.clock == clock && !cache.goal_dist.is_empty() {
+            return;
+        }
+        if cache.goal_dist.is_empty() {
+            cache.goal_dist = ctx
+                .goal
+                .iter()
+                .map(|&g| ctx.graph.distances_from(g, |_| false))
+                .collect();
+        }
+        cache.support.clear();
+        for a in 0..state.agent_count() {
+            let at = state.position_of(a as u32);
+            let Some(dist) = cache.goal_dist.get(a) else {
+                continue;
+            };
+            let here = dist[at];
+            if here == 0 {
+                continue; // already home; it will not move again
+            }
+            // Every bus offering this atom a step closer to its goal counts as
+            // support for that bus.
+            let mut seen: Vec<GroupKey> = Vec::new();
+            for &w in ctx.graph.neighbors(at) {
+                if dist[w] >= here {
+                    continue;
+                }
+                if let Some(info) = ctx.edge(at, w)
+                    && !seen.contains(&info.group)
+                {
+                    seen.push(info.group);
+                }
+            }
+            for g in seen {
+                *cache.support.entry(g).or_insert(0) += 1;
+            }
+        }
+        cache.clock = clock;
+    }
+}
+
+impl PlanHeuristics for AlignmentHeuristics {
+    fn score_step(
+        &self,
+        ctx: &PlanCtx,
+        state: &PlanState,
+        agent: u32,
+        from: VertexId,
+        to: VertexId,
+    ) -> f64 {
+        let Some(info) = ctx.edge(from, to) else {
+            return 0.0;
+        };
+        self.refresh(ctx, state);
+        let cache = self.cache.borrow();
+
+        // Discount this agent's own contribution, so the score reflects how
+        // much *company* the step would have.
+        let peers = cache
+            .support
+            .get(&info.group)
+            .copied()
+            .unwrap_or(0)
+            .saturating_sub(1);
+        let _ = agent;
+
+        let word_bus = if info.group.0 == 1 { 1.0 } else { 0.0 };
+        self.bus_weight * peers as f64 + self.word_bus_weight * word_bus
+    }
+}

--- a/crates/bloqade-lanes-search/src/push_rotate/heuristics.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/heuristics.rs
@@ -164,10 +164,12 @@ impl PlanHeuristics for DefaultHeuristics {}
 /// `O(agents x degree)`, a few hundred operations, against the thousands of
 /// `score_step` calls a single BFS makes.
 pub struct AlignmentHeuristics {
-    /// Weight on routing onto a bus other atoms can also use.
+    /// Weight on routing onto a bus other atoms can also use. This is the
+    /// whole heuristic: a separate flat preference for word buses was tried
+    /// and ablation showed it contributed nothing on top of the support
+    /// term (physical/logical k16 operation counts identical with and
+    /// without it), so it was removed.
     pub bus_weight: f64,
-    /// Weight on preferring word buses, where most parallelism lives.
-    pub word_bus_weight: f64,
     cache: RefCell<Cache>,
 }
 
@@ -186,7 +188,6 @@ impl Default for AlignmentHeuristics {
     fn default() -> Self {
         Self {
             bus_weight: 1.0,
-            word_bus_weight: 0.25,
             cache: RefCell::new(Cache {
                 clock: usize::MAX,
                 ..Default::default()
@@ -196,10 +197,9 @@ impl Default for AlignmentHeuristics {
 }
 
 impl AlignmentHeuristics {
-    pub fn new(bus_weight: f64, word_bus_weight: f64) -> Self {
+    pub fn new(bus_weight: f64) -> Self {
         Self {
             bus_weight,
-            word_bus_weight,
             ..Default::default()
         }
     }
@@ -249,11 +249,13 @@ impl AlignmentHeuristics {
 }
 
 impl PlanHeuristics for AlignmentHeuristics {
+    // `_agent` is part of the trait signature (a heuristic may score by
+    // agent identity); this one scores purely by bus-group company.
     fn score_step(
         &self,
         ctx: &PlanCtx,
         state: &PlanState,
-        agent: u32,
+        _agent: u32,
         from: VertexId,
         to: VertexId,
     ) -> f64 {
@@ -271,9 +273,6 @@ impl PlanHeuristics for AlignmentHeuristics {
             .copied()
             .unwrap_or(0)
             .saturating_sub(1);
-        let _ = agent;
-
-        let word_bus = if info.group.0 == 1 { 1.0 } else { 0.0 };
-        self.bus_weight * peers as f64 + self.word_bus_weight * word_bus
+        self.bus_weight * peers as f64
     }
 }

--- a/crates/bloqade-lanes-search/src/push_rotate/instances.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/instances.rs
@@ -1,0 +1,173 @@
+//! Deterministic routing-instance generation for benchmarks.
+//!
+//! Instances are built by **replaying legal single-atom moves** from a random
+//! start placement: scatter `k` atoms, then repeatedly slide one into an empty
+//! neighbour. The end placement becomes the target.
+//!
+//! This matters for the benchmark's headline metric. If targets were sampled
+//! at random, some would be genuinely unreachable, and a router "failing" them
+//! would be correct behaviour indistinguishable from a defect — so a success
+//! *rate* would mean nothing. Generating by replay guarantees every instance
+//! has a solution, which makes any failure a real deficiency of the router.
+//!
+//! Single-atom moves are the right generator because a one-lane `MoveSet` is
+//! always a legal AOD operation, so every configuration reached this way is
+//! reachable on hardware.
+
+use std::collections::HashMap;
+
+use crate::primitives::lane_index::LaneIndex;
+use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
+use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+
+/// One routing problem: where the atoms start, where they must end up.
+#[derive(Debug, Clone)]
+pub struct Instance {
+    /// Human-readable id, e.g. `physical/k8/seed3`.
+    pub id: String,
+    /// Architecture this instance is posed on.
+    pub arch_json: &'static str,
+    /// `(qubit, encoded location)` start placement.
+    pub initial: Vec<(u32, u64)>,
+    /// `(qubit, encoded location)` target placement.
+    pub target: Vec<(u32, u64)>,
+    /// Number of single-atom slides used to build the target. An upper bound
+    /// on the optimal solution length, and a rough difficulty dial.
+    pub walk_len: usize,
+}
+
+/// Undirected adjacency over lane endpoints, keyed by encoded location.
+fn adjacency(index: &LaneIndex) -> (Vec<u64>, HashMap<u64, Vec<u64>>) {
+    let mut ids: Vec<u64> = Vec::new();
+    let mut idx: HashMap<u64, usize> = HashMap::new();
+    let mut adj: Vec<Vec<usize>> = Vec::new();
+
+    let mut intern = |loc: u64, ids: &mut Vec<u64>, adj: &mut Vec<Vec<usize>>| -> usize {
+        *idx.entry(loc).or_insert_with(|| {
+            ids.push(loc);
+            adj.push(Vec::new());
+            ids.len() - 1
+        })
+    };
+
+    for (mt, bus_id, zone_id, dir) in index.bus_groups() {
+        for lane in index.lanes_for(mt, bus_id, zone_id, dir) {
+            let Some((src, dst)) = index.endpoints(lane) else {
+                continue;
+            };
+            let a = intern(src.encode(), &mut ids, &mut adj);
+            let b = intern(dst.encode(), &mut ids, &mut adj);
+            if a != b {
+                adj[a].push(b);
+                adj[b].push(a);
+            }
+        }
+    }
+    for list in &mut adj {
+        list.sort_unstable();
+        list.dedup();
+    }
+
+    // Sort by encoded location before returning. `LaneIndex::bus_groups`
+    // iterates a `HashMap`, so the order locations are discovered in varies
+    // between processes — and since the generator indexes into this vector
+    // with a seeded RNG, unsorted order would make the same seed produce a
+    // *different instance on every run*, which would silently invalidate any
+    // comparison across runs.
+    let mut order: Vec<usize> = (0..ids.len()).collect();
+    order.sort_unstable_by_key(|&i| ids[i]);
+
+    // Adjacency is keyed and valued by *encoded location*, not by index, so
+    // it stays correct independently of the vector ordering above. Each
+    // neighbour list is re-sorted by location for the same reason the vertex
+    // list is: the walk picks a neighbour by index, so index order determined
+    // by HashMap discovery order would leak nondeterminism back in.
+    let by_loc: HashMap<u64, Vec<u64>> = ids
+        .iter()
+        .enumerate()
+        .map(|(i, &l)| {
+            let mut nbrs: Vec<u64> = adj[i].iter().map(|&j| ids[j]).collect();
+            nbrs.sort_unstable();
+            (l, nbrs)
+        })
+        .collect();
+    let sorted_ids: Vec<u64> = order.into_iter().map(|i| ids[i]).collect();
+    let _ = idx;
+    (sorted_ids, by_loc)
+}
+
+/// Build one instance with `n_atoms` atoms and `walk_len` slides.
+///
+/// Returns `None` if the architecture has too few locations to place the
+/// atoms and still leave room to move.
+pub fn generate(
+    id: String,
+    arch_json: &'static str,
+    n_atoms: usize,
+    walk_len: usize,
+    seed: u64,
+) -> Option<Instance> {
+    let spec: ArchSpec = serde_json::from_str(arch_json).ok()?;
+    let index = LaneIndex::new(spec);
+    let (locations, adj) = adjacency(&index);
+    if locations.len() < n_atoms + 2 {
+        return None;
+    }
+
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut occupant: HashMap<u64, u32> = HashMap::new();
+    let mut position: Vec<u64> = Vec::with_capacity(n_atoms);
+
+    while position.len() < n_atoms {
+        let loc = locations[rng.random_range(0..locations.len())];
+        if occupant.contains_key(&loc) || adj.get(&loc).is_none_or(|a| a.is_empty()) {
+            continue;
+        }
+        occupant.insert(loc, position.len() as u32);
+        position.push(loc);
+    }
+
+    let initial: Vec<(u32, u64)> = position
+        .iter()
+        .enumerate()
+        .map(|(q, &l)| (q as u32, l))
+        .collect();
+
+    for _ in 0..walk_len {
+        let q = rng.random_range(0..n_atoms);
+        let from = position[q];
+        let empty: Vec<u64> = adj[&from]
+            .iter()
+            .copied()
+            .filter(|l| !occupant.contains_key(l))
+            .collect();
+        if empty.is_empty() {
+            continue;
+        }
+        let to = empty[rng.random_range(0..empty.len())];
+        occupant.remove(&from);
+        occupant.insert(to, q as u32);
+        position[q] = to;
+    }
+
+    let target: Vec<(u32, u64)> = position
+        .iter()
+        .enumerate()
+        .map(|(q, &l)| (q as u32, l))
+        .collect();
+
+    Some(Instance {
+        id,
+        arch_json,
+        initial,
+        target,
+        walk_len,
+    })
+}
+
+/// Decode an encoded location. Convenience for callers building reports.
+pub fn decode(loc: u64) -> LocationAddr {
+    LocationAddr::decode(loc)
+}

--- a/crates/bloqade-lanes-search/src/push_rotate/mod.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/mod.rs
@@ -31,9 +31,7 @@ pub use solver::{DEFAULT_MOVE_BUDGET, solve_push_rotate, solve_push_rotate_with}
 
 use std::collections::HashMap;
 
-use crate::feasibility::decomposition::{
-    Decomposition, assign_agents, find_planks, find_subgraphs,
-};
+use crate::feasibility::decomposition::{Decomposition, assign_agents};
 use crate::feasibility::graph::{LaneGraph, VertexId};
 use crate::primitives::lane_index::LaneIndex;
 
@@ -123,10 +121,6 @@ pub fn plan_with(
     }
 
     // ── Algorithm 7 ────────────────────────────────────────────────
-    let bcc = graph.biconnected();
-    let (subgraphs, subgraph_of_vertex) = find_subgraphs(graph, &bcc, empty_count);
-    let planks = find_planks(graph, &subgraphs, &subgraph_of_vertex, empty_count);
-
     let occupancy = |placement: &[VertexId]| -> Vec<Option<u32>> {
         let mut occ = vec![None; graph.len()];
         for (a, &v) in placement.iter().enumerate() {
@@ -135,38 +129,37 @@ pub fn plan_with(
         occ
     };
 
-    let f_initial = assign_agents(
-        graph,
-        &subgraphs,
-        &subgraph_of_vertex,
-        &occupancy(&start),
-        empty_count,
-    );
+    // The decomposition (subgraphs, planks, per-component empty counts, and
+    // the start-side assignment `f`) comes from the shared feasibility
+    // builder, so the planner and the infeasibility oracle can never
+    // disagree about the structure of an instance.
+    let decomp = Decomposition::build(graph, &occupancy(&start));
+
+    // Goal-side assignment `f'` reuses the same subgraphs and per-component
+    // `m` — those depend on the graph and the empty counts, not on where
+    // the atoms sit, and any solvable instance keeps each agent (and thus
+    // each component's empty count) in its own component.
+    let m_of_vertex: Vec<usize> = graph
+        .vertices()
+        .map(|v| decomp.empties_in_component[decomp.component_of_vertex[v]])
+        .collect();
     let f_goal = assign_agents(
         graph,
-        &subgraphs,
-        &subgraph_of_vertex,
+        &decomp.subgraphs,
+        &decomp.subgraph_of_vertex,
         &occupancy(&goal),
-        empty_count,
+        &m_of_vertex,
     );
 
     // Line 5: `if f = f'`. A mismatch means some agent is confined to one
     // subgraph at the start and a different one at the goal, which
     // Proposition 1 forbids — so the instance is unsolvable.
     for a in 0..n_agents as u32 {
-        if f_initial.get(&a) != f_goal.get(&a) {
+        if decomp.assignment.get(&a) != f_goal.get(&a) {
             let qubit = initial[a as usize].0;
             return Err(PlanError::Unsolvable { agent: qubit });
         }
     }
-
-    let decomp = Decomposition {
-        subgraphs,
-        subgraph_of_vertex,
-        planks,
-        assignment: f_initial,
-        empty_count,
-    };
 
     let ctx = PlanCtx::new(graph, index, &decomp, &goal, heuristics);
     solve(&ctx, &start, budget)

--- a/crates/bloqade-lanes-search/src/push_rotate/mod.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/mod.rs
@@ -1,9 +1,20 @@
 //! Push and Rotate: a complete multi-agent pathfinding planner.
 //!
 //! de Wilde, ter Mors & Witteveen, *Push and Rotate: a Complete Multi-agent
-//! Pathfinding Algorithm*, JAIR 51 (2014) 443–492. Complete for instances with
-//! at least two empty vertices (Theorem 1): it finds a solution whenever one
-//! exists, and returns [`PlanError::Unsolvable`] otherwise.
+//! Pathfinding Algorithm*, JAIR 51 (2014) 443–492. Theorem 1: complete for
+//! instances with at least two empty vertices per connected component where
+//! an atom moves.
+//!
+//! This implementation meets the *solving* half of that claim (validated by
+//! the brute-force property tests) and a **sound but partial** proving half:
+//! [`PlanError::Unsolvable`] and [`PlanError::UnknownQubit`] are genuine
+//! proofs, but some unsolvable in-regime instances come back as
+//! [`PlanError::Stuck`] instead of a proof. The gap is deliberate — the
+//! paper's `f = f'` test is only sound with its full-strength agent
+//! assignment, and the shared decomposition in `crate::feasibility`
+//! intentionally under-assigns (see the containment-form check in
+//! [`plan_with`]). Closing it would need a planner-specific,
+//! paper-faithful `assign_agents`.
 //!
 //! The Kornhauser decomposition it runs on (Algorithms 1–3) lives in the open
 //! `crate::feasibility` module — it is the paper's own content
@@ -41,25 +52,46 @@ use crate::push_rotate::ops::{no_blocked, push, rotate, swap};
 use crate::push_rotate::state::{Move, PlanState};
 
 /// Why planning stopped without a solution.
+///
+/// The variants split into **proofs** and **non-proofs**, and the
+/// distinction is load-bearing: the fallback path in the target solver
+/// promotes the planner's verdict over the search's, so only
+/// [`PlanError::Unsolvable`] and [`PlanError::UnknownQubit`] — the two
+/// variants that genuinely prove no solution exists — may be surfaced as
+/// [`SolveStatus::Unsolvable`](crate::search::result::SolveStatus::Unsolvable).
+/// Everything else means "the planner did not find a plan", which proves
+/// nothing.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum PlanError {
-    /// Proven unsolvable. Algorithm 7 line 5: the agent→subgraph assignment
-    /// computed from the initial placement differs from the one computed from
-    /// the goal, so some agent would have to leave the region Proposition 1
-    /// confines it to.
+    /// **Proof.** No solution exists: either the agent→subgraph assignment
+    /// differs between the initial and goal placements (Algorithm 7 line 5 —
+    /// the agent would have to leave the region Proposition 1 confines it
+    /// to), or no path to the target exists at all.
+    #[error("instance is unsolvable: {reason} (qubit {qubit})")]
+    Unsolvable { qubit: u32, reason: &'static str },
+    /// **Proof.** A target was given for a qubit that is not in the initial
+    /// placement. No sequence of moves creates an atom that does not exist,
+    /// so a goal that requires placing one is unsatisfiable. (This is a
+    /// caller bug — but a loud verdict beats fabricating a placement.)
+    #[error("target given for qubit {qubit}, which is not in the initial placement")]
+    UnknownQubit { qubit: u32 },
+    /// **Not a proof.** Fewer than two empty vertices in a connected
+    /// component where an atom must move. Push and Rotate's completeness
+    /// result does not cover this regime — the instance may still be
+    /// solvable (single-hole 15-puzzle instances are).
     #[error(
-        "instance is unsolvable: agent {agent} is confined to a different subgraph in the goal"
+        "push and rotate requires at least 2 empty vertices in every component \
+         where an atom moves, found {found}"
     )]
-    Unsolvable { agent: u32 },
-    /// Fewer than two empty vertices. Push and Rotate's completeness result
-    /// does not cover this regime.
-    #[error("push and rotate requires at least 2 empty vertices, found {found}")]
     TooFewEmpty { found: usize },
-    /// An atom or target is not a vertex of the lane graph.
-    #[error("location {location:#x} for qubit {agent} is blocked or not on any lane")]
-    OffGraph { agent: u32, location: u64 },
-    /// The planner exceeded its step budget. Distinct from `Unsolvable`: this
-    /// says nothing about whether a solution exists.
+    /// **Not a proof.** An operation the completeness argument says must
+    /// succeed in-regime (rotate, swap, or the final placement check)
+    /// failed. Either the instance slipped outside the regime in a way the
+    /// gates did not catch, or this is a planner bug; in neither case is it
+    /// evidence that no solution exists.
+    #[error("planner stuck: {reason} (qubit {qubit}) — not a proof of unsolvability")]
+    Stuck { qubit: u32, reason: &'static str },
+    /// **Not a proof.** The planner exceeded its step budget.
     #[error("exceeded step budget of {budget} moves")]
     BudgetExceeded { budget: usize },
 }
@@ -101,23 +133,25 @@ pub fn plan_with(
     heuristics: &dyn PlanHeuristics,
 ) -> Result<Plan, PlanError> {
     let n_agents = initial.len();
-    let empty_count = graph.len().saturating_sub(n_agents);
-    if empty_count < 2 {
-        return Err(PlanError::TooFewEmpty { found: empty_count });
-    }
 
     // Dense agent indexing: the planner works with 0..n_agents internally.
     let mut agent_of_qubit: HashMap<u32, u32> = HashMap::new();
     let mut start = vec![0usize; n_agents];
+    let mut qubit_of_agent = vec![0u32; n_agents];
     for (i, &(qubit, v)) in initial.iter().enumerate() {
         agent_of_qubit.insert(qubit, i as u32);
+        qubit_of_agent[i] = qubit;
         start[i] = v;
     }
     let mut goal = start.clone();
     for &(qubit, v) in target {
-        if let Some(&a) = agent_of_qubit.get(&qubit) {
-            goal[a as usize] = v;
-        }
+        let Some(&a) = agent_of_qubit.get(&qubit) else {
+            // A target for an atom that does not exist can never be
+            // satisfied; silently dropping it would let the solver report
+            // `Solved` for a goal it did not (and cannot) meet.
+            return Err(PlanError::UnknownQubit { qubit });
+        };
+        goal[a as usize] = v;
     }
 
     // ── Algorithm 7 ────────────────────────────────────────────────
@@ -135,6 +169,19 @@ pub fn plan_with(
     // disagree about the structure of an instance.
     let decomp = Decomposition::build(graph, &occupancy(&start));
 
+    // Regime gate, per connected component: Theorem 1 covers each
+    // pebble-motion instance separately, and empties in another component
+    // cannot help maneuvering. A component where nothing needs to move is
+    // fine with any empty count.
+    for a in 0..n_agents {
+        if start[a] != goal[a] {
+            let found = decomp.empties_in_component[decomp.component_of_vertex[start[a]]];
+            if found < 2 {
+                return Err(PlanError::TooFewEmpty { found });
+            }
+        }
+    }
+
     // Goal-side assignment `f'` reuses the same subgraphs and per-component
     // `m` — those depend on the graph and the empty counts, not on where
     // the atoms sit, and any solvable instance keeps each agent (and thus
@@ -151,17 +198,41 @@ pub fn plan_with(
         &m_of_vertex,
     );
 
-    // Line 5: `if f = f'`. A mismatch means some agent is confined to one
-    // subgraph at the start and a different one at the goal, which
-    // Proposition 1 forbids — so the instance is unsolvable.
-    for a in 0..n_agents as u32 {
-        if decomp.assignment.get(&a) != f_goal.get(&a) {
-            let qubit = initial[a as usize].0;
-            return Err(PlanError::Unsolvable { agent: qubit });
+    // Line 5, in region-containment form rather than the paper's `f = f'`
+    // equality. Our `assign_agents` deliberately under-assigns relative to
+    // the paper (see the soundness note in the decomposition module), which
+    // breaks the symmetry the equality test relies on: the two placements
+    // can gate differently for an agent that is confined the same way in
+    // both, turning `Some(S) != None` into a false proof. What Proposition 1
+    // actually licenses — and what the feasibility module's brute-force
+    // tests validate — is the region claim, applied in both time directions
+    // since pebble moves are reversible:
+    //
+    // * an agent confined at the start must have its goal inside that
+    //   region, and
+    // * an agent confined at the goal must have its start inside that
+    //   region (running the plan backwards).
+    //
+    // Subgraphs and planks depend only on the graph and the per-component
+    // empty counts, so the one decomposition serves both directions.
+    for (&a, &sub) in &decomp.assignment {
+        if !decomp.contains_in_subgraph_or_planks(sub, goal[a as usize]) {
+            return Err(PlanError::Unsolvable {
+                qubit: qubit_of_agent[a as usize],
+                reason: "the atom is confined to a region that excludes its goal",
+            });
+        }
+    }
+    for (&a, &sub) in &f_goal {
+        if !decomp.contains_in_subgraph_or_planks(sub, start[a as usize]) {
+            return Err(PlanError::Unsolvable {
+                qubit: qubit_of_agent[a as usize],
+                reason: "the atom's goal is confined to a region that excludes its start",
+            });
         }
     }
 
-    let ctx = PlanCtx::new(graph, index, &decomp, &goal, heuristics);
+    let ctx = PlanCtx::new(graph, index, &decomp, &goal, &qubit_of_agent, heuristics);
     solve(&ctx, &start, budget)
 }
 
@@ -182,8 +253,16 @@ fn solve(ctx: &PlanCtx, start: &[VertexId], budget: usize) -> Result<Plan, PlanE
     let mut current: Option<u32> = None;
 
     // Line 5: on a polygon every vertex has degree 2, so no swap vertex
-    // exists and paths must avoid finished agents entirely.
-    let is_polygon = graph.vertices().all(|v| graph.degree(v) == 2);
+    // exists and paths must avoid finished agents entirely. Decided per
+    // connected component — a graph mixing a polygon component with a
+    // branching one must treat each by its own rule.
+    let n_components = ctx.decomp.empties_in_component.len();
+    let mut polygon_component = vec![true; n_components];
+    for v in graph.vertices() {
+        if graph.degree(v) != 2 {
+            polygon_component[ctx.decomp.component_of_vertex[v]] = false;
+        }
+    }
 
     // Agents are planned in subgraph-precedence order; within that, agents
     // assigned to no subgraph go last (§3.1.3).
@@ -222,6 +301,7 @@ fn solve(ctx: &PlanCtx, start: &[VertexId], budget: usize) -> Result<Plan, PlanE
         }
 
         // Lines 9-12: choose the path.
+        let is_polygon = polygon_component[ctx.decomp.component_of_vertex[state.position_of(r)]];
         let path_block = if is_polygon {
             blocked_finished.clone()
         } else {
@@ -233,7 +313,14 @@ fn solve(ctx: &PlanCtx, start: &[VertexId], budget: usize) -> Result<Plan, PlanE
                 ctx.heuristics.score_step(ctx, &state, r, from, to)
             })
         else {
-            return Err(PlanError::Unsolvable { agent: r });
+            // With no blocking (non-polygon) this is graph disconnection —
+            // a genuine proof. On a polygon, settled agents can never be
+            // displaced, so a path avoiding them failing to exist is the
+            // paper's line 9-12 unsolvability criterion.
+            return Err(PlanError::Unsolvable {
+                qubit: ctx.qubits[r as usize],
+                reason: "no path to the target exists",
+            });
         };
         q.push(state.position_of(r));
 
@@ -251,7 +338,10 @@ fn solve(ctx: &PlanCtx, start: &[VertexId], budget: usize) -> Result<Plan, PlanE
                     &path_block,
                     |from, to| ctx.heuristics.score_step(ctx, &state, r, from, to),
                 ) else {
-                    return Err(PlanError::Unsolvable { agent: r });
+                    return Err(PlanError::Unsolvable {
+                        qubit: ctx.qubits[r as usize],
+                        reason: "no path to the target exists",
+                    });
                 };
                 path = p;
                 step_i = 0;
@@ -266,12 +356,17 @@ fn solve(ctx: &PlanCtx, start: &[VertexId], budget: usize) -> Result<Plan, PlanE
                 // Lines 16-19: a cycle of displaced agents.
                 let cycle: Vec<VertexId> = q[pos..].to_vec();
                 q.truncate(pos);
-                if !rotate(ctx, &mut state, &cycle) {
-                    return Err(PlanError::Unsolvable { agent: r });
+                if rotate(ctx, &mut state, &cycle) {
+                    // The rotate moved r; recompute the path.
+                    step_i = usize::MAX;
+                    continue;
                 }
-                // The rotate moved r; recompute the path.
-                step_i = usize::MAX;
-                continue;
+                // Not a rotatable cycle. `q` accumulates vertices across
+                // successive agents (the return loop below can break early
+                // on purpose), so a repeated vertex can be a stale artifact
+                // of an earlier agent's path rather than a closed walk of
+                // displaced atoms. Fall through to the ordinary push/swap
+                // handling of `v` instead of aborting the whole plan.
             }
 
             let mut blocked_now = no_blocked(graph.len());
@@ -282,12 +377,20 @@ fn solve(ctx: &PlanCtx, start: &[VertexId], budget: usize) -> Result<Plan, PlanE
             }
             if !push(ctx, &mut state, r, v, &blocked_now) {
                 // Line 22: push failed, so (Lemma 1) the blocker shares r's
-                // subgraph and swap must succeed.
+                // subgraph and swap must succeed. If either expectation
+                // fails, that is the planner losing its footing — not
+                // evidence about the instance.
                 let Some(s) = state.agent_at(v) else {
-                    return Err(PlanError::Unsolvable { agent: r });
+                    return Err(PlanError::Stuck {
+                        qubit: ctx.qubits[r as usize],
+                        reason: "push failed with no blocking atom to swap with",
+                    });
                 };
                 if !swap(ctx, &mut state, r, s) {
-                    return Err(PlanError::Unsolvable { agent: r });
+                    return Err(PlanError::Stuck {
+                        qubit: ctx.qubits[r as usize],
+                        reason: "swap failed where Lemma 1 requires it to succeed",
+                    });
                 }
                 step_i = usize::MAX;
             }
@@ -328,10 +431,15 @@ fn solve(ctx: &PlanCtx, start: &[VertexId], budget: usize) -> Result<Plan, PlanE
         }
     }
 
-    // Only a genuine success if every agent actually reached its goal.
+    // Only a genuine success if every agent actually reached its goal. On a
+    // correct implementation this is unreachable for in-regime instances —
+    // if it fires, it is a planner-bug sentinel, never a proof.
     for (a, &want) in goal.iter().enumerate() {
         if state.position_of(a as u32) != want {
-            return Err(PlanError::Unsolvable { agent: a as u32 });
+            return Err(PlanError::Stuck {
+                qubit: ctx.qubits[a],
+                reason: "final placement check failed after planning completed",
+            });
         }
     }
 

--- a/crates/bloqade-lanes-search/src/push_rotate/mod.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/mod.rs
@@ -1,0 +1,354 @@
+//! Push and Rotate: a complete multi-agent pathfinding planner.
+//!
+//! de Wilde, ter Mors & Witteveen, *Push and Rotate: a Complete Multi-agent
+//! Pathfinding Algorithm*, JAIR 51 (2014) 443–492. Complete for instances with
+//! at least two empty vertices (Theorem 1): it finds a solution whenever one
+//! exists, and returns [`PlanError::Unsolvable`] otherwise.
+//!
+//! The Kornhauser decomposition it runs on (Algorithms 1–3) lives in the open
+//! `crate::feasibility` module — it is the paper's own content
+//! and is shared with the open feasibility checker. This module implements the
+//! planner proper: Algorithms 4–8 and 10–13.
+//!
+//! ## Output shape
+//!
+//! The planner emits **single-atom moves**, one per step. That is not a usable
+//! AOD schedule on its own — turning it into one is the condenser's job
+//! (phase 2b), which merges consecutive moves into complete X×Y rectangle
+//! batches. Sound by construction: a legal AOD move is exactly a set of
+//! vertex-disjoint single moves into empty destinations.
+
+pub mod context;
+pub mod heuristics;
+pub mod instances;
+pub mod ops;
+pub mod schedule;
+pub mod smooth;
+pub mod solver;
+pub mod state;
+
+pub use solver::{DEFAULT_MOVE_BUDGET, solve_push_rotate, solve_push_rotate_with};
+
+use std::collections::HashMap;
+
+use crate::feasibility::decomposition::{
+    Decomposition, assign_agents, find_planks, find_subgraphs,
+};
+use crate::feasibility::graph::{LaneGraph, VertexId};
+use crate::primitives::lane_index::LaneIndex;
+
+use crate::push_rotate::context::PlanCtx;
+use crate::push_rotate::heuristics::{DefaultHeuristics, PlanHeuristics};
+use crate::push_rotate::ops::{no_blocked, push, rotate, swap};
+use crate::push_rotate::state::{Move, PlanState};
+
+/// Why planning stopped without a solution.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum PlanError {
+    /// Proven unsolvable. Algorithm 7 line 5: the agent→subgraph assignment
+    /// computed from the initial placement differs from the one computed from
+    /// the goal, so some agent would have to leave the region Proposition 1
+    /// confines it to.
+    #[error(
+        "instance is unsolvable: agent {agent} is confined to a different subgraph in the goal"
+    )]
+    Unsolvable { agent: u32 },
+    /// Fewer than two empty vertices. Push and Rotate's completeness result
+    /// does not cover this regime.
+    #[error("push and rotate requires at least 2 empty vertices, found {found}")]
+    TooFewEmpty { found: usize },
+    /// An atom or target is not a vertex of the lane graph.
+    #[error("location {location:#x} for qubit {agent} is blocked or not on any lane")]
+    OffGraph { agent: u32, location: u64 },
+    /// The planner exceeded its step budget. Distinct from `Unsolvable`: this
+    /// says nothing about whether a solution exists.
+    #[error("exceeded step budget of {budget} moves")]
+    BudgetExceeded { budget: usize },
+}
+
+/// A completed plan: single-atom moves in execution order.
+#[derive(Debug, Clone)]
+pub struct Plan {
+    /// The moves, after [`smooth`](smooth::smooth).
+    pub moves: Vec<Move>,
+    /// Move count before smoothing. Reported so the post-processing's
+    /// contribution is visible rather than inferred — on Gemini instances it
+    /// turns out to be near zero, which is worth being able to see.
+    pub raw_move_count: usize,
+}
+
+/// Plan a rearrangement with Push and Rotate.
+///
+/// `initial` and `target` are `(qubit, vertex)` placements over `graph`.
+pub fn plan(
+    index: &LaneIndex,
+    graph: &LaneGraph,
+    initial: &[(u32, VertexId)],
+    target: &[(u32, VertexId)],
+    budget: usize,
+) -> Result<Plan, PlanError> {
+    plan_with(index, graph, initial, target, budget, &DefaultHeuristics)
+}
+
+/// Plan with an explicit heuristic strategy.
+///
+/// [`plan`] is this with [`DefaultHeuristics`], which is the unoptimised
+/// baseline all current benchmark numbers were measured against.
+pub fn plan_with(
+    index: &LaneIndex,
+    graph: &LaneGraph,
+    initial: &[(u32, VertexId)],
+    target: &[(u32, VertexId)],
+    budget: usize,
+    heuristics: &dyn PlanHeuristics,
+) -> Result<Plan, PlanError> {
+    let n_agents = initial.len();
+    let empty_count = graph.len().saturating_sub(n_agents);
+    if empty_count < 2 {
+        return Err(PlanError::TooFewEmpty { found: empty_count });
+    }
+
+    // Dense agent indexing: the planner works with 0..n_agents internally.
+    let mut agent_of_qubit: HashMap<u32, u32> = HashMap::new();
+    let mut start = vec![0usize; n_agents];
+    for (i, &(qubit, v)) in initial.iter().enumerate() {
+        agent_of_qubit.insert(qubit, i as u32);
+        start[i] = v;
+    }
+    let mut goal = start.clone();
+    for &(qubit, v) in target {
+        if let Some(&a) = agent_of_qubit.get(&qubit) {
+            goal[a as usize] = v;
+        }
+    }
+
+    // ── Algorithm 7 ────────────────────────────────────────────────
+    let bcc = graph.biconnected();
+    let (subgraphs, subgraph_of_vertex) = find_subgraphs(graph, &bcc, empty_count);
+    let planks = find_planks(graph, &subgraphs, &subgraph_of_vertex, empty_count);
+
+    let occupancy = |placement: &[VertexId]| -> Vec<Option<u32>> {
+        let mut occ = vec![None; graph.len()];
+        for (a, &v) in placement.iter().enumerate() {
+            occ[v] = Some(a as u32);
+        }
+        occ
+    };
+
+    let f_initial = assign_agents(
+        graph,
+        &subgraphs,
+        &subgraph_of_vertex,
+        &occupancy(&start),
+        empty_count,
+    );
+    let f_goal = assign_agents(
+        graph,
+        &subgraphs,
+        &subgraph_of_vertex,
+        &occupancy(&goal),
+        empty_count,
+    );
+
+    // Line 5: `if f = f'`. A mismatch means some agent is confined to one
+    // subgraph at the start and a different one at the goal, which
+    // Proposition 1 forbids — so the instance is unsolvable.
+    for a in 0..n_agents as u32 {
+        if f_initial.get(&a) != f_goal.get(&a) {
+            let qubit = initial[a as usize].0;
+            return Err(PlanError::Unsolvable { agent: qubit });
+        }
+    }
+
+    let decomp = Decomposition {
+        subgraphs,
+        subgraph_of_vertex,
+        planks,
+        assignment: f_initial,
+        empty_count,
+    };
+
+    let ctx = PlanCtx::new(graph, index, &decomp, &goal, heuristics);
+    solve(&ctx, &start, budget)
+}
+
+/// Algorithm 8: `solve`.
+///
+/// Move agents to their destinations one at a time along a shortest path,
+/// pushing where possible and swapping where not. `q` accumulates the path
+/// walked so far; a step back onto `q` means a cycle of displaced agents,
+/// which `rotate` resolves. The second loop returns agents that a swap knocked
+/// off their goal.
+fn solve(ctx: &PlanCtx, start: &[VertexId], budget: usize) -> Result<Plan, PlanError> {
+    let graph = ctx.graph;
+    let goal = ctx.goal;
+    let n_agents = start.len();
+    let mut state = PlanState::new(graph, start);
+    let mut finished = vec![false; n_agents];
+    let mut q: Vec<VertexId> = Vec::new();
+    let mut current: Option<u32> = None;
+
+    // Line 5: on a polygon every vertex has degree 2, so no swap vertex
+    // exists and paths must avoid finished agents entirely.
+    let is_polygon = graph.vertices().all(|v| graph.degree(v) == 2);
+
+    // Agents are planned in subgraph-precedence order; within that, agents
+    // assigned to no subgraph go last (§3.1.3).
+    let order = ctx.heuristics.agent_order(ctx, &state);
+    debug_assert_eq!(
+        order.len(),
+        n_agents,
+        "agent_order must return every agent exactly once"
+    );
+    let mut next_idx = 0usize;
+
+    while finished.iter().any(|&f| !f) {
+        if state.moves().len() > budget {
+            return Err(PlanError::BudgetExceeded { budget });
+        }
+
+        let r = match current.take() {
+            Some(r) => r,
+            None => {
+                // Line 8: next unfinished agent by priority.
+                while next_idx < order.len() && finished[order[next_idx] as usize] {
+                    next_idx += 1;
+                }
+                if next_idx >= order.len() {
+                    break;
+                }
+                order[next_idx]
+            }
+        };
+
+        let mut blocked_finished = no_blocked(graph.len());
+        for a in 0..n_agents {
+            if finished[a] {
+                blocked_finished[state.position_of(a as u32)] = true;
+            }
+        }
+
+        // Lines 9-12: choose the path.
+        let path_block = if is_polygon {
+            blocked_finished.clone()
+        } else {
+            no_blocked(graph.len())
+        };
+        let goal_v = goal[r as usize];
+        let Some(mut path) =
+            state.shortest_path_scored(state.position_of(r), goal_v, &path_block, |from, to| {
+                ctx.heuristics.score_step(ctx, &state, r, from, to)
+            })
+        else {
+            return Err(PlanError::Unsolvable { agent: r });
+        };
+        q.push(state.position_of(r));
+
+        // Line 14: advance r one vertex at a time.
+        let mut step_i = 0usize;
+        while state.position_of(r) != goal_v {
+            if state.moves().len() > budget {
+                return Err(PlanError::BudgetExceeded { budget });
+            }
+            if step_i >= path.len() {
+                // The placement shifted under us (a swap moved r); re-plan.
+                let Some(p) = state.shortest_path_scored(
+                    state.position_of(r),
+                    goal_v,
+                    &path_block,
+                    |from, to| ctx.heuristics.score_step(ctx, &state, r, from, to),
+                ) else {
+                    return Err(PlanError::Unsolvable { agent: r });
+                };
+                path = p;
+                step_i = 0;
+                if path.is_empty() {
+                    break;
+                }
+            }
+            let v = path[step_i];
+            step_i += 1;
+
+            if let Some(pos) = q.iter().position(|&x| x == v) {
+                // Lines 16-19: a cycle of displaced agents.
+                let cycle: Vec<VertexId> = q[pos..].to_vec();
+                q.truncate(pos);
+                if !rotate(ctx, &mut state, &cycle) {
+                    return Err(PlanError::Unsolvable { agent: r });
+                }
+                // The rotate moved r; recompute the path.
+                step_i = usize::MAX;
+                continue;
+            }
+
+            let mut blocked_now = no_blocked(graph.len());
+            for a in 0..n_agents {
+                if finished[a] {
+                    blocked_now[state.position_of(a as u32)] = true;
+                }
+            }
+            if !push(ctx, &mut state, r, v, &blocked_now) {
+                // Line 22: push failed, so (Lemma 1) the blocker shares r's
+                // subgraph and swap must succeed.
+                let Some(s) = state.agent_at(v) else {
+                    return Err(PlanError::Unsolvable { agent: r });
+                };
+                if !swap(ctx, &mut state, r, s) {
+                    return Err(PlanError::Unsolvable { agent: r });
+                }
+                step_i = usize::MAX;
+            }
+            q.push(v);
+        }
+
+        finished[r as usize] = true;
+        current = None;
+
+        // Lines 26-35: return agents a swap knocked off their goal.
+        while let Some(&v) = q.last() {
+            if state.moves().len() > budget {
+                return Err(PlanError::BudgetExceeded { budget });
+            }
+            let Some(s) = state.agent_at(v) else {
+                q.pop();
+                continue;
+            };
+            if finished[s as usize] && v != goal[s as usize] {
+                let target_v = goal[s as usize];
+                match state.agent_at(target_v) {
+                    None => {
+                        if graph.neighbors(v).contains(&target_v) {
+                            state.step(s, target_v);
+                        } else {
+                            break;
+                        }
+                    }
+                    Some(blocker) => {
+                        // Line 34: restart the outer loop with the blocker.
+                        finished[blocker as usize] = false;
+                        current = Some(blocker);
+                        break;
+                    }
+                }
+            }
+            q.pop();
+        }
+    }
+
+    // Only a genuine success if every agent actually reached its goal.
+    for (a, &want) in goal.iter().enumerate() {
+        if state.position_of(a as u32) != want {
+            return Err(PlanError::Unsolvable { agent: a as u32 });
+        }
+    }
+
+    // Algorithm 9. Push and Rotate generates round trips constantly — `clear`
+    // shoves an agent aside and the swap reversal shoves it back — and while
+    // pnr emits one atom per operation, every move removed is an operation
+    // removed.
+    let raw_move_count = state.moves().len();
+    Ok(Plan {
+        moves: smooth::smooth(state.moves()),
+        raw_move_count,
+    })
+}

--- a/crates/bloqade-lanes-search/src/push_rotate/ops.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/ops.rs
@@ -1,0 +1,457 @@
+//! The `push`, `swap`, and `rotate` operations, and their auxiliaries.
+//!
+//! Direct implementations of Algorithms 4, 5, 6 and 10–13 of de Wilde, ter
+//! Mors & Witteveen (JAIR 51, 2014). Algorithm numbers are cited on each
+//! function; where this deviates from the paper it says so and why.
+//!
+//! Blocked-vertex sets (`U` in the paper) are passed as `&[bool]` indexed by
+//! vertex rather than as a set: they are consulted inside BFS inner loops, and
+//! every call site already has a dense vertex space.
+
+use crate::feasibility::graph::VertexId;
+
+use crate::push_rotate::context::PlanCtx;
+use crate::push_rotate::state::PlanState;
+
+/// A blocked-vertex mask.
+pub type Blocked = Vec<bool>;
+
+/// An all-false mask sized for the graph.
+pub fn no_blocked(n: usize) -> Blocked {
+    vec![false; n]
+}
+
+/// Algorithm 10: `clear_vertex(Π, G, A, v, U)`.
+///
+/// Find a shortest path from some unoccupied vertex `u` to `v` avoiding `U`,
+/// then shift every agent on that path one step towards `u`, vacating `v`.
+///
+/// Which empty vertex to drain into is §5 decision 1, delegated to
+/// [`PlanHeuristics::rank_clear_target`](crate::push_rotate::heuristics::PlanHeuristics::rank_clear_target).
+/// The default ranks by distance, which is what the paper's Appendix A notes
+/// affects both runtime and solution length.
+pub fn clear_vertex(ctx: &PlanCtx, state: &mut PlanState, v: VertexId, blocked: &Blocked) -> bool {
+    if !state.is_occupied(v) {
+        return true;
+    }
+    if blocked.get(v).copied().unwrap_or(false) {
+        return false;
+    }
+
+    // BFS outward from `v`, one pass rather than one per empty vertex.
+    //
+    // The scan stops once it is past the depth of the first empty vertex
+    // found, so the heuristic ranks only the *equally nearest* candidates.
+    // That is deliberate: letting it reach past them would let a heuristic
+    // lengthen the plan, and the whole point of ranking rather than choosing
+    // is that a heuristic can reorder equally-good options but not make a
+    // worse one. It also preserves the early exit — without it every call
+    // would sweep the whole component.
+    let n = state.graph().len();
+    let mut prev = vec![usize::MAX; n];
+    let mut seen = vec![false; n];
+    let mut depth = vec![0u32; n];
+    let mut queue = std::collections::VecDeque::new();
+    seen[v] = true;
+    queue.push_back(v);
+
+    let mut best: Option<(i64, VertexId)> = None;
+    let mut best_depth: Option<u32> = None;
+    while let Some(u) = queue.pop_front() {
+        if best_depth.is_some_and(|d| depth[u] > d) {
+            break;
+        }
+        if !state.is_occupied(u) {
+            let key = ctx.heuristics.rank_clear_target(ctx, state, v, u, depth[u]);
+            if best.is_none_or(|(bk, _)| key < bk) {
+                best = Some((key, u));
+            }
+            best_depth.get_or_insert(depth[u]);
+        }
+        for &w in state.graph().neighbors(u) {
+            if seen[w] || blocked.get(w).copied().unwrap_or(false) {
+                continue;
+            }
+            seen[w] = true;
+            prev[w] = u;
+            depth[w] = depth[u] + 1;
+            queue.push_back(w);
+        }
+    }
+
+    let Some((_, empty)) = best else {
+        return false;
+    };
+
+    // Walk back v <- ... <- empty, shifting each agent one step outward.
+    let mut chain = vec![empty];
+    let mut cur = empty;
+    while cur != v {
+        cur = prev[cur];
+        debug_assert_ne!(cur, usize::MAX, "clear_vertex parent chain broke");
+        chain.push(cur);
+    }
+    // chain is [empty, ..., v]; move the agent adjacent to `empty` into it,
+    // and repeat towards v.
+    for pair in chain.windows(2) {
+        let (dst, src) = (pair[0], pair[1]);
+        let agent = state.agent_at(src).expect("chain interior is occupied");
+        state.step(agent, dst);
+    }
+    debug_assert!(!state.is_occupied(v));
+    true
+}
+
+/// Algorithm 4: `push(Π, G, A, r, v, U)`.
+///
+/// Move agent `r` onto adjacent vertex `v`, clearing `v` first if needed.
+/// `r`'s own vertex is added to the blocked set while clearing, so the clear
+/// cannot route through the agent that is about to move.
+pub fn push(ctx: &PlanCtx, state: &mut PlanState, r: u32, v: VertexId, blocked: &Blocked) -> bool {
+    if state.is_occupied(v) {
+        let mut u = blocked.clone();
+        u[state.position_of(r)] = true;
+        if !clear_vertex(ctx, state, v, &u) {
+            return false;
+        }
+    }
+    state.step(r, v);
+    true
+}
+
+/// Algorithm 11: `multipush(Π, G, A, r', s', v)`.
+///
+/// Bring the adjacent pair `r'`/`s'` to `v`, leading with whichever is closer,
+/// the other following into the vacated vertex.
+fn multipush(
+    ctx: &PlanCtx,
+    state: &mut PlanState,
+    r_prime: u32,
+    s_prime: u32,
+    v: VertexId,
+) -> Option<(u32, u32)> {
+    let none = no_blocked(state.graph().len());
+    let dist = state.graph().distances_from(v, |_| false);
+    let (r, s) = if dist[state.position_of(r_prime)] <= dist[state.position_of(s_prime)] {
+        (r_prime, s_prime)
+    } else {
+        (s_prime, r_prime)
+    };
+
+    let path = state.shortest_path(state.position_of(r), v, &none)?;
+    for x in path {
+        let vr = state.position_of(r);
+        let vs = state.position_of(s);
+        if state.is_occupied(x) {
+            let mut u = no_blocked(state.graph().len());
+            u[vr] = true;
+            u[vs] = true;
+            if !clear_vertex(ctx, state, x, &u) {
+                return None;
+            }
+        }
+        state.step(r, x);
+        state.step(s, vr);
+    }
+    Some((r, s))
+}
+
+/// Algorithm 13: `exchange(Π, G, A, r', s', v)`.
+///
+/// With `r` on `v`, `s` adjacent, and two empty neighbours of `v`, swap the
+/// two agents in place.
+fn exchange(state: &mut PlanState, r: u32, s: u32, v: VertexId) -> bool {
+    let vs = state.position_of(s);
+    let empties: Vec<VertexId> = state
+        .graph()
+        .neighbors(v)
+        .iter()
+        .copied()
+        .filter(|&n| !state.is_occupied(n))
+        .take(2)
+        .collect();
+    if empties.len() < 2 {
+        return false;
+    }
+    let (v1, v2) = (empties[0], empties[1]);
+    state.step(r, v1);
+    state.step_through(s, v, v2);
+    state.step_through(r, v, vs);
+    state.step(s, v);
+    true
+}
+
+/// Algorithm 12: `clear(Π, G, A, r', s', v)`.
+///
+/// Try to give `v` two empty neighbours, in the paper's four escalating
+/// stages. `r` is on `v`, `s` on the adjacent `v'`.
+fn clear(ctx: &PlanCtx, state: &mut PlanState, r: u32, s: u32, v: VertexId) -> bool {
+    let n_v = state.graph().len();
+    let v_prime = state.position_of(s);
+
+    let empties = |st: &PlanState| -> Vec<VertexId> {
+        st.graph()
+            .neighbors(v)
+            .iter()
+            .copied()
+            .filter(|&x| !st.is_occupied(x))
+            .collect()
+    };
+
+    // Stage 1: push neighbours of `v` away from `v`.
+    if empties(state).len() >= 2 {
+        return true;
+    }
+    let neighbours: Vec<VertexId> = state.graph().neighbors(v).to_vec();
+    for &n in &neighbours {
+        if !state.is_occupied(n) || n == v_prime {
+            continue;
+        }
+        let mut u = no_blocked(n_v);
+        u[v] = true;
+        u[v_prime] = true;
+        for e in empties(state) {
+            u[e] = true;
+        }
+        if clear_vertex(ctx, state, n, &u) && empties(state).len() >= 2 {
+            return true;
+        }
+    }
+
+    let current = empties(state);
+    if current.is_empty() {
+        return false;
+    }
+    let eps = current[0];
+
+    // Stage 2: vacate a neighbour, then re-clear the empty one behind it.
+    for &n in &neighbours {
+        if n == v_prime || n == eps {
+            continue;
+        }
+        let cp = state.checkpoint();
+        let mut u = no_blocked(n_v);
+        u[v] = true;
+        u[v_prime] = true;
+        if clear_vertex(ctx, state, n, &u) {
+            let mut u2 = no_blocked(n_v);
+            u2[v] = true;
+            u2[v_prime] = true;
+            u2[n] = true;
+            if clear_vertex(ctx, state, eps, &u2) {
+                return true;
+            }
+        }
+        state.rollback(cp);
+        break;
+    }
+
+    // Stage 3: move r and s back a step so a neighbour can vacate through v'.
+    for &n in &neighbours {
+        if n == v_prime || n == eps {
+            continue;
+        }
+        let cp = state.checkpoint();
+        state.step(r, eps);
+        state.step(s, v);
+        let mut u = no_blocked(n_v);
+        u[v] = true;
+        u[eps] = true;
+        if clear_vertex(ctx, state, n, &u) {
+            let mut u2 = no_blocked(n_v);
+            u2[v] = true;
+            u2[eps] = true;
+            u2[n] = true;
+            if clear_vertex(ctx, state, v_prime, &u2) {
+                return true;
+            }
+        }
+        state.rollback(cp);
+        break;
+    }
+
+    // Stage 4: make room behind eps by routing a neighbour through v.
+    let cp = state.checkpoint();
+    let mut u = no_blocked(n_v);
+    u[v] = true;
+    if !clear_vertex(ctx, state, v_prime, &u) {
+        state.rollback(cp);
+        return false;
+    }
+    state.step(r, v_prime);
+    let mut u2 = no_blocked(n_v);
+    u2[v] = true;
+    u2[v_prime] = true;
+    u2[state.position_of(s)] = true;
+    if !clear_vertex(ctx, state, eps, &u2) {
+        state.rollback(cp);
+        return false;
+    }
+    let Some(&n) = neighbours.iter().find(|&&x| x != v_prime && x != eps) else {
+        state.rollback(cp);
+        return false;
+    };
+    let Some(t) = state.agent_at(n) else {
+        state.rollback(cp);
+        return false;
+    };
+    if state.is_occupied(v) || state.is_occupied(eps) {
+        state.rollback(cp);
+        return false;
+    }
+    state.step_through(t, v, eps);
+    state.step(r, v);
+    state.step(s, v_prime);
+    let mut u3 = no_blocked(n_v);
+    u3[v] = true;
+    u3[v_prime] = true;
+    u3[n] = true;
+    if clear_vertex(ctx, state, eps, &u3) {
+        true
+    } else {
+        state.rollback(cp);
+        false
+    }
+}
+
+/// Algorithm 5: `swap(Π, G, A, r, s)`.
+///
+/// Exchange two adjacent agents by walking both to a degree-≥3 vertex in their
+/// shared subgraph, exchanging there, and reversing the approach with the two
+/// roles switched.
+///
+/// Proposition 3: this succeeds iff `r` and `s` are assigned to the same
+/// subgraph.
+pub fn swap(ctx: &PlanCtx, state: &mut PlanState, r: u32, s: u32) -> bool {
+    let Some(&sub) = ctx.decomp.assignment.get(&r) else {
+        return false;
+    };
+    if ctx.decomp.assignment.get(&s) != Some(&sub) {
+        return false;
+    }
+
+    // Candidate swap vertices: degree ≥ 3 within r's subgraph, nearest first
+    // (the paper: "we evaluate the vertices closest to r and s first").
+    let from = state.position_of(r);
+    let dist = state.graph().distances_from(from, |_| false);
+    // Which swap vertex to use is §5 decision 2.
+    let mut candidates: Vec<VertexId> = ctx.decomp.subgraphs[sub]
+        .iter()
+        .copied()
+        .filter(|&x| state.graph().degree(x) >= 3 && dist[x] != u32::MAX)
+        .collect();
+    candidates.sort_by_key(|&x| {
+        (
+            ctx.heuristics
+                .rank_swap_vertex(ctx, state, r, s, x, dist[x]),
+            x,
+        )
+    });
+
+    for v in candidates {
+        let cp = state.checkpoint();
+        let Some((lead, follow)) = multipush(ctx, state, r, s, v) else {
+            state.rollback(cp);
+            continue;
+        };
+        if !clear(ctx, state, lead, follow, v) {
+            state.rollback(cp);
+            continue;
+        }
+        // End of Π′ (multipush + clear). The exchange that follows is
+        // appended to Π, not Π′, and must survive the reversal.
+        let after_approach = state.checkpoint();
+        if !exchange(state, lead, follow, v) {
+            state.rollback(cp);
+            continue;
+        }
+        state.reverse_range_with_roles(cp, after_approach, lead, follow);
+        return true;
+    }
+    false
+}
+
+/// Algorithm 6: `rotate(Π, G, A, c)`.
+///
+/// Advance every agent on cycle `c` one step. `c` is in path order, and the
+/// agent on `c[i]` moves to `c[i+1]` (wrapping).
+pub fn rotate(ctx: &PlanCtx, state: &mut PlanState, cycle: &[VertexId]) -> bool {
+    if cycle.len() < 2 {
+        return false;
+    }
+    // `q` in Algorithm 8 accumulates vertices across successive agents, so a
+    // repeated vertex does not on its own guarantee the suffix is a closed
+    // walk. Verify before rotating: a non-cycle would produce non-adjacent
+    // steps and corrupt the placement.
+    for i in 0..cycle.len() {
+        let a = cycle[i];
+        let b = cycle[(i + 1) % cycle.len()];
+        if !state.graph().neighbors(a).contains(&b) {
+            return false;
+        }
+    }
+
+    // Trivial case: some vertex on the cycle is already empty, so shift into
+    // it and let each agent behind follow.
+    if let Some(hole) = cycle.iter().position(|&v| !state.is_occupied(v)) {
+        for k in 1..cycle.len() {
+            let dst = cycle[(hole + cycle.len() - k + 1) % cycle.len()];
+            let src = cycle[(hole + cycle.len() - k) % cycle.len()];
+            if let Some(agent) = state.agent_at(src) {
+                state.step(agent, dst);
+            }
+        }
+        return true;
+    }
+
+    // Fully occupied: evict one agent, swap it into place, rotate, restore.
+    let n_v = state.graph().len();
+    for (i, &v) in cycle.iter().enumerate() {
+        let Some(r) = state.agent_at(v) else { continue };
+        let cp = state.checkpoint();
+        let mut u = no_blocked(n_v);
+        for &c in cycle {
+            if c != v {
+                u[c] = true;
+            }
+        }
+        if !clear_vertex(ctx, state, v, &u) {
+            state.rollback(cp);
+            continue;
+        }
+        // Algorithm 6 line 9: Π′ is the clear_vertex phase alone. Everything
+        // after — the swap and the rotation itself — stays.
+        let after_clear = state.checkpoint();
+        let v_prev = cycle[(i + cycle.len() - 1) % cycle.len()];
+        let Some(r_prev) = state.agent_at(v_prev) else {
+            state.rollback(cp);
+            continue;
+        };
+        state.step(r_prev, v);
+        if !swap(ctx, state, r, r_prev) {
+            state.rollback(cp);
+            continue;
+        }
+        // Algorithm 6 line 14: advance *every* cycle agent one step, starting
+        // with the one moving into the hole at `v_prev` and walking backwards
+        // around the cycle. The last step moves `r` out of `v`, which is what
+        // leaves `v` free for the reversal below to put `r_prev` back into —
+        // stopping an iteration early strands `r` on `v` and the reversal
+        // then tries to move onto an occupied vertex.
+        for k in 1..cycle.len() {
+            let dst = cycle[(i + cycle.len() - k) % cycle.len()];
+            let src = cycle[(i + cycle.len() - k - 1) % cycle.len()];
+            if let Some(agent) = state.agent_at(src) {
+                state.step(agent, dst);
+            }
+        }
+        // Algorithm 6 line 15: `reverse(Pi, A, Pi'_{r/r'})`. Pi' is the
+        // clear_vertex phase — the range [cp, after_clear) — so the agents
+        // shoved aside to vacate `v` are put back. Reversing the *later*
+        // range would undo the swap and the rotation instead, which is the
+        // whole point of the operation.
+        state.reverse_range_with_roles(cp, after_clear, r, r_prev);
+        return true;
+    }
+    false
+}

--- a/crates/bloqade-lanes-search/src/push_rotate/ops.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/ops.rs
@@ -225,6 +225,9 @@ fn clear(ctx: &PlanCtx, state: &mut PlanState, r: u32, s: u32, v: VertexId) -> b
     let eps = current[0];
 
     // Stage 2: vacate a neighbour, then re-clear the empty one behind it.
+    // Every eligible neighbour is attempted — Algorithm 12 picks *a*
+    // neighbour, and giving up after the first failed candidate turned
+    // `clear` incomplete (a false-`Stuck` channel via `swap`).
     for &n in &neighbours {
         if n == v_prime || n == eps {
             continue;
@@ -243,10 +246,10 @@ fn clear(ctx: &PlanCtx, state: &mut PlanState, r: u32, s: u32, v: VertexId) -> b
             }
         }
         state.rollback(cp);
-        break;
     }
 
-    // Stage 3: move r and s back a step so a neighbour can vacate through v'.
+    // Stage 3: move r and s back a step so a neighbour can vacate through
+    // v'. As in stage 2, every eligible neighbour is attempted.
     for &n in &neighbours {
         if n == v_prime || n == eps {
             continue;
@@ -267,7 +270,6 @@ fn clear(ctx: &PlanCtx, state: &mut PlanState, r: u32, s: u32, v: VertexId) -> b
             }
         }
         state.rollback(cp);
-        break;
     }
 
     // Stage 4: make room behind eps by routing a neighbour through v.
@@ -323,21 +325,21 @@ fn clear(ctx: &PlanCtx, state: &mut PlanState, r: u32, s: u32, v: VertexId) -> b
 /// Proposition 3: this succeeds iff `r` and `s` are assigned to the same
 /// subgraph.
 pub fn swap(ctx: &PlanCtx, state: &mut PlanState, r: u32, s: u32) -> bool {
-    let Some(&sub) = ctx.decomp.assignment.get(&r) else {
-        return false;
-    };
-    if ctx.decomp.assignment.get(&s) != Some(&sub) {
-        return false;
-    }
-
-    // Candidate swap vertices: degree ≥ 3 within r's subgraph, nearest first
-    // (the paper: "we evaluate the vertices closest to r and s first").
+    // Candidate swap vertices: any reachable vertex of degree ≥ 3, nearest
+    // first (the paper: "we evaluate the vertices closest to r and s
+    // first"). The paper restricts candidates to the subgraph the agents
+    // are assigned to (Proposition 3), but our `assign_agents` deliberately
+    // under-assigns relative to the paper — gating the swap on that map
+    // made it refuse instances the completeness argument requires it to
+    // solve. Reachable degree-≥3 vertices are a superset of every subgraph
+    // restriction, and a failed candidate rolls back cleanly, so widening
+    // costs attempts, never correctness.
     let from = state.position_of(r);
     let dist = state.graph().distances_from(from, |_| false);
     // Which swap vertex to use is §5 decision 2.
-    let mut candidates: Vec<VertexId> = ctx.decomp.subgraphs[sub]
-        .iter()
-        .copied()
+    let mut candidates: Vec<VertexId> = state
+        .graph()
+        .vertices()
         .filter(|&x| state.graph().degree(x) >= 3 && dist[x] != u32::MAX)
         .collect();
     candidates.sort_by_key(|&x| {

--- a/crates/bloqade-lanes-search/src/push_rotate/schedule.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/schedule.rs
@@ -1,0 +1,295 @@
+//! Turn a sequential move list into a parallel AOD schedule.
+//!
+//! This is the "condenser" of `docs/design.md` phase 2b, and it is a **list
+//! scheduler over a dependency DAG**, not a peephole merger. Push and Rotate
+//! moves one agent to its destination before starting the next, so two moves
+//! that could share an AOD operation are typically hundreds of positions apart
+//! in the sequence. Nothing can be merged without reordering first.
+//!
+//! ## Dependencies
+//!
+//! For each vertex, the moves touching it (as source or destination) are
+//! totally ordered by the input sequence, and consecutive pairs get a
+//! precedence edge. Together with each agent's own move order that is
+//! sufficient for validity: a move's destination is vacated before it enters.
+//!
+//! The edges are *strict* — a move cannot enter a vertex in the same operation
+//! that another leaves it. That would need the vertex to be both a source and
+//! a destination of one bus group, and every bus has disjoint source and
+//! destination sets (see the `feasibility` module in the open crate for why
+//! that property holds and why it matters).
+//!
+//! ## Batching
+//!
+//! A legal AOD operation is a set of lanes sharing one
+//! `(move_type, bus_id, zone_id, direction)` group whose source positions form
+//! a complete X×Y rectangle — the Cartesian product of their distinct x and y
+//! values. So each scheduling step takes the ready set, partitions it by bus
+//! group, and picks the largest rectangle available. Every emitted batch is
+//! re-validated with `ArchSpec::check_lanes`, which is the authoritative rule.
+
+use std::collections::HashMap;
+
+use crate::feasibility::graph::{LaneGraph, VertexId};
+use crate::primitives::lane_index::LaneIndex;
+use bloqade_lanes_bytecode_core::arch::addr::{LaneAddr, LocationAddr};
+
+use crate::push_rotate::state::Move;
+
+/// One AOD operation: moves executed simultaneously, with the lanes realising
+/// them.
+#[derive(Debug, Clone)]
+pub struct Batch {
+    pub moves: Vec<Move>,
+    pub lanes: Vec<LaneAddr>,
+}
+
+/// Bus-group key. Matches `LaneIndex`'s own grouping.
+type GroupKey = (u8, u32, u32, u8);
+
+/// Strategy for choosing which AOD operation to emit next.
+///
+/// At each step the scheduler finds the largest legal rectangle available in
+/// each bus group; the policy then decides which of those to take. That is the
+/// scheduler's only free choice, and the counterpart to
+/// [`PlanHeuristics`](crate::push_rotate::heuristics::PlanHeuristics) on the
+/// planner side.
+///
+/// Scores are compared strictly, so an implementation that ties with the
+/// default leaves the default's group ordering intact.
+pub trait BatchPolicy {
+    /// Rank a candidate batch. **Higher is better.**
+    ///
+    /// `lanes` are the batch's lanes and `index` is available for geometry —
+    /// transport duration, positions — should a policy want to weigh a
+    /// slower-but-larger operation against a faster-but-smaller one.
+    fn score_batch(&self, moves: &[Move], lanes: &[LaneAddr], index: &LaneIndex) -> f64 {
+        let _ = (lanes, index);
+        moves.len() as f64
+    }
+}
+
+/// Take the biggest rectangle available. The behaviour all current benchmark
+/// numbers were measured with.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct LargestBatch;
+
+impl BatchPolicy for LargestBatch {}
+
+fn group_key(l: &LaneAddr) -> GroupKey {
+    (l.move_type as u8, l.bus_id, l.zone_id, l.direction as u8)
+}
+
+/// Schedule `moves` into AOD operations, preserving the placement they
+/// produce.
+///
+/// Returns `None` if any move has no lane realising it, which would mean the
+/// plan and the architecture disagree.
+pub fn schedule(index: &LaneIndex, graph: &LaneGraph, moves: &[Move]) -> Option<Vec<Batch>> {
+    schedule_with(index, graph, moves, &LargestBatch)
+}
+
+/// Schedule with an explicit batch policy.
+pub fn schedule_with(
+    index: &LaneIndex,
+    graph: &LaneGraph,
+    moves: &[Move],
+    policy: &dyn BatchPolicy,
+) -> Option<Vec<Batch>> {
+    if moves.is_empty() {
+        return Some(Vec::new());
+    }
+    let n = moves.len();
+
+    // Resolve each move to the lane that realises it, plus its source position.
+    let mut lanes: Vec<LaneAddr> = Vec::with_capacity(n);
+    let mut src_pos: Vec<(u64, u64)> = Vec::with_capacity(n);
+    for m in moves {
+        let lane = lane_between(index, graph, m.from, m.to)?;
+        let src = LocationAddr::decode(graph.location_of(m.from));
+        let (x, y) = index.position(src)?;
+        lanes.push(lane);
+        src_pos.push((x.to_bits(), y.to_bits()));
+    }
+
+    // ── Dependency edges ───────────────────────────────────────────
+    // Per vertex, chain the moves touching it in input order; per agent,
+    // chain its own moves. Both are captured by "last event at X".
+    let mut succ: Vec<Vec<usize>> = vec![Vec::new(); n];
+    let mut indeg = vec![0usize; n];
+    let mut last_at_vertex: HashMap<VertexId, usize> = HashMap::new();
+    let mut last_of_agent: HashMap<u32, usize> = HashMap::new();
+
+    let add_edge = |a: usize, b: usize, succ: &mut Vec<Vec<usize>>, indeg: &mut Vec<usize>| {
+        if a != b && !succ[a].contains(&b) {
+            succ[a].push(b);
+            indeg[b] += 1;
+        }
+    };
+
+    for (i, m) in moves.iter().enumerate() {
+        for v in [m.from, m.to] {
+            if let Some(&prev) = last_at_vertex.get(&v) {
+                add_edge(prev, i, &mut succ, &mut indeg);
+            }
+        }
+        // Register after adding edges so a move touching the same vertex
+        // twice does not depend on itself.
+        last_at_vertex.insert(m.from, i);
+        last_at_vertex.insert(m.to, i);
+
+        if let Some(&prev) = last_of_agent.get(&m.agent) {
+            add_edge(prev, i, &mut succ, &mut indeg);
+        }
+        last_of_agent.insert(m.agent, i);
+    }
+
+    // ── List scheduling ────────────────────────────────────────────
+    let arch = index.arch_spec();
+    let mut ready: Vec<usize> = (0..n).filter(|&i| indeg[i] == 0).collect();
+    let mut scheduled = vec![false; n];
+    let mut out: Vec<Batch> = Vec::new();
+
+    while !ready.is_empty() {
+        // Partition the ready set by bus group and take the biggest legal
+        // rectangle across all groups.
+        let mut by_group: HashMap<GroupKey, Vec<usize>> = HashMap::new();
+        for &i in &ready {
+            by_group.entry(group_key(&lanes[i])).or_default().push(i);
+        }
+        let mut best: Vec<usize> = Vec::new();
+        let mut best_score = f64::NEG_INFINITY;
+        let mut keys: Vec<&GroupKey> = by_group.keys().collect();
+        keys.sort_unstable();
+        for k in keys {
+            let pick = largest_rectangle(&by_group[k], &src_pos);
+            if pick.is_empty() {
+                continue;
+            }
+            let pick_moves: Vec<Move> = pick.iter().map(|&i| moves[i]).collect();
+            let pick_lanes: Vec<LaneAddr> = pick.iter().map(|&i| lanes[i]).collect();
+            let score = policy.score_batch(&pick_moves, &pick_lanes, index);
+            // Strictly greater, so a tie keeps the earlier group — which is
+            // what makes the default identical to a plain size comparison.
+            if score > best_score {
+                best_score = score;
+                best = pick;
+            }
+        }
+        if best.is_empty() {
+            // Should not happen — a single move is always a 1×1 rectangle.
+            best = vec![*ready.iter().min().expect("ready is non-empty")];
+        }
+
+        // Authoritative check. If the arch rejects the group, fall back to
+        // emitting one move, which is always legal.
+        let batch_lanes: Vec<LaneAddr> = best.iter().map(|&i| lanes[i]).collect();
+        let best = if batch_lanes.len() > 1 && !arch.check_lanes(&batch_lanes).is_empty() {
+            vec![best[0]]
+        } else {
+            best
+        };
+
+        let batch_lanes: Vec<LaneAddr> = best.iter().map(|&i| lanes[i]).collect();
+        out.push(Batch {
+            moves: best.iter().map(|&i| moves[i]).collect(),
+            lanes: batch_lanes,
+        });
+
+        for &i in &best {
+            scheduled[i] = true;
+            for &s in &succ[i] {
+                indeg[s] -= 1;
+            }
+        }
+        ready = (0..n).filter(|&i| !scheduled[i] && indeg[i] == 0).collect();
+    }
+
+    debug_assert!(scheduled.iter().all(|&s| s), "dependency graph had a cycle");
+    Some(out)
+}
+
+/// Largest subset of `cand` whose source positions form a complete X×Y grid.
+///
+/// Enumerates subsets of the distinct y values and, for each, intersects the
+/// x values present on those rows — the largest `|rows| × |common x|` wins.
+/// Exponential in the number of distinct rows, which is why it is capped;
+/// observed rectangles on Gemini top out at 3×3.
+fn largest_rectangle(cand: &[usize], src_pos: &[(u64, u64)]) -> Vec<usize> {
+    const MAX_ROWS_EXHAUSTIVE: usize = 12;
+
+    if cand.len() <= 1 {
+        return cand.to_vec();
+    }
+    // rows: y -> { x -> move index }
+    let mut rows: Vec<(u64, HashMap<u64, usize>)> = Vec::new();
+    for &i in cand {
+        let (x, y) = src_pos[i];
+        match rows.iter_mut().find(|(ry, _)| *ry == y) {
+            Some((_, m)) => {
+                m.entry(x).or_insert(i);
+            }
+            None => {
+                let mut m = HashMap::new();
+                m.insert(x, i);
+                rows.push((y, m));
+            }
+        }
+    }
+    rows.sort_by_key(|(y, _)| *y);
+
+    if rows.len() > MAX_ROWS_EXHAUSTIVE {
+        // Degrade to the single best row rather than enumerate 2^n.
+        let best = rows
+            .iter()
+            .max_by_key(|(_, m)| m.len())
+            .expect("rows is non-empty");
+        let mut xs: Vec<(&u64, &usize)> = best.1.iter().collect();
+        xs.sort_unstable();
+        return xs.into_iter().map(|(_, &i)| i).collect();
+    }
+
+    let mut best: Vec<usize> = Vec::new();
+    for mask in 1u32..(1 << rows.len()) {
+        let chosen: Vec<usize> = (0..rows.len()).filter(|b| mask >> b & 1 == 1).collect();
+        // x values present on every chosen row.
+        let mut common: Vec<u64> = rows[chosen[0]].1.keys().copied().collect();
+        for &r in &chosen[1..] {
+            common.retain(|x| rows[r].1.contains_key(x));
+        }
+        if common.len() * chosen.len() <= best.len() {
+            continue;
+        }
+        common.sort_unstable();
+        let mut pick: Vec<usize> = Vec::with_capacity(common.len() * chosen.len());
+        for &r in &chosen {
+            for x in &common {
+                pick.push(rows[r].1[x]);
+            }
+        }
+        if pick.len() > best.len() {
+            best = pick;
+        }
+    }
+    best
+}
+
+/// The lane realising the edge `from -> to`.
+fn lane_between(
+    index: &LaneIndex,
+    graph: &LaneGraph,
+    from: VertexId,
+    to: VertexId,
+) -> Option<LaneAddr> {
+    let src = LocationAddr::decode(graph.location_of(from));
+    let dst_enc = graph.location_of(to);
+    index
+        .outgoing_lanes(src)
+        .iter()
+        .find(|lane| {
+            index
+                .endpoints(lane)
+                .is_some_and(|(_, d)| d.encode() == dst_enc)
+        })
+        .copied()
+}

--- a/crates/bloqade-lanes-search/src/push_rotate/schedule.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/schedule.rs
@@ -34,6 +34,7 @@ use crate::feasibility::graph::{LaneGraph, VertexId};
 use crate::primitives::lane_index::LaneIndex;
 use bloqade_lanes_bytecode_core::arch::addr::{LaneAddr, LocationAddr};
 
+use crate::push_rotate::context::GroupKey;
 use crate::push_rotate::state::Move;
 
 /// One AOD operation: moves executed simultaneously, with the lanes realising
@@ -43,9 +44,6 @@ pub struct Batch {
     pub moves: Vec<Move>,
     pub lanes: Vec<LaneAddr>,
 }
-
-/// Bus-group key. Matches `LaneIndex`'s own grouping.
-type GroupKey = (u8, u32, u32, u8);
 
 /// Strategy for choosing which AOD operation to emit next.
 ///

--- a/crates/bloqade-lanes-search/src/push_rotate/smooth.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/smooth.rs
@@ -49,6 +49,21 @@
 //! returned to is untouched by anyone else, which is exactly what the
 //! redundancy condition guarantees. Plans are replayed against the graph in
 //! the tests regardless.
+//!
+//! ## Ordering relative to the scheduler
+//!
+//! Smoothing runs *before* the batch scheduler. Could it strip moves a
+//! heuristic added to improve parallelism? No — heuristics cannot add moves
+//! at all: `score_step` is only consulted among steps already on a shortest
+//! path (rank, don't choose), so every move smoothing removes is a
+//! `clear`/swap side effect, never a parallelism investment. There remains a
+//! theoretical interaction in the other direction: a removed leg could have
+//! been incidentally completing an AOD rectangle, so deleting it can in
+//! principle cost more operations than it saves. Empirically this has no
+//! surface — smoothing's contribution on Gemini instances is near zero
+//! (compare [`Plan::raw_move_count`](crate::push_rotate::Plan) against the
+//! smoothed count). If that ever changes, the cheap airtight fix is to
+//! schedule both the smoothed and unsmoothed plans and keep the shallower.
 
 use std::collections::VecDeque;
 

--- a/crates/bloqade-lanes-search/src/push_rotate/smooth.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/smooth.rs
@@ -1,0 +1,331 @@
+//! Algorithm 9: `smooth` — remove redundant moves from a finished plan.
+//!
+//! From §5.1 of de Wilde, ter Mors & Witteveen (JAIR 51, 2014):
+//!
+//! > A sequence of agent moves is redundant if the agent visits a vertex for a
+//! > second time, and no agents have visited the vertex in the meantime.
+//!
+//! Push and Rotate generates these constantly: `clear` shoves an agent aside,
+//! the swap reversal shoves it back, and the agent later walks the same way
+//! again. Every move in such a round trip can be deleted — the agent ends where
+//! it started and, by the definition above, nothing else depended on it being
+//! away.
+//!
+//! ## Why the linked lists
+//!
+//! Deleting a move can make *other* moves redundant, so the naive approach
+//! rescans the whole plan until it reaches a fixed point. Algorithm 9 instead
+//! threads four doubly-linked chains through the move list — previous/next
+//! move **by agent**, previous/next move **to a vertex** — so that after a
+//! deletion the newly-adjacent pair at that vertex can be checked in O(1).
+//!
+//! ## Deviation from the printed pseudocode
+//!
+//! Line 8 reads `while π′ ≠ NV(π)`, which stops *before* deleting the agent's
+//! return to the vertex. That leaves the agent moving to a vertex it never
+//! left. The prose one paragraph earlier is unambiguous — "from the sequence
+//! [π, NA(π), NA(NA(π)), ⋯ , NV(π)] all moves except for the first can be
+//! removed" — and the worked example in Figure 16 says the *final two* moves
+//! go, including the return. So the deletion here is inclusive of `NV(π)`.
+//!
+//! ## Extension: virtual start arrivals
+//!
+//! Algorithm 9 detects a round trip by finding two *moves* arriving at the
+//! same vertex. An agent's initial position is not a move, so a round trip
+//! that leaves the starting vertex and comes back is invisible to the printed
+//! algorithm — and Push and Rotate produces exactly those, since `clear` and
+//! the swap reversal routinely shove a not-yet-planned agent aside and back.
+//!
+//! We therefore seed each agent's start vertex as a virtual arrival, ordered
+//! before every real move. It is never itself removed. The soundness argument
+//! is unchanged: the agent ends where it began and, by the same
+//! no-one-else-visited condition, nothing depended on it being away.
+//!
+//! ## Why this is safe
+//!
+//! Removing a round trip can only make later moves *more* legal, never less:
+//! a move's precondition is that its destination is empty, and deleting an
+//! agent's excursion only frees vertices earlier. The vertex the agent
+//! returned to is untouched by anyone else, which is exactly what the
+//! redundancy condition guarantees. Plans are replayed against the graph in
+//! the tests regardless.
+
+use std::collections::VecDeque;
+
+use crate::feasibility::graph::VertexId;
+
+use crate::push_rotate::state::Move;
+
+const NONE: usize = usize::MAX;
+
+/// Remove redundant moves, returning the shortened plan.
+pub fn smooth(moves: &[Move]) -> Vec<Move> {
+    let n = moves.len();
+    if n < 2 {
+        return moves.to_vec();
+    }
+
+    // Nodes 0..n are real moves; n.. are the virtual start arrivals, one per
+    // agent that moves at all. `agent_of` / `vertex_of` resolve either kind.
+    let max_agent = moves.iter().map(|m| m.agent).max().unwrap_or(0) as usize;
+    let mut start_vertex: Vec<Option<VertexId>> = vec![None; max_agent + 1];
+    for m in moves {
+        let a = m.agent as usize;
+        if start_vertex[a].is_none() {
+            start_vertex[a] = Some(m.from);
+        }
+    }
+    let virtuals: Vec<(u32, VertexId)> = start_vertex
+        .iter()
+        .enumerate()
+        .filter_map(|(a, v)| v.map(|v| (a as u32, v)))
+        .collect();
+    let total = n + virtuals.len();
+    let agent_of = |i: usize| -> u32 {
+        if i < n {
+            moves[i].agent
+        } else {
+            virtuals[i - n].0
+        }
+    };
+    let mut prev_agent = vec![NONE; total];
+    let mut next_agent = vec![NONE; total];
+    let mut prev_vertex = vec![NONE; total];
+    let mut next_vertex = vec![NONE; total];
+    let mut removed = vec![false; total];
+
+    let mut last_by_agent = vec![NONE; max_agent + 1];
+    let max_vertex = moves.iter().map(|m| m.to.max(m.from)).max().unwrap_or(0);
+    let mut last_by_vertex = vec![NONE; max_vertex + 1];
+
+    // Virtual arrivals first, so they head their vertex chains.
+    for (k, &(a, v)) in virtuals.iter().enumerate() {
+        let i = n + k;
+        last_by_agent[a as usize] = i;
+        last_by_vertex[v] = i;
+    }
+
+    for (i, m) in moves.iter().enumerate() {
+        let a = m.agent as usize;
+        if last_by_agent[a] != NONE {
+            prev_agent[i] = last_by_agent[a];
+            next_agent[last_by_agent[a]] = i;
+        }
+        last_by_agent[a] = i;
+
+        let v: VertexId = m.to;
+        if last_by_vertex[v] != NONE {
+            prev_vertex[i] = last_by_vertex[v];
+            next_vertex[last_by_vertex[v]] = i;
+        }
+        last_by_vertex[v] = i;
+    }
+
+    // Lines 2-4: seed with every arrival whose *previous* arrival at the same
+    // vertex was by the same agent — the start of a round trip.
+    let mut queue: VecDeque<usize> = VecDeque::new();
+    let mut queued = vec![false; total];
+    for (i, &p) in prev_vertex.iter().enumerate().take(n) {
+        if p != NONE && agent_of(p) == agent_of(i) && !queued[p] {
+            queued[p] = true;
+            queue.push_back(p);
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    let unlink = |i: usize,
+                  removed: &mut Vec<bool>,
+                  prev_agent: &mut Vec<usize>,
+                  next_agent: &mut Vec<usize>,
+                  prev_vertex: &mut Vec<usize>,
+                  next_vertex: &mut Vec<usize>,
+                  queue: &mut VecDeque<usize>,
+                  queued: &mut Vec<bool>| {
+        removed[i] = true;
+        let (pa, na) = (prev_agent[i], next_agent[i]);
+        if pa != NONE {
+            next_agent[pa] = na;
+        }
+        if na != NONE {
+            prev_agent[na] = pa;
+        }
+        let (pv, nv) = (prev_vertex[i], next_vertex[i]);
+        if pv != NONE {
+            next_vertex[pv] = nv;
+        }
+        if nv != NONE {
+            prev_vertex[nv] = pv;
+        }
+        // Line 12: the pair now adjacent at this vertex may itself be a round
+        // trip.
+        if pv != NONE && nv != NONE && agent_of(pv) == agent_of(nv) && !queued[pv] {
+            queued[pv] = true;
+            queue.push_back(pv);
+        }
+    };
+
+    // Lines 5-14.
+    while let Some(start) = queue.pop_front() {
+        queued[start] = false;
+        if removed[start] {
+            continue;
+        }
+        // Capture the return arrival before any unlinking rewrites pointers.
+        let target = next_vertex[start];
+        if target == NONE || removed[target] || agent_of(target) != agent_of(start) {
+            continue;
+        }
+
+        let mut cur = next_agent[start];
+        while cur != NONE {
+            let next = next_agent[cur];
+            unlink(
+                cur,
+                &mut removed,
+                &mut prev_agent,
+                &mut next_agent,
+                &mut prev_vertex,
+                &mut next_vertex,
+                &mut queue,
+                &mut queued,
+            );
+            if cur == target {
+                break;
+            }
+            cur = next;
+        }
+    }
+
+    moves
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !removed[*i])
+        .map(|(_, m)| *m)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn mv(agent: u32, from: VertexId, to: VertexId) -> Move {
+        Move { agent, from, to }
+    }
+
+    /// Each agent's initial vertex, taken from its first move in the original
+    /// plan. Seeding both replays with this is what makes an agent that ends
+    /// where it began comparable to one that never moved.
+    fn starts(plan: &[Move]) -> BTreeMap<u32, VertexId> {
+        let mut out: BTreeMap<u32, VertexId> = BTreeMap::new();
+        for m in plan {
+            out.entry(m.agent).or_insert(m.from);
+        }
+        out
+    }
+
+    /// Replay a move list from `starts`, asserting each agent departs from
+    /// where it actually is, and return the final placement.
+    fn final_positions(
+        starts: &BTreeMap<u32, VertexId>,
+        moves: &[Move],
+    ) -> BTreeMap<u32, VertexId> {
+        let mut pos = starts.clone();
+        for m in moves {
+            let at = pos
+                .get_mut(&m.agent)
+                .expect("agent seen in the original plan");
+            assert_eq!(
+                *at, m.from,
+                "agent {} departs from the wrong vertex",
+                m.agent
+            );
+            *at = m.to;
+        }
+        pos
+    }
+
+    /// Smoothing must not change where anyone ends up, and must not grow the
+    /// plan. Returns the smoothed plan.
+    fn check(plan: &[Move]) -> Vec<Move> {
+        let s = starts(plan);
+        let before = final_positions(&s, plan);
+        let out = smooth(plan);
+        let after = final_positions(&s, &out);
+        assert_eq!(before, after, "smoothing changed the final placement");
+        assert!(out.len() <= plan.len(), "smoothing grew the plan");
+        out
+    }
+
+    /// The paper's Figure 16: `a3` is pushed into its goal by `clear`, put back
+    /// by the swap reversal, then walks there again when it is planned.
+    #[test]
+    fn collapses_the_figure_16_round_trip() {
+        let plan = vec![
+            mv(3, 0, 1), // a3 makes room, arriving at its goal
+            mv(1, 5, 6), // unrelated traffic
+            mv(3, 1, 0), // a3 put back
+            mv(3, 0, 1), // a3 walks to its goal again
+        ];
+        let out = check(&plan);
+        assert_eq!(
+            out.len(),
+            2,
+            "a3 should move once, not three times: {out:?}"
+        );
+    }
+
+    #[test]
+    fn keeps_a_round_trip_another_agent_interrupted() {
+        // a1 visits vertex 1, a2 arrives at vertex 1 in between and moves on
+        // elsewhere. a1's return to 1 is therefore not redundant.
+        let plan = vec![
+            mv(1, 0, 1),
+            mv(1, 1, 2),
+            mv(2, 9, 1),
+            mv(2, 1, 8),
+            mv(1, 2, 1),
+        ];
+        let out = check(&plan);
+        assert_eq!(out, plan, "nothing here is redundant");
+    }
+
+    /// The virtual-start extension: a round trip back to an agent's *initial*
+    /// vertex is invisible to the printed algorithm, which only sees moves.
+    #[test]
+    fn collapses_a_round_trip_to_the_starting_vertex() {
+        let plan = vec![mv(1, 0, 1), mv(1, 1, 2), mv(1, 2, 1), mv(1, 1, 0)];
+        assert!(
+            check(&plan).is_empty(),
+            "a closed walk from the start with no other traffic should vanish"
+        );
+    }
+
+    #[test]
+    fn cascades_to_newly_redundant_moves() {
+        // Removing a1's inner round trip at vertex 2 exposes the outer one at
+        // vertex 1, which exposes the return to the start.
+        let plan = vec![
+            mv(1, 0, 1),
+            mv(1, 1, 2),
+            mv(1, 2, 3),
+            mv(1, 3, 2),
+            mv(1, 2, 1),
+            mv(1, 1, 0),
+        ];
+        assert!(check(&plan).is_empty());
+    }
+
+    #[test]
+    fn leaves_a_straight_path_alone() {
+        let plan = vec![mv(1, 0, 1), mv(1, 1, 2), mv(1, 2, 3)];
+        assert_eq!(check(&plan), plan);
+    }
+
+    #[test]
+    fn handles_trivial_inputs() {
+        assert!(smooth(&[]).is_empty());
+        let one = vec![mv(0, 0, 1)];
+        assert_eq!(smooth(&one), one);
+    }
+}

--- a/crates/bloqade-lanes-search/src/push_rotate/solver.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/solver.rs
@@ -33,9 +33,17 @@ pub const DEFAULT_MOVE_BUDGET: usize = 500_000;
 
 /// Route `initial` to `target` with Push and Rotate.
 ///
-/// Complete for instances with at least two empty locations: a
+/// Complete for instances with at least two empty locations in every
+/// connected component where an atom must move: within that regime a
 /// [`SolveStatus::Unsolvable`] result is a *proof* that no solution exists,
-/// unlike the search drivers where it means the frontier drained.
+/// unlike the search drivers where it means the frontier drained. Outside
+/// the regime (or when the planner gets stuck) the result is
+/// [`SolveStatus::BudgetExceeded`], which proves nothing.
+///
+/// The proof is **relative to `blocked`**: callers that encode spectator
+/// atoms as blocked locations (see `block_spectators` in the Python
+/// placement strategy) get "no solution that leaves the spectators
+/// untouched" — unblocking a spectator may make the instance solvable.
 ///
 /// # Errors
 ///
@@ -77,24 +85,37 @@ pub fn solve_push_rotate_with(
     let plan = match plan_with(index, &graph, &initial_v, &target_v, budget, heuristics) {
         Ok(p) => p,
         Err(e) => {
+            // Only genuine proofs may surface as `Unsolvable`: the fallback
+            // path in the target solver promotes this status over the
+            // search's own verdict precisely because it is a proof.
             let status = match e {
-                // Proven: the agent-to-subgraph assignment differs between
-                // the initial and goal placements, so some atom would have to
-                // leave the region it is confined to.
+                // Proven: subgraph confinement differs between initial and
+                // goal, or no path to a target exists at all.
                 PlanError::Unsolvable { .. } => SolveStatus::Unsolvable,
-                // Not proven — say so rather than claiming impossibility.
-                PlanError::BudgetExceeded { .. } => SolveStatus::BudgetExceeded,
-                // Outside the completeness regime, or a malformed instance.
-                PlanError::TooFewEmpty { .. } | PlanError::OffGraph { .. } => {
-                    SolveStatus::Unsolvable
-                }
+                // Proven: no sequence of moves creates an atom that does
+                // not exist, so a target for one is unsatisfiable.
+                PlanError::UnknownQubit { .. } => SolveStatus::Unsolvable,
+                // Not proven. `TooFewEmpty` is outside the completeness
+                // regime (the instance may still be solvable), and `Stuck`
+                // means the planner lost its footing — neither is evidence
+                // that no solution exists, so neither may claim it.
+                PlanError::TooFewEmpty { .. }
+                | PlanError::Stuck { .. }
+                | PlanError::BudgetExceeded { .. } => SolveStatus::BudgetExceeded,
             };
             return Ok(SolveResult::unsolved(status, root, 0, 0));
         }
     };
 
     let Some(batches) = schedule(index, &graph, &plan.moves) else {
-        return Ok(SolveResult::unsolvable(root));
+        // A plan exists but could not be packaged into AOD operations —
+        // a condenser artifact, not evidence about the instance.
+        return Ok(SolveResult::unsolved(
+            SolveStatus::BudgetExceeded,
+            root,
+            0,
+            0,
+        ));
     };
 
     let move_layers: Vec<MoveSet> = batches

--- a/crates/bloqade-lanes-search/src/push_rotate/solver.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/solver.rs
@@ -18,7 +18,9 @@ use std::collections::HashSet;
 use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
 
 use crate::feasibility::graph::{LaneGraph, VertexId};
-use crate::primitives::config::{Config, ConfigError, validate_target_assignment};
+use crate::primitives::config::{
+    Config, ConfigError, validate_initial_placement, validate_target_assignment,
+};
 use crate::primitives::graph::MoveSet;
 use crate::primitives::lane_index::LaneIndex;
 use crate::push_rotate::heuristics::{DefaultHeuristics, PlanHeuristics};
@@ -69,7 +71,8 @@ pub fn solve_push_rotate_with(
 ) -> Result<SolveResult, ConfigError> {
     let root = Config::new(initial.iter().copied())?;
     // Malformed requests are rejected before planning; see
-    // `validate_target_assignment`.
+    // `validate_initial_placement` and `validate_target_assignment`.
+    validate_initial_placement(&root)?;
     validate_target_assignment(target)?;
 
     let blocked_set: HashSet<u64> = blocked.iter().map(|l| l.encode()).collect();

--- a/crates/bloqade-lanes-search/src/push_rotate/solver.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/solver.rs
@@ -49,7 +49,10 @@ pub const DEFAULT_MOVE_BUDGET: usize = 500_000;
 ///
 /// # Errors
 ///
-/// Returns [`ConfigError`] if `initial` contains duplicate qubit IDs.
+/// Returns [`ConfigError`] for a malformed request, rejected before any
+/// planning runs: a duplicate qubit ID in `initial`, two qubits placed on
+/// one initial location, two qubits sharing a target location, or one
+/// qubit assigned two targets.
 pub fn solve_push_rotate(
     index: &LaneIndex,
     initial: &[(u32, LocationAddr)],

--- a/crates/bloqade-lanes-search/src/push_rotate/solver.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/solver.rs
@@ -1,0 +1,123 @@
+//! [`SolveResult`]-producing entry point, so Push and Rotate composes with the
+//! rest of the solver surface.
+//!
+//! Adapts the planner's `(LaneGraph, VertexId)` world to the
+//! `(ArchSpec, LocationAddr)` one every other router speaks, and packages the
+//! scheduled AOD operations as [`MoveSet`] layers.
+//!
+//! ## Why this exists as a peer rather than a `Strategy` inside the frontier
+//!
+//! The frontier drivers all share `pop, expand, push` and differ only in node
+//! ordering. Push and Rotate is not a search at all — it has no frontier, no
+//! node expansion and no heuristic to guide it, so `nodes_expanded` is
+//! reported as `0`. What it shares with the others is the *contract*: take a
+//! fixed target, return a `SolveResult`.
+
+use std::collections::HashSet;
+
+use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
+
+use crate::feasibility::graph::{LaneGraph, VertexId};
+use crate::primitives::config::{Config, ConfigError};
+use crate::primitives::graph::MoveSet;
+use crate::primitives::lane_index::LaneIndex;
+use crate::push_rotate::heuristics::{DefaultHeuristics, PlanHeuristics};
+use crate::push_rotate::{PlanError, plan_with, schedule::schedule};
+use crate::search::result::{SolveResult, SolveStatus};
+
+/// Default cap on emitted single-atom moves.
+///
+/// Push and Rotate is rule-based, so this is a runaway guard rather than a
+/// search budget — a solvable instance is not expected to approach it.
+pub const DEFAULT_MOVE_BUDGET: usize = 500_000;
+
+/// Route `initial` to `target` with Push and Rotate.
+///
+/// Complete for instances with at least two empty locations: a
+/// [`SolveStatus::Unsolvable`] result is a *proof* that no solution exists,
+/// unlike the search drivers where it means the frontier drained.
+///
+/// # Errors
+///
+/// Returns [`ConfigError`] if `initial` contains duplicate qubit IDs.
+pub fn solve_push_rotate(
+    index: &LaneIndex,
+    initial: &[(u32, LocationAddr)],
+    target: &[(u32, LocationAddr)],
+    blocked: &[LocationAddr],
+    budget: usize,
+) -> Result<SolveResult, ConfigError> {
+    solve_push_rotate_with(index, initial, target, blocked, budget, &DefaultHeuristics)
+}
+
+/// As [`solve_push_rotate`], with an explicit heuristic strategy.
+pub fn solve_push_rotate_with(
+    index: &LaneIndex,
+    initial: &[(u32, LocationAddr)],
+    target: &[(u32, LocationAddr)],
+    blocked: &[LocationAddr],
+    budget: usize,
+    heuristics: &dyn PlanHeuristics,
+) -> Result<SolveResult, ConfigError> {
+    let root = Config::new(initial.iter().copied())?;
+
+    let blocked_set: HashSet<u64> = blocked.iter().map(|l| l.encode()).collect();
+    let graph = LaneGraph::build(index, &blocked_set);
+
+    // A location off the graph is not a planner failure — it is an instance
+    // that cannot be expressed, so report it as unsolvable rather than
+    // erroring.
+    let Some(initial_v) = to_vertices(&graph, initial) else {
+        return Ok(SolveResult::unsolvable(root));
+    };
+    let Some(target_v) = to_vertices(&graph, target) else {
+        return Ok(SolveResult::unsolvable(root));
+    };
+
+    let plan = match plan_with(index, &graph, &initial_v, &target_v, budget, heuristics) {
+        Ok(p) => p,
+        Err(e) => {
+            let status = match e {
+                // Proven: the agent-to-subgraph assignment differs between
+                // the initial and goal placements, so some atom would have to
+                // leave the region it is confined to.
+                PlanError::Unsolvable { .. } => SolveStatus::Unsolvable,
+                // Not proven — say so rather than claiming impossibility.
+                PlanError::BudgetExceeded { .. } => SolveStatus::BudgetExceeded,
+                // Outside the completeness regime, or a malformed instance.
+                PlanError::TooFewEmpty { .. } | PlanError::OffGraph { .. } => {
+                    SolveStatus::Unsolvable
+                }
+            };
+            return Ok(SolveResult::unsolved(status, root, 0, 0));
+        }
+    };
+
+    let Some(batches) = schedule(index, &graph, &plan.moves) else {
+        return Ok(SolveResult::unsolvable(root));
+    };
+
+    let move_layers: Vec<MoveSet> = batches
+        .iter()
+        .map(|b| MoveSet::new(b.lanes.to_vec()))
+        .collect();
+
+    let goal_config = Config::new(
+        target_v
+            .iter()
+            .map(|&(q, v)| (q, LocationAddr::decode(graph.location_of(v)))),
+    )?;
+
+    // `nodes_expanded` is 0 by construction: this is not a search. Cost is the
+    // operation count, matching `UniformCost` over the emitted layers so the
+    // value is comparable with the frontier drivers'.
+    let cost = move_layers.len() as f64;
+    Ok(SolveResult::solved(goal_config, move_layers, cost, 0, 0))
+}
+
+fn to_vertices(graph: &LaneGraph, pairs: &[(u32, LocationAddr)]) -> Option<Vec<(u32, VertexId)>> {
+    pairs
+        .iter()
+        .map(|&(q, loc)| graph.vertex_of(loc.encode()).map(|v| (q, v)))
+        .collect()
+}

--- a/crates/bloqade-lanes-search/src/push_rotate/solver.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/solver.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
 
 use crate::feasibility::graph::{LaneGraph, VertexId};
-use crate::primitives::config::{Config, ConfigError};
+use crate::primitives::config::{Config, ConfigError, validate_target_assignment};
 use crate::primitives::graph::MoveSet;
 use crate::primitives::lane_index::LaneIndex;
 use crate::push_rotate::heuristics::{DefaultHeuristics, PlanHeuristics};
@@ -68,6 +68,9 @@ pub fn solve_push_rotate_with(
     heuristics: &dyn PlanHeuristics,
 ) -> Result<SolveResult, ConfigError> {
     let root = Config::new(initial.iter().copied())?;
+    // Malformed requests are rejected before planning; see
+    // `validate_target_assignment`.
+    validate_target_assignment(target)?;
 
     let blocked_set: HashSet<u64> = blocked.iter().map(|l| l.encode()).collect();
     let graph = LaneGraph::build(index, &blocked_set);

--- a/crates/bloqade-lanes-search/src/push_rotate/state.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/state.rs
@@ -1,0 +1,242 @@
+//! Mutable planning state: where every agent is, and the moves made so far.
+//!
+//! The paper's algorithms pass `Π` (the move sequence) and `A` (the agent
+//! placement) by reference and mutate both, with several operations
+//! speculatively trying something and rolling back. [`PlanState`] is that
+//! pair, with explicit checkpoint/rollback rather than the paper's
+//! `A' ← A ; Π' ← [ ]` copies.
+//!
+//! Moves record `from` as well as `to`. The paper writes `move(Π, A, agent r
+//! to vertex x)`, but [`reverse`](PlanState::reverse_with_roles) needs to know
+//! where each agent came from, and recovering that by replaying the prefix
+//! would be quadratic.
+
+use crate::feasibility::graph::{LaneGraph, VertexId};
+
+/// One agent stepping between adjacent vertices.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Move {
+    pub agent: u32,
+    pub from: VertexId,
+    pub to: VertexId,
+}
+
+/// A point in the move log to roll back to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Checkpoint(usize);
+
+/// Agent placement plus the move log that produced it.
+pub struct PlanState<'g> {
+    graph: &'g LaneGraph,
+    /// Vertex → the agent on it.
+    occupant: Vec<Option<u32>>,
+    /// Agent → the vertex it is on.
+    position: Vec<VertexId>,
+    moves: Vec<Move>,
+}
+
+impl<'g> PlanState<'g> {
+    /// Build from an initial placement. `initial[i]` is agent `i`'s vertex.
+    pub fn new(graph: &'g LaneGraph, initial: &[VertexId]) -> Self {
+        let mut occupant = vec![None; graph.len()];
+        for (agent, &v) in initial.iter().enumerate() {
+            occupant[v] = Some(agent as u32);
+        }
+        Self {
+            graph,
+            occupant,
+            position: initial.to_vec(),
+            moves: Vec::new(),
+        }
+    }
+
+    pub fn graph(&self) -> &'g LaneGraph {
+        self.graph
+    }
+
+    pub fn agent_count(&self) -> usize {
+        self.position.len()
+    }
+
+    /// The agent on `v`, if any.
+    pub fn agent_at(&self, v: VertexId) -> Option<u32> {
+        self.occupant[v]
+    }
+
+    pub fn position_of(&self, agent: u32) -> VertexId {
+        self.position[agent as usize]
+    }
+
+    pub fn is_occupied(&self, v: VertexId) -> bool {
+        self.occupant[v].is_some()
+    }
+
+    /// Move `agent` onto the adjacent, unoccupied vertex `to`.
+    ///
+    /// # Panics
+    ///
+    /// Debug-asserts adjacency and vacancy. Every caller in this crate is
+    /// responsible for clearing `to` first — a violation is a planner bug, not
+    /// an input error, so it should surface loudly in tests rather than
+    /// silently corrupt the placement.
+    pub fn step(&mut self, agent: u32, to: VertexId) {
+        let from = self.position[agent as usize];
+        debug_assert!(
+            self.graph.neighbors(from).contains(&to),
+            "step {agent}: {from} -> {to} is not an edge"
+        );
+        debug_assert!(
+            self.occupant[to].is_none(),
+            "step {agent}: {to} is occupied by {:?}",
+            self.occupant[to]
+        );
+        self.occupant[from] = None;
+        self.occupant[to] = Some(agent);
+        self.position[agent as usize] = to;
+        self.moves.push(Move { agent, from, to });
+    }
+
+    /// Move `agent` two steps, `via` then `to`. The paper's "move agent r
+    /// through vertex v to vertex x".
+    pub fn step_through(&mut self, agent: u32, via: VertexId, to: VertexId) {
+        self.step(agent, via);
+        self.step(agent, to);
+    }
+
+    /// Current position in the move log.
+    pub fn checkpoint(&self) -> Checkpoint {
+        Checkpoint(self.moves.len())
+    }
+
+    /// Moves recorded since `at`.
+    pub fn moves_since(&self, at: Checkpoint) -> &[Move] {
+        &self.moves[at.0..]
+    }
+
+    /// Undo every move since `at`, restoring the placement exactly.
+    pub fn rollback(&mut self, at: Checkpoint) {
+        while self.moves.len() > at.0 {
+            let m = self.moves.pop().expect("length checked");
+            self.occupant[m.to] = None;
+            self.occupant[m.from] = Some(m.agent);
+            self.position[m.agent as usize] = m.from;
+        }
+    }
+
+    /// Replay the moves in `[from, to)` backwards, with `r` and `s` swapped,
+    /// and append the result to the log.
+    ///
+    /// This is the paper's `reverse(Π, A, Π'_{r/s})` (Algorithm 5 line 10).
+    /// It is *not* a rollback: undoing the moves with the two roles exchanged
+    /// returns every uninvolved agent to where it started while leaving `r`
+    /// and `s` in each other's original positions — which, combined with the
+    /// `exchange` at the swap vertex, is what makes `swap` a swap.
+    ///
+    /// The range is half-open and explicit because `swap` must reverse *only*
+    /// `Π′` — the multipush and clear phases — while leaving the `exchange`
+    /// that follows them intact. Reversing to the end of the log would undo
+    /// the exchange too, and the agents would arrive back at non-adjacent
+    /// vertices.
+    pub fn reverse_range_with_roles(&mut self, from: Checkpoint, to: Checkpoint, r: u32, s: u32) {
+        let to_undo: Vec<Move> = self.moves[from.0..to.0].to_vec();
+        for m in to_undo.into_iter().rev() {
+            let agent = if m.agent == r {
+                s
+            } else if m.agent == s {
+                r
+            } else {
+                m.agent
+            };
+            self.step(agent, m.from);
+        }
+    }
+
+    /// The full move log.
+    pub fn moves(&self) -> &[Move] {
+        &self.moves
+    }
+
+    /// Every unoccupied vertex.
+    pub fn empty_vertices(&self) -> impl Iterator<Item = VertexId> + '_ {
+        self.graph.vertices().filter(|&v| !self.is_occupied(v))
+    }
+
+    /// Number of unoccupied vertices — the paper's `m`.
+    pub fn empty_count(&self) -> usize {
+        self.empty_vertices().count()
+    }
+
+    /// Shortest path from `from` to `to` as a vertex list *excluding* `from`,
+    /// treating any vertex in `blocked` as absent. Returns `None` if
+    /// unreachable; an empty vec if `from == to`.
+    pub fn shortest_path(
+        &self,
+        from: VertexId,
+        to: VertexId,
+        blocked: &[bool],
+    ) -> Option<Vec<VertexId>> {
+        self.shortest_path_scored(from, to, blocked, |_, _| 0.0)
+    }
+
+    /// Shortest path, with `score` breaking ties between equally short routes.
+    ///
+    /// `score(from, to)` rates a candidate step; **higher wins**. It is only
+    /// consulted between predecessors that reach a vertex at the *same* BFS
+    /// depth, so it can choose among equally short paths but can never make a
+    /// path longer. That is what keeps a bad heuristic from being a
+    /// correctness problem.
+    ///
+    /// With a constant score this is byte-for-byte the plain BFS it replaced:
+    /// the first predecessor to claim a vertex keeps it, since a tie does not
+    /// satisfy the strict `>`.
+    pub fn shortest_path_scored(
+        &self,
+        from: VertexId,
+        to: VertexId,
+        blocked: &[bool],
+        score: impl Fn(VertexId, VertexId) -> f64,
+    ) -> Option<Vec<VertexId>> {
+        if from == to {
+            return Some(Vec::new());
+        }
+        let n = self.graph.len();
+        let mut prev = vec![usize::MAX; n];
+        let mut depth = vec![u32::MAX; n];
+        let mut prev_score = vec![f64::NEG_INFINITY; n];
+        let mut queue = std::collections::VecDeque::new();
+        depth[from] = 0;
+        queue.push_back(from);
+
+        while let Some(u) = queue.pop_front() {
+            for &w in self.graph.neighbors(u) {
+                if blocked.get(w).copied().unwrap_or(false) {
+                    continue;
+                }
+                let s = score(u, w);
+                if depth[w] == u32::MAX {
+                    depth[w] = depth[u] + 1;
+                    prev[w] = u;
+                    prev_score[w] = s;
+                    queue.push_back(w);
+                } else if depth[w] == depth[u] + 1 && s > prev_score[w] {
+                    // Same distance, better step: re-parent. Strictly better
+                    // only, so equal scores leave the first claimer in place.
+                    prev[w] = u;
+                    prev_score[w] = s;
+                }
+            }
+        }
+
+        if depth[to] == u32::MAX {
+            return None;
+        }
+        let mut path = vec![to];
+        let mut cur = to;
+        while prev[cur] != from && prev[cur] != usize::MAX {
+            cur = prev[cur];
+            path.push(cur);
+        }
+        path.reverse();
+        Some(path)
+    }
+}

--- a/crates/bloqade-lanes-search/src/search/options.rs
+++ b/crates/bloqade-lanes-search/src/search/options.rs
@@ -38,6 +38,21 @@ pub enum Strategy {
     Cascade { inner: InnerStrategy },
     /// Entropy-guided search: single-path DFS with entropy-based backtracking.
     Entropy,
+    /// Push and Rotate: a complete rule-based router, not a search.
+    ///
+    /// Finds a solution whenever one exists (at two or more empty locations),
+    /// so an `Unsolvable` result from it is a proof rather than an exhausted
+    /// frontier. Produces more AOD operations than the search strategies on
+    /// instances they can solve, and is roughly two orders of magnitude
+    /// faster. Intended mainly as a reliability net — see
+    /// [`SolveOptions::fallback_push_rotate`].
+    ///
+    /// Only honoured on the **fixed-target** path
+    /// ([`TargetSolver::solve`](crate::search::target_solver::TargetSolver::solve)
+    /// and the placements that compose it). The loose-goal path leaves the
+    /// target open for the Hungarian assignment to choose, so there is nothing
+    /// for a fixed-target router to aim at; it substitutes A* there.
+    PushRotate,
 }
 
 /// Core search-tuning parameters shared by every solver entry point.
@@ -68,6 +83,19 @@ pub struct SolveOptions {
     /// [`solve_loose_goal`](crate::placement::loose_goal::solve_loose_goal)
     /// defaults this to `Some(3)` when not set.
     pub top_c: Option<usize>,
+    /// Retry with [`Strategy::PushRotate`] when the chosen strategy returns
+    /// anything other than [`SolveStatus::Solved`](crate::search::result::SolveStatus::Solved).
+    ///
+    /// Off by default, so no existing caller changes behaviour. Push and
+    /// Rotate is complete, so enabling this converts "the search gave up"
+    /// into either a valid schedule or a *proof* that none exists. The
+    /// recovered schedule uses more AOD operations than a search would have,
+    /// but it only ever applies where the search produced nothing at all.
+    ///
+    /// Cheap to leave on: the planner is rule-based and runs in well under a
+    /// millisecond on Gemini-sized instances, and it only runs after a
+    /// failure.
+    pub fallback_push_rotate: bool,
 }
 
 impl Default for SolveOptions {
@@ -79,6 +107,7 @@ impl Default for SolveOptions {
             deadlock_policy: DeadlockPolicy::Skip,
             lookahead: false,
             top_c: None,
+            fallback_push_rotate: false,
         }
     }
 }

--- a/crates/bloqade-lanes-search/src/search/options.rs
+++ b/crates/bloqade-lanes-search/src/search/options.rs
@@ -52,6 +52,10 @@ pub enum Strategy {
     /// and the placements that compose it). The loose-goal path leaves the
     /// target open for the Hungarian assignment to choose, so there is nothing
     /// for a fixed-target router to aim at; it substitutes A* there.
+    ///
+    /// `max_expansions` is ignored under this strategy: it budgets search
+    /// node expansions, and the planner is rule-based with its own runaway
+    /// guard on emitted moves.
     PushRotate,
 }
 

--- a/crates/bloqade-lanes-search/src/search/options.rs
+++ b/crates/bloqade-lanes-search/src/search/options.rs
@@ -86,11 +86,24 @@ pub struct SolveOptions {
     /// Retry with [`Strategy::PushRotate`] when the chosen strategy returns
     /// anything other than [`SolveStatus::Solved`](crate::search::result::SolveStatus::Solved).
     ///
-    /// Off by default, so no existing caller changes behaviour. Push and
-    /// Rotate is complete, so enabling this converts "the search gave up"
-    /// into either a valid schedule or a *proof* that none exists. The
-    /// recovered schedule uses more AOD operations than a search would have,
-    /// but it only ever applies where the search produced nothing at all.
+    /// Off by default, so no existing caller changes behaviour. Enabling it
+    /// usually converts "the search gave up" into a valid schedule or a
+    /// *proof* that none exists
+    /// ([`SolveStatus::Unsolvable`](crate::search::result::SolveStatus::Unsolvable)
+    /// from the planner is a proof, unlike from the search) — with two
+    /// caveats:
+    ///
+    /// * The proof is **relative to `blocked`**. Callers that encode
+    ///   spectator atoms as blocked locations (`block_spectators` in the
+    ///   Python placement strategy) get "no solution that leaves spectators
+    ///   untouched"; unblocking a spectator may make the instance solvable.
+    /// * The planner does not prove every unsolvable instance: outside its
+    ///   completeness regime, or when its proof checks come up short, it
+    ///   reports `BudgetExceeded` and the search's own result stands.
+    ///
+    /// The recovered schedule uses more AOD operations than a search would
+    /// have, but it only ever applies where the search produced nothing at
+    /// all.
     ///
     /// Cheap to leave on: the planner is rule-based and runs in well under a
     /// millisecond on Gemini-sized instances, and it only runs after a

--- a/crates/bloqade-lanes-search/src/search/restarts.rs
+++ b/crates/bloqade-lanes-search/src/search/restarts.rs
@@ -304,6 +304,16 @@ where
             let mut f = PriorityFrontier::greedy(heuristic_fn);
             run_frontier(&root, generator, goal, ctx, &mut f, max_expansions, None)
         }
+        // Push and Rotate needs a concrete target placement, which this path
+        // does not have: `run_with_components` is reached with a `Goal`
+        // predicate, and the loose-goal callers deliberately leave the target
+        // open for the Hungarian assignment to choose. Fall back to A* rather
+        // than panicking, and note it in `Strategy::PushRotate`'s docs so the
+        // substitution is not a surprise.
+        Strategy::PushRotate => {
+            let mut f = PriorityFrontier::astar(heuristic_fn, weight);
+            run_frontier(&root, generator, goal, ctx, &mut f, max_expansions, None)
+        }
         _ => {
             unreachable!("IDS/DFS/Cascade/Entropy handled before run_strategy_v2")
         }

--- a/crates/bloqade-lanes-search/src/search/target_solver.rs
+++ b/crates/bloqade-lanes-search/src/search/target_solver.rs
@@ -16,7 +16,9 @@ use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
 use crate::generators::HeuristicGenerator;
 use crate::generators::heuristic::DeadlockPolicy;
 use crate::goals::AllAtTarget;
-use crate::primitives::config::{Config, ConfigError, validate_target_assignment};
+use crate::primitives::config::{
+    Config, ConfigError, validate_initial_placement, validate_target_assignment,
+};
 use crate::primitives::context::SearchContext;
 use crate::primitives::distance::{DistanceTable, HopDistanceHeuristic};
 use crate::push_rotate::{DEFAULT_MOVE_BUDGET, solve_push_rotate};
@@ -105,6 +107,7 @@ pub(crate) fn solve_with_engine(
     max_expansions: Option<u32>,
 ) -> Result<SolveResult, ConfigError> {
     let root = Config::new(initial)?;
+    validate_initial_placement(&root)?;
     let target_pairs: Vec<(u32, LocationAddr)> = target.into_iter().collect();
     // A non-injective target assignment (two qubits on one location, or one
     // qubit given two locations) is a malformed request. Reject it here —

--- a/crates/bloqade-lanes-search/src/search/target_solver.rs
+++ b/crates/bloqade-lanes-search/src/search/target_solver.rs
@@ -119,6 +119,13 @@ pub(crate) fn solve_with_engine(
 
     // Push and Rotate is not a search, so it bypasses the whole
     // frontier/generator apparatus below rather than being a `Frontier`.
+    //
+    // `max_expansions` is deliberately NOT mapped onto the planner's move
+    // budget: it caps search *node expansions*, a knob for frontier
+    // strategies, while the planner is rule-based and needs no exploration
+    // budget — its `DEFAULT_MOVE_BUDGET` is a runaway guard, not a search
+    // budget. Mapping the (often small) expansion cap onto emitted moves
+    // would strangle exactly the solves this strategy exists to finish.
     if opts.strategy == Strategy::PushRotate {
         return solve_push_rotate(
             engine.index(),

--- a/crates/bloqade-lanes-search/src/search/target_solver.rs
+++ b/crates/bloqade-lanes-search/src/search/target_solver.rs
@@ -16,7 +16,7 @@ use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
 use crate::generators::HeuristicGenerator;
 use crate::generators::heuristic::DeadlockPolicy;
 use crate::goals::AllAtTarget;
-use crate::primitives::config::{Config, ConfigError};
+use crate::primitives::config::{Config, ConfigError, validate_target_assignment};
 use crate::primitives::context::SearchContext;
 use crate::primitives::distance::{DistanceTable, HopDistanceHeuristic};
 use crate::push_rotate::{DEFAULT_MOVE_BUDGET, solve_push_rotate};
@@ -106,6 +106,11 @@ pub(crate) fn solve_with_engine(
 ) -> Result<SolveResult, ConfigError> {
     let root = Config::new(initial)?;
     let target_pairs: Vec<(u32, LocationAddr)> = target.into_iter().collect();
+    // A non-injective target assignment (two qubits on one location, or one
+    // qubit given two locations) is a malformed request. Reject it here —
+    // ahead of every strategy, the Push and Rotate branch, and any
+    // feasibility pass — rather than letting it surface as a verdict.
+    validate_target_assignment(&target_pairs)?;
     let blocked_locs: Vec<LocationAddr> = blocked.into_iter().collect();
     let initial_pairs: Vec<(u32, LocationAddr)> = root.iter().collect();
 

--- a/crates/bloqade-lanes-search/src/search/target_solver.rs
+++ b/crates/bloqade-lanes-search/src/search/target_solver.rs
@@ -19,11 +19,13 @@ use crate::goals::AllAtTarget;
 use crate::primitives::config::{Config, ConfigError};
 use crate::primitives::context::SearchContext;
 use crate::primitives::distance::{DistanceTable, HopDistanceHeuristic};
+use crate::push_rotate::{DEFAULT_MOVE_BUDGET, solve_push_rotate};
 use crate::search::engine::SearchEngine;
 use crate::search::move_search::MoveSearch;
-use crate::search::options::{EntropyOptions, SolveOptions};
+use crate::search::options::{EntropyOptions, SolveOptions, Strategy};
 use crate::search::restarts::run_with_components;
 use crate::search::result::SolveResult;
+use crate::search::result::SolveStatus;
 
 /// Single-target move-synthesis solver.
 ///
@@ -105,6 +107,19 @@ pub(crate) fn solve_with_engine(
     let root = Config::new(initial)?;
     let target_pairs: Vec<(u32, LocationAddr)> = target.into_iter().collect();
     let blocked_locs: Vec<LocationAddr> = blocked.into_iter().collect();
+    let initial_pairs: Vec<(u32, LocationAddr)> = root.iter().collect();
+
+    // Push and Rotate is not a search, so it bypasses the whole
+    // frontier/generator apparatus below rather than being a `Frontier`.
+    if opts.strategy == Strategy::PushRotate {
+        return solve_push_rotate(
+            engine.index(),
+            &initial_pairs,
+            &target_pairs,
+            &blocked_locs,
+            DEFAULT_MOVE_BUDGET,
+        );
+    }
 
     // Build goal predicate.
     let target_encoded: Vec<(u32, u64)> =
@@ -138,8 +153,8 @@ pub(crate) fn solve_with_engine(
         HeuristicGenerator::configured(seed, policy, lookahead, top_c)
     };
 
-    Ok(run_with_components(
-        root,
+    let result = run_with_components(
+        root.clone(),
         &goal_obj,
         make_generator,
         h_max,
@@ -148,7 +163,30 @@ pub(crate) fn solve_with_engine(
         max_expansions,
         opts,
         entropy_opts,
-    ))
+    );
+
+    // Opt-in reliability net. Push and Rotate is complete, so this converts
+    // "the search gave up" into either a schedule or a proof that none
+    // exists. Only the *failure* path pays for it.
+    if opts.fallback_push_rotate && result.status != SolveStatus::Solved {
+        let fallback = solve_push_rotate(
+            engine.index(),
+            &initial_pairs,
+            &target_pairs,
+            &blocked_locs,
+            DEFAULT_MOVE_BUDGET,
+        )?;
+        if fallback.status == SolveStatus::Solved {
+            return Ok(fallback);
+        }
+        // Both failed. Prefer the planner's verdict when it is a *proof* of
+        // unsolvability; the search's `Unsolvable` only means its frontier
+        // drained, which says nothing.
+        if fallback.status == SolveStatus::Unsolvable {
+            return Ok(fallback);
+        }
+    }
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/crates/bloqade-lanes-search/tests/push_rotate.rs
+++ b/crates/bloqade-lanes-search/tests/push_rotate.rs
@@ -37,7 +37,8 @@ use bloqade_lanes_search::push_rotate::heuristics::{
 use bloqade_lanes_search::push_rotate::instances::generate;
 use bloqade_lanes_search::push_rotate::schedule::schedule;
 use bloqade_lanes_search::push_rotate::state::PlanState;
-use bloqade_lanes_search::push_rotate::{PlanError, plan, plan_with};
+use bloqade_lanes_search::push_rotate::{PlanError, plan, plan_with, solve_push_rotate};
+use bloqade_lanes_search::search::result::SolveStatus;
 use rand::rngs::SmallRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
@@ -271,8 +272,10 @@ fn identity_target_produces_no_operations() {
     assert_eq!((ops, moves), (0, 0), "identity should require no moves");
 }
 
-/// Guard the failure path too: a fully packed graph is outside Push and
-/// Rotate's regime and must be reported distinctly, not as unsolvable.
+/// Guard the failure path too: a fully packed graph where an atom must
+/// move is outside Push and Rotate's regime and must be reported
+/// distinctly, not as unsolvable — zero empties does not prove the
+/// instance impossible.
 #[test]
 fn packed_graph_is_reported_as_out_of_regime() {
     let fx = fixture(LOGICAL);
@@ -282,8 +285,312 @@ fn packed_graph_is_reported_as_out_of_regime() {
         .enumerate()
         .map(|(i, v)| (i as u32, v))
         .collect();
-    let err = plan(&fx.index, &fx.graph, &all, &all, 10_000).expect_err("should refuse");
+
+    // Swap the targets of two adjacent atoms so movement is required.
+    let v0 = all[0].1;
+    let &neighbor = fx
+        .graph
+        .neighbors(v0)
+        .first()
+        .expect("vertex 0 has a lane neighbour");
+    let mut target = all.clone();
+    let j = target
+        .iter()
+        .position(|&(_, v)| v == neighbor)
+        .expect("the neighbour is occupied on a packed graph");
+    target[0].1 = neighbor;
+    target[j].1 = v0;
+
+    let err = plan(&fx.index, &fx.graph, &all, &target, 10_000).expect_err("should refuse");
     assert!(matches!(err, PlanError::TooFewEmpty { .. }), "got {err:?}");
+}
+
+/// The regime gate is per component *and* per moving atom: an identity
+/// target on a fully packed graph needs nothing moved, so it must succeed
+/// with an empty plan rather than being refused.
+#[test]
+fn packed_graph_with_identity_target_is_a_trivial_success() {
+    let fx = fixture(LOGICAL);
+    let all: Vec<(u32, VertexId)> = fx
+        .graph
+        .vertices()
+        .enumerate()
+        .map(|(i, v)| (i as u32, v))
+        .collect();
+    let plan = plan(&fx.index, &fx.graph, &all, &all, 10_000).expect("identity is solvable");
+    assert!(plan.moves.is_empty(), "identity should require no moves");
+}
+
+// ── Verdict semantics ──────────────────────────────────────────────
+//
+// `SolveStatus::Unsolvable` from this router is documented as a *proof*, and
+// the fallback path promotes it over the search's verdict on that basis.
+// These tests pin the two directions: proofs stay proofs, and everything
+// that is not a proof must not claim to be one.
+
+/// A target for a qubit absent from `initial` is unsatisfiable — no move
+/// sequence creates an atom that does not exist. It must be reported as
+/// `Unsolvable` (a genuine proof), never as `Solved` with a fabricated
+/// placement.
+#[test]
+fn phantom_target_is_unsolvable_not_a_fabricated_success() {
+    let fx = fixture(LOGICAL);
+    let loc_a = LocationAddr::decode(fx.graph.location_of(0));
+    let loc_b = LocationAddr::decode(fx.graph.location_of(1));
+
+    let result = solve_push_rotate(&fx.index, &[(0, loc_a)], &[(7, loc_b)], &[], 10_000)
+        .expect("valid config");
+    assert_eq!(result.status, SolveStatus::Unsolvable);
+}
+
+/// A nearly-packed register asking for a single legal slide into the hole is
+/// trivially solvable — but with one empty vertex it is outside Push and
+/// Rotate's completeness regime, so the honest verdict is `BudgetExceeded`
+/// ("gave up"), never `Unsolvable` ("proof").
+#[test]
+fn out_of_regime_reports_budget_exceeded_not_unsolvable() {
+    let fx = fixture(LOGICAL);
+    let n = fx.graph.len();
+    // Occupy every vertex except the last; ask the hole's neighbour to
+    // slide in.
+    let hole = n - 1;
+    let initial: Vec<(u32, LocationAddr)> = (0..n - 1)
+        .map(|v| (v as u32, LocationAddr::decode(fx.graph.location_of(v))))
+        .collect();
+    let &mover = fx
+        .graph
+        .neighbors(hole)
+        .first()
+        .expect("the hole has a lane neighbour");
+    let target = [(
+        mover as u32,
+        LocationAddr::decode(fx.graph.location_of(hole)),
+    )];
+
+    let result =
+        solve_push_rotate(&fx.index, &initial, &target, &[], 10_000).expect("valid config");
+    assert_eq!(
+        result.status,
+        SolveStatus::BudgetExceeded,
+        "a solvable out-of-regime instance must not be reported as proven unsolvable"
+    );
+}
+
+/// Spectators encoded as blocked locations — the primary production wiring —
+/// are routed around: the solve succeeds and no emitted lane touches a
+/// blocked location.
+#[test]
+fn blocked_spectators_are_routed_around() {
+    let fx = fixture(LOGICAL);
+    // Block the three highest-numbered vertices, then plan a move between
+    // two vertices that remain connected in the carved graph.
+    let n = fx.graph.len();
+    let blocked_locs: Vec<LocationAddr> = (n - 3..n)
+        .map(|v| LocationAddr::decode(fx.graph.location_of(v)))
+        .collect();
+    let blocked_enc: HashSet<u64> = blocked_locs.iter().map(|l| l.encode()).collect();
+    let carved = LaneGraph::build(&fx.index, &blocked_enc);
+    assert!(!carved.is_empty(), "carving must leave a graph");
+
+    // Pick a start with a neighbour and route to a vertex reachable from it.
+    let start = carved
+        .vertices()
+        .find(|&v| carved.degree(v) > 0)
+        .expect("carved graph has edges");
+    let dist = carved.distances_from(start, |_| false);
+    let dest = carved
+        .vertices()
+        .filter(|&v| dist[v] != u32::MAX && v != start)
+        .max_by_key(|&v| dist[v])
+        .expect("something is reachable");
+
+    let initial = [(0u32, LocationAddr::decode(carved.location_of(start)))];
+    let target = [(0u32, LocationAddr::decode(carved.location_of(dest)))];
+    let result = solve_push_rotate(&fx.index, &initial, &target, &blocked_locs, 10_000)
+        .expect("valid config");
+    assert_eq!(result.status, SolveStatus::Solved);
+
+    for layer in &result.move_layers {
+        for lane in layer.decode() {
+            let (src, dst) = fx.index.endpoints(&lane).expect("lane resolves");
+            assert!(
+                !blocked_enc.contains(&src.encode()) && !blocked_enc.contains(&dst.encode()),
+                "emitted lane touches a blocked location"
+            );
+        }
+    }
+}
+
+/// Verdicts agree with exhaustive search on small carved instances.
+///
+/// The graph is carved down to ≤ 8 vertices with a blocked set (often
+/// disconnecting it), atoms and targets are random, and a configuration-space
+/// BFS is the ground truth. Two directions:
+///
+/// * **Soundness — hard assertions.** `Unsolvable` must imply the oracle
+///   finds no solution, and `Solved` must imply it does. A violation of
+///   either is a bug, full stop.
+/// * **Completeness (solving) — asserted.** In-regime and oracle-solvable
+///   must mean `Solved`; currently clean across all seeds.
+///
+/// One Theorem 1 obligation is deliberately *not* asserted: proving
+/// unsolvability of every in-regime unsolvable instance. The planner's
+/// proof checks are containment-form (weaker than the paper's `f = f'`,
+/// which is unsound under our conservative `assign_agents`), so some
+/// unsolvable instances return an honest `BudgetExceeded` instead of a
+/// proof. One-sidedness is preserved — the fallback then simply keeps the
+/// search's own verdict.
+#[test]
+fn verdicts_match_brute_force_on_carved_instances() {
+    let fx = fixture(LOGICAL);
+    let n_full = fx.graph.len();
+    let keep = 8.min(n_full);
+
+    let mut proofs = 0usize;
+    let mut completeness_misses = 0usize;
+    for seed in 0..120u64 {
+        let mut rng = SmallRng::seed_from_u64(seed);
+
+        // Carve: keep a random set of `keep` vertices, block the rest.
+        let mut verts: Vec<VertexId> = (0..n_full).collect();
+        verts.shuffle(&mut rng);
+        let blocked_locs: Vec<LocationAddr> = verts[keep..]
+            .iter()
+            .map(|&v| LocationAddr::decode(fx.graph.location_of(v)))
+            .collect();
+        let blocked_enc: HashSet<u64> = blocked_locs.iter().map(|l| l.encode()).collect();
+        let carved = LaneGraph::build(&fx.index, &blocked_enc);
+        let n = carved.len();
+        if n < 4 {
+            continue;
+        }
+
+        // Random occupancy (1..=n-2 atoms) and random distinct targets.
+        let mut order: Vec<VertexId> = carved.vertices().collect();
+        order.shuffle(&mut rng);
+        let n_atoms = rng.random_range(1..=n - 2);
+        let initial_v: Vec<(u32, VertexId)> = order[..n_atoms]
+            .iter()
+            .enumerate()
+            .map(|(q, &v)| (q as u32, v))
+            .collect();
+        let mut goal_order: Vec<VertexId> = carved.vertices().collect();
+        goal_order.shuffle(&mut rng);
+        let target_v: Vec<(u32, VertexId)> = goal_order[..n_atoms]
+            .iter()
+            .enumerate()
+            .map(|(q, &v)| (q as u32, v))
+            .collect();
+
+        let to_locs = |pairs: &[(u32, VertexId)]| -> Vec<(u32, LocationAddr)> {
+            pairs
+                .iter()
+                .map(|&(q, v)| (q, LocationAddr::decode(carved.location_of(v))))
+                .collect()
+        };
+        let result = solve_push_rotate(
+            &fx.index,
+            &to_locs(&initial_v),
+            &to_locs(&target_v),
+            &blocked_locs,
+            50_000,
+        )
+        .expect("valid config");
+
+        let solvable = oracle_solvable(&carved, &initial_v, &target_v);
+        match result.status {
+            SolveStatus::Unsolvable => {
+                proofs += 1;
+                assert!(
+                    !solvable,
+                    "seed {seed}: Unsolvable claimed for an oracle-solvable instance \
+                     (n={n}, initial={initial_v:?}, target={target_v:?})"
+                );
+            }
+            SolveStatus::Solved => {}
+            SolveStatus::BudgetExceeded => {
+                // In-regime give-ups are the known completeness gap —
+                // counted and bounded, not asserted away (see the test doc).
+                if in_regime(&carved, &initial_v, &target_v) && solvable {
+                    completeness_misses += 1;
+                }
+            }
+        }
+        if result.status != SolveStatus::Solved {
+            continue;
+        }
+        assert!(
+            solvable,
+            "seed {seed}: Solved returned for an oracle-unsolvable instance"
+        );
+    }
+    assert!(proofs > 0, "no seed exercised the proof path");
+    assert_eq!(
+        completeness_misses, 0,
+        "{completeness_misses} in-regime oracle-solvable instances returned \
+         BudgetExceeded — the planner must solve these (Theorem 1)"
+    );
+}
+
+/// Ground truth: BFS over the configuration space.
+fn oracle_solvable(
+    graph: &LaneGraph,
+    initial: &[(u32, VertexId)],
+    target: &[(u32, VertexId)],
+) -> bool {
+    use std::collections::VecDeque;
+    let mut occupant: Vec<Option<u32>> = vec![None; graph.len()];
+    for &(q, v) in initial {
+        occupant[v] = Some(q);
+    }
+    let goals: HashMap<u32, VertexId> = target.iter().copied().collect();
+    let satisfied = |state: &[Option<u32>]| goals.iter().all(|(&q, &goal)| state[goal] == Some(q));
+
+    if satisfied(&occupant) {
+        return true;
+    }
+    let mut seen: HashSet<Vec<Option<u32>>> = HashSet::new();
+    let mut queue: VecDeque<Vec<Option<u32>>> = VecDeque::new();
+    seen.insert(occupant.clone());
+    queue.push_back(occupant);
+    while let Some(state) = queue.pop_front() {
+        for v in graph.vertices() {
+            let Some(q) = state[v] else { continue };
+            for &w in graph.neighbors(v) {
+                if state[w].is_some() {
+                    continue;
+                }
+                let mut next = state.clone();
+                next[v] = None;
+                next[w] = Some(q);
+                if satisfied(&next) {
+                    return true;
+                }
+                if seen.insert(next.clone()) {
+                    queue.push_back(next);
+                }
+            }
+        }
+    }
+    false
+}
+
+/// In Push and Rotate's completeness regime: every component where an atom
+/// must move has at least two empties.
+fn in_regime(graph: &LaneGraph, initial: &[(u32, VertexId)], target: &[(u32, VertexId)]) -> bool {
+    let (component, n_components) = graph.connected_components();
+    let occupied: HashSet<VertexId> = initial.iter().map(|&(_, v)| v).collect();
+    let mut empties = vec![0usize; n_components];
+    for v in graph.vertices() {
+        if !occupied.contains(&v) {
+            empties[component[v]] += 1;
+        }
+    }
+    let start: HashMap<u32, VertexId> = initial.iter().copied().collect();
+    target.iter().all(|&(q, goal)| match start.get(&q) {
+        Some(&s) if s != goal => empties[component[s]] >= 2,
+        _ => true,
+    })
 }
 
 // ── The heuristic seam ─────────────────────────────────────────────
@@ -550,6 +857,23 @@ mod solver_surface {
             "the fallback should have recovered this"
         );
         assert!(!with.move_layers.is_empty());
+    }
+
+    /// On double failure, the planner's verdict is promoted only when it is
+    /// a genuine proof. A target for a qubit that does not exist is one: no
+    /// move sequence creates an atom, so the budget-starved search's
+    /// non-answer is upgraded to `Unsolvable`.
+    #[test]
+    fn fallback_promotes_a_genuine_proof_on_double_failure() {
+        let initial = [(0, at(0, 0))];
+        let target = [(7, at(0, 4))]; // qubit 7 is not in `initial`
+        let result = solver(SolveOptions {
+            fallback_push_rotate: true,
+            ..Default::default()
+        })
+        .solve(initial, target, [], Some(1))
+        .expect("valid placement");
+        assert_eq!(result.status, SolveStatus::Unsolvable);
     }
 
     /// The fallback must not disturb a search that already succeeded.

--- a/crates/bloqade-lanes-search/tests/push_rotate.rs
+++ b/crates/bloqade-lanes-search/tests/push_rotate.rs
@@ -343,6 +343,20 @@ fn phantom_target_is_unsolvable_not_a_fabricated_success() {
     assert_eq!(result.status, SolveStatus::Unsolvable);
 }
 
+/// A request assigning two qubits to one target location is malformed —
+/// rejected as an error at the entry point, before any planning runs,
+/// rather than surfacing as a verdict about a nonsensical instance.
+#[test]
+fn duplicate_target_location_is_an_invalid_request() {
+    let fx = fixture(LOGICAL);
+    let loc_of = |v: VertexId| LocationAddr::decode(fx.graph.location_of(v));
+    let initial = [(0u32, loc_of(0)), (1u32, loc_of(1))];
+    let target = [(0u32, loc_of(5)), (1u32, loc_of(5))];
+    let err = solve_push_rotate(&fx.index, &initial, &target, &[], 10_000)
+        .expect_err("must reject the request");
+    assert!(err.to_string().contains("invalid request"), "got {err}");
+}
+
 /// A nearly-packed register asking for a single legal slide into the hole is
 /// trivially solvable — but with one empty vertex it is outside Push and
 /// Rotate's completeness regime, so the honest verdict is `BudgetExceeded`
@@ -874,6 +888,22 @@ mod solver_surface {
         .solve(initial, target, [], Some(1))
         .expect("valid placement");
         assert_eq!(result.status, SolveStatus::Unsolvable);
+    }
+
+    /// Malformed requests error out at the solver surface, ahead of every
+    /// strategy and the fallback — never a verdict for nonsense.
+    #[test]
+    fn duplicate_target_location_errors_at_the_solver_surface() {
+        let s = solver(SolveOptions::default());
+        let err = s
+            .solve(
+                [(0, at(0, 0)), (1, at(1, 0))],
+                [(0, at(2, 0)), (1, at(2, 0))],
+                [],
+                None,
+            )
+            .expect_err("must reject the request");
+        assert!(err.to_string().contains("invalid request"), "got {err}");
     }
 
     /// The fallback must not disturb a search that already succeeded.

--- a/crates/bloqade-lanes-search/tests/push_rotate.rs
+++ b/crates/bloqade-lanes-search/tests/push_rotate.rs
@@ -1,0 +1,578 @@
+//! End-to-end validation of the Push and Rotate router.
+//!
+//! Two properties, checked with [`AtomStateData`] — the same simulator the IR
+//! analysis pipeline uses — rather than a reimplementation of it, since a bug
+//! in a hand-rolled replay could mask exactly the bug it exists to catch:
+//!
+//! 1. **The plan rearranges the atoms correctly.** Feed each scheduled AOD
+//!    operation to [`AtomStateData::apply_moves`] and compare the resulting
+//!    `qubit_to_locations` against the requested target.
+//! 2. **Every operation is a valid AOD move.** Each batch's lane group is
+//!    checked with `ArchSpec::check_lanes`, the same authority the open
+//!    solver's generators are held to.
+//!
+//! `AtomStateData` earns its place here by failing in ways a naive replay
+//! would not notice:
+//!
+//! * A move onto an occupied site is recorded in `collision`, and **both**
+//!   qubits are dropped from the location maps. Asserting `collision` is
+//!   empty catches any operation that would crash two atoms together.
+//! * `apply_moves` *silently skips* a lane whose source holds no qubit. A
+//!   scheduler that emitted a lane for an atom that is not there would look
+//!   fine on the final placement in some cases, so the total `move_count` is
+//!   asserted against the number of lanes issued.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
+use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+use bloqade_lanes_bytecode_core::atom_state::AtomStateData;
+use bloqade_lanes_search::feasibility::graph::{LaneGraph, VertexId};
+use bloqade_lanes_search::primitives::lane_index::LaneIndex;
+use bloqade_lanes_search::push_rotate::context::PlanCtx;
+use bloqade_lanes_search::push_rotate::heuristics::{
+    AlignmentHeuristics, DefaultHeuristics, PlanHeuristics,
+};
+use bloqade_lanes_search::push_rotate::instances::generate;
+use bloqade_lanes_search::push_rotate::schedule::schedule;
+use bloqade_lanes_search::push_rotate::state::PlanState;
+use bloqade_lanes_search::push_rotate::{PlanError, plan, plan_with};
+use rand::rngs::SmallRng;
+use rand::seq::SliceRandom;
+use rand::{Rng, SeedableRng};
+
+/// An `(initial, target)` pair of `(qubit, encoded location)` placements.
+type Instance = (Vec<(u32, u64)>, Vec<(u32, u64)>);
+
+const PHYSICAL: &str =
+    include_str!("../../../python/bloqade/lanes/arch/gemini/physical/_physical_spec.json");
+const LOGICAL: &str =
+    include_str!("../../../python/bloqade/lanes/arch/gemini/logical/_logical_spec.json");
+
+struct Fixture {
+    spec: ArchSpec,
+    index: LaneIndex,
+    graph: LaneGraph,
+}
+
+fn fixture(arch_json: &str) -> Fixture {
+    let spec: ArchSpec = serde_json::from_str(arch_json).expect("fixture parses");
+    let index = LaneIndex::new(spec.clone());
+    let graph = LaneGraph::build(&index, &Default::default());
+    Fixture { spec, index, graph }
+}
+
+/// Plan, schedule, then validate both properties through `AtomStateData`.
+///
+/// `initial` and `target` are `(qubit, encoded location)`. Returns
+/// `(operations, moves)`.
+fn check_end_to_end(
+    fx: &Fixture,
+    initial: &[(u32, u64)],
+    target: &[(u32, u64)],
+    label: &str,
+) -> (usize, usize) {
+    let to_v = |pairs: &[(u32, u64)]| -> Vec<(u32, VertexId)> {
+        pairs
+            .iter()
+            .map(|&(q, loc)| {
+                (
+                    q,
+                    fx.graph.vertex_of(loc).expect("location is on the graph"),
+                )
+            })
+            .collect()
+    };
+
+    let p = plan(&fx.index, &fx.graph, &to_v(initial), &to_v(target), 500_000)
+        .unwrap_or_else(|e| panic!("{label}: planning failed: {e}"));
+    let batches = schedule(&fx.index, &fx.graph, &p.moves)
+        .unwrap_or_else(|| panic!("{label}: scheduling failed"));
+
+    // ── Property 2: every operation is a legal AOD move ────────────
+    for (bi, b) in batches.iter().enumerate() {
+        let errors = fx.spec.check_lanes(&b.lanes);
+        assert!(
+            errors.is_empty(),
+            "{label}: operation {bi} is not a valid AOD move: {errors:?}"
+        );
+        // A bus maps disjoint source and destination sets, so simultaneous
+        // execution is only meaningful if no destination is also a source.
+        let srcs: HashSet<VertexId> = b.moves.iter().map(|m| m.from).collect();
+        for m in &b.moves {
+            assert!(
+                !srcs.contains(&m.to),
+                "{label}: operation {bi} moves into {} while another move leaves it",
+                m.to
+            );
+        }
+    }
+
+    // ── Property 1: the atoms end up where they were asked to ──────
+    let start: Vec<(u32, LocationAddr)> = initial
+        .iter()
+        .map(|&(q, loc)| (q, LocationAddr::decode(loc)))
+        .collect();
+    let mut state = AtomStateData::from_locations(&start);
+
+    let mut lanes_issued = 0usize;
+    for (bi, b) in batches.iter().enumerate() {
+        lanes_issued += b.lanes.len();
+        state = state
+            .apply_moves(&b.lanes, &fx.spec)
+            .unwrap_or_else(|| panic!("{label}: operation {bi} has an unresolvable lane"));
+        assert!(
+            state.collision.is_empty(),
+            "{label}: operation {bi} collided atoms: {:?}",
+            state.collision
+        );
+    }
+
+    // Every lane must have actually moved an atom. `apply_moves` skips a lane
+    // whose source is empty, which would otherwise pass unnoticed.
+    let moved: u32 = state.move_count.values().sum();
+    assert_eq!(
+        moved as usize, lanes_issued,
+        "{label}: {lanes_issued} lanes issued but only {moved} atom moves took effect"
+    );
+
+    let want: HashMap<u32, LocationAddr> = target
+        .iter()
+        .map(|&(q, loc)| (q, LocationAddr::decode(loc)))
+        .collect();
+    assert_eq!(
+        state.qubit_to_locations, want,
+        "{label}: final placement does not match the requested target"
+    );
+
+    (batches.len(), p.moves.len())
+}
+
+/// Instance from the reachable-by-construction generator: atoms are displaced
+/// to wherever a random walk of legal single-atom slides leaves them.
+fn walk_instance(fx: &Fixture, arch: &'static str, k: usize, seed: u64) -> Instance {
+    let inst = generate("t".into(), arch, k, 4 * k, seed).expect("instance");
+    for (_, loc) in inst.initial.iter().chain(inst.target.iter()) {
+        assert!(fx.graph.vertex_of(*loc).is_some());
+    }
+    (inst.initial, inst.target)
+}
+
+/// A pure **permutation**: the occupied sites are unchanged, the atoms are
+/// shuffled among them.
+///
+/// This is the harder and more representative case. A displacement can often
+/// be routed by pushing atoms into free space, but a permutation forces the
+/// planner to exchange atoms in place — which is exactly what `swap` and
+/// `rotate` exist for, and what CZ placement asks for when two qubits trade
+/// entangling slots.
+fn permutation_instance(fx: &Fixture, arch: &'static str, k: usize, seed: u64) -> Instance {
+    let inst = generate("t".into(), arch, k, 0, seed).expect("instance");
+    let sites: Vec<u64> = inst.initial.iter().map(|&(_, l)| l).collect();
+    let mut shuffled = sites.clone();
+    let mut rng = SmallRng::seed_from_u64(seed ^ 0xA5A5);
+    // Reshuffle until at least one atom actually has to move, so the test is
+    // not silently trivial.
+    for _ in 0..32 {
+        shuffled.shuffle(&mut rng);
+        if shuffled.iter().zip(&sites).any(|(a, b)| a != b) {
+            break;
+        }
+    }
+    let target: Vec<(u32, u64)> = shuffled
+        .into_iter()
+        .enumerate()
+        .map(|(q, l)| (q as u32, l))
+        .collect();
+    let _ = (fx, &mut rng);
+    (inst.initial, target)
+}
+
+// ── Displacement instances ─────────────────────────────────────────
+
+#[test]
+fn rearranges_correctly_on_physical() {
+    let fx = fixture(PHYSICAL);
+    for k in [1usize, 2, 4, 8, 16] {
+        for seed in 0..5u64 {
+            let (i, t) = walk_instance(&fx, PHYSICAL, k, seed);
+            check_end_to_end(&fx, &i, &t, &format!("physical/walk/k{k}/seed{seed}"));
+        }
+    }
+}
+
+#[test]
+fn rearranges_correctly_on_logical() {
+    let fx = fixture(LOGICAL);
+    for k in [1usize, 2, 4, 8, 16] {
+        for seed in 0..5u64 {
+            let (i, t) = walk_instance(&fx, LOGICAL, k, seed);
+            check_end_to_end(&fx, &i, &t, &format!("logical/walk/k{k}/seed{seed}"));
+        }
+    }
+}
+
+// ── Permutation instances ──────────────────────────────────────────
+
+#[test]
+fn rearranges_permutations_on_physical() {
+    let fx = fixture(PHYSICAL);
+    for k in [2usize, 4, 8, 16] {
+        for seed in 0..5u64 {
+            let (i, t) = permutation_instance(&fx, PHYSICAL, k, seed);
+            check_end_to_end(&fx, &i, &t, &format!("physical/perm/k{k}/seed{seed}"));
+        }
+    }
+}
+
+#[test]
+fn rearranges_permutations_on_logical() {
+    let fx = fixture(LOGICAL);
+    for k in [2usize, 4, 8, 16] {
+        for seed in 0..5u64 {
+            let (i, t) = permutation_instance(&fx, LOGICAL, k, seed);
+            check_end_to_end(&fx, &i, &t, &format!("logical/perm/k{k}/seed{seed}"));
+        }
+    }
+}
+
+/// A two-atom transposition — the smallest thing that cannot be solved by
+/// pushing alone and must go through `swap`.
+#[test]
+fn swaps_two_adjacent_atoms() {
+    let fx = fixture(PHYSICAL);
+    let mut rng = SmallRng::seed_from_u64(7);
+    let mut found = 0;
+    for _ in 0..200 {
+        let v = rng.random_range(0..fx.graph.len());
+        let nbrs = fx.graph.neighbors(v);
+        if nbrs.is_empty() {
+            continue;
+        }
+        let w = nbrs[rng.random_range(0..nbrs.len())];
+        let (a, b) = (fx.graph.location_of(v), fx.graph.location_of(w));
+        check_end_to_end(&fx, &[(0, a), (1, b)], &[(0, b), (1, a)], "transposition");
+        found += 1;
+        if found == 10 {
+            break;
+        }
+    }
+    assert_eq!(found, 10, "expected 10 adjacent pairs to test");
+}
+
+/// A move request that leaves an atom exactly where it is must produce a plan
+/// that touches nothing.
+#[test]
+fn identity_target_produces_no_operations() {
+    let fx = fixture(PHYSICAL);
+    let (initial, _) = walk_instance(&fx, PHYSICAL, 8, 0);
+    let (ops, moves) = check_end_to_end(&fx, &initial, &initial, "identity");
+    assert_eq!((ops, moves), (0, 0), "identity should require no moves");
+}
+
+/// Guard the failure path too: a fully packed graph is outside Push and
+/// Rotate's regime and must be reported distinctly, not as unsolvable.
+#[test]
+fn packed_graph_is_reported_as_out_of_regime() {
+    let fx = fixture(LOGICAL);
+    let all: Vec<(u32, VertexId)> = fx
+        .graph
+        .vertices()
+        .enumerate()
+        .map(|(i, v)| (i as u32, v))
+        .collect();
+    let err = plan(&fx.index, &fx.graph, &all, &all, 10_000).expect_err("should refuse");
+    assert!(matches!(err, PlanError::TooFewEmpty { .. }), "got {err:?}");
+}
+
+// ── The heuristic seam ─────────────────────────────────────────────
+
+/// A heuristic that inverts every default preference: farthest-first for
+/// clear targets and swap vertices, reversed agent order, and a step score
+/// that prefers *staying in the same bus group* as the previous edge.
+///
+/// It exists to prove the seam is real — that overriding these methods
+/// actually changes the plan — and that correctness does not depend on the
+/// choices being sensible. A heuristic can only reorder equally-good options,
+/// so even a deliberately perverse one must still produce a valid plan.
+struct ContraryHeuristics;
+
+impl PlanHeuristics for ContraryHeuristics {
+    fn agent_order(&self, ctx: &PlanCtx, state: &PlanState) -> Vec<u32> {
+        let mut order = DefaultHeuristics.agent_order(ctx, state);
+        order.reverse();
+        order
+    }
+
+    fn rank_clear_target(
+        &self,
+        _ctx: &PlanCtx,
+        _state: &PlanState,
+        _clearing: VertexId,
+        candidate: VertexId,
+        _hops: u32,
+    ) -> i64 {
+        // Prefer the highest vertex id among the equally-near candidates.
+        -(candidate as i64)
+    }
+
+    fn rank_swap_vertex(
+        &self,
+        _ctx: &PlanCtx,
+        _state: &PlanState,
+        _r: u32,
+        _s: u32,
+        candidate: VertexId,
+        hops: u32,
+    ) -> i64 {
+        // Still distance-ordered — a swap vertex must stay reachable — but
+        // inverted within a distance tier.
+        (hops as i64) * 1000 - (candidate as i64)
+    }
+
+    fn score_step(
+        &self,
+        ctx: &PlanCtx,
+        _state: &PlanState,
+        _agent: u32,
+        from: VertexId,
+        to: VertexId,
+    ) -> f64 {
+        // Prefer word-bus steps, the group carrying most of the parallelism
+        // on this architecture.
+        match ctx.edge(from, to) {
+            Some(info) if info.group.0 == 1 => 1.0,
+            _ => 0.0,
+        }
+    }
+}
+
+#[test]
+fn a_custom_heuristic_changes_the_plan_but_not_its_validity() {
+    let fx = fixture(PHYSICAL);
+    let (initial, target) = walk_instance(&fx, PHYSICAL, 8, 3);
+    let to_v = |pairs: &[(u32, u64)]| -> Vec<(u32, VertexId)> {
+        pairs
+            .iter()
+            .map(|&(q, loc)| (q, fx.graph.vertex_of(loc).expect("on graph")))
+            .collect()
+    };
+    let (iv, tv) = (to_v(&initial), to_v(&target));
+
+    let base = plan(&fx.index, &fx.graph, &iv, &tv, 500_000).expect("default plans");
+    let contrary = plan_with(&fx.index, &fx.graph, &iv, &tv, 500_000, &ContraryHeuristics)
+        .expect("contrary heuristics still plan");
+
+    assert_ne!(
+        base.moves, contrary.moves,
+        "overriding every decision point produced an identical plan — the seam is not wired"
+    );
+
+    // Both must still be correct. Validity is not the heuristic's job.
+    for (label, p) in [("default", &base), ("contrary", &contrary)] {
+        let batches = schedule(&fx.index, &fx.graph, &p.moves).expect("schedules");
+        let start: Vec<(u32, LocationAddr)> = initial
+            .iter()
+            .map(|&(q, loc)| (q, LocationAddr::decode(loc)))
+            .collect();
+        let mut state = AtomStateData::from_locations(&start);
+        for b in &batches {
+            assert!(
+                fx.spec.check_lanes(&b.lanes).is_empty(),
+                "{label}: bad batch"
+            );
+            state = state.apply_moves(&b.lanes, &fx.spec).expect("applies");
+            assert!(state.collision.is_empty(), "{label}: collision");
+        }
+        let want: HashMap<u32, LocationAddr> = target
+            .iter()
+            .map(|&(q, loc)| (q, LocationAddr::decode(loc)))
+            .collect();
+        assert_eq!(state.qubit_to_locations, want, "{label}: wrong placement");
+    }
+}
+
+/// The default strategy must be exactly the trait defaults, since every
+/// benchmark number is measured against it.
+#[test]
+fn default_heuristics_match_the_plain_entry_point() {
+    let fx = fixture(PHYSICAL);
+    let (initial, target) = walk_instance(&fx, PHYSICAL, 8, 1);
+    let to_v = |pairs: &[(u32, u64)]| -> Vec<(u32, VertexId)> {
+        pairs
+            .iter()
+            .map(|&(q, loc)| (q, fx.graph.vertex_of(loc).expect("on graph")))
+            .collect()
+    };
+    let (iv, tv) = (to_v(&initial), to_v(&target));
+
+    let a = plan(&fx.index, &fx.graph, &iv, &tv, 500_000).expect("plans");
+    let b = plan_with(&fx.index, &fx.graph, &iv, &tv, 500_000, &DefaultHeuristics).expect("plans");
+    assert_eq!(a.moves, b.moves);
+}
+
+/// The alignment heuristic ships, so it gets the same correctness treatment as
+/// the default: valid AOD operations, no collisions, correct final placement.
+#[test]
+fn alignment_heuristics_produce_valid_plans() {
+    let fx = fixture(PHYSICAL);
+    for k in [2usize, 8, 16] {
+        for seed in 0..3u64 {
+            let (initial, target) = walk_instance(&fx, PHYSICAL, k, seed);
+            let to_v = |pairs: &[(u32, u64)]| -> Vec<(u32, VertexId)> {
+                pairs
+                    .iter()
+                    .map(|&(q, loc)| (q, fx.graph.vertex_of(loc).expect("on graph")))
+                    .collect()
+            };
+            let p = plan_with(
+                &fx.index,
+                &fx.graph,
+                &to_v(&initial),
+                &to_v(&target),
+                500_000,
+                &AlignmentHeuristics::default(),
+            )
+            .unwrap_or_else(|e| panic!("k={k} seed={seed}: {e}"));
+
+            let batches = schedule(&fx.index, &fx.graph, &p.moves).expect("schedules");
+            let start: Vec<(u32, LocationAddr)> = initial
+                .iter()
+                .map(|&(q, loc)| (q, LocationAddr::decode(loc)))
+                .collect();
+            let mut state = AtomStateData::from_locations(&start);
+            for b in &batches {
+                assert!(fx.spec.check_lanes(&b.lanes).is_empty(), "k={k}: bad batch");
+                state = state.apply_moves(&b.lanes, &fx.spec).expect("applies");
+                assert!(state.collision.is_empty(), "k={k}: collision");
+            }
+            let want: HashMap<u32, LocationAddr> = target
+                .iter()
+                .map(|&(q, loc)| (q, LocationAddr::decode(loc)))
+                .collect();
+            assert_eq!(state.qubit_to_locations, want, "k={k} seed={seed}");
+        }
+    }
+}
+
+// ── Solver-level surface ───────────────────────────────────────────
+
+mod solver_surface {
+    use std::sync::Arc;
+
+    use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
+    use bloqade_lanes_search::search::engine::SearchEngine;
+    use bloqade_lanes_search::search::move_search::MoveSearch;
+    use bloqade_lanes_search::search::options::{SolveOptions, Strategy};
+    use bloqade_lanes_search::search::result::SolveStatus;
+    use bloqade_lanes_search::search::target_solver::TargetSolver;
+
+    use super::PHYSICAL;
+
+    fn engine() -> Arc<SearchEngine> {
+        Arc::new(SearchEngine::from_json(PHYSICAL).expect("spec parses"))
+    }
+
+    fn at(word_id: u32, site_id: u32) -> LocationAddr {
+        LocationAddr {
+            zone_id: 0,
+            word_id,
+            site_id,
+        }
+    }
+
+    fn solver(opts: SolveOptions) -> TargetSolver {
+        TargetSolver::new(engine(), MoveSearch::default().with_options(opts))
+    }
+
+    /// `Strategy::PushRotate` must be selectable and return a normal
+    /// `SolveResult`, so it can be benchmarked next to the search strategies.
+    #[test]
+    fn push_rotate_is_selectable_as_a_strategy() {
+        let s = solver(SolveOptions {
+            strategy: Strategy::PushRotate,
+            ..Default::default()
+        });
+        let r = s
+            .solve([(0, at(0, 0))], [(0, at(0, 4))], [], None)
+            .expect("valid placement");
+
+        assert_eq!(r.status, SolveStatus::Solved);
+        assert!(!r.move_layers.is_empty());
+        assert_eq!(
+            r.goal_config.location_of(0),
+            Some(at(0, 4)),
+            "goal config must report the requested target"
+        );
+        // Not a search: there is no frontier to expand.
+        assert_eq!(r.nodes_expanded, 0);
+    }
+
+    /// The fallback is off unless asked for. Every existing caller must be
+    /// unaffected, which is what lets this land without moving the committed
+    /// benchmark baselines.
+    #[test]
+    fn fallback_is_off_by_default() {
+        assert!(!SolveOptions::default().fallback_push_rotate);
+    }
+
+    /// With the fallback on, a search that cannot finish inside its budget
+    /// still yields a schedule.
+    #[test]
+    fn fallback_recovers_a_budget_starved_search() {
+        let initial: Vec<(u32, LocationAddr)> = (0..8u32).map(|w| (w, at(w, 0))).collect();
+        let target: Vec<(u32, LocationAddr)> = (0..8u32).map(|w| (w, at((w + 1) % 8, 0))).collect();
+
+        // One expansion is not enough for any search to finish this.
+        let starved = SolveOptions {
+            strategy: Strategy::AStar,
+            ..Default::default()
+        };
+        let without = solver(starved.clone())
+            .solve(initial.clone(), target.clone(), [], Some(1))
+            .expect("valid placement");
+        assert_ne!(
+            without.status,
+            SolveStatus::Solved,
+            "fixture must actually starve the search"
+        );
+
+        let with = solver(SolveOptions {
+            fallback_push_rotate: true,
+            ..starved
+        })
+        .solve(initial, target, [], Some(1))
+        .expect("valid placement");
+        assert_eq!(
+            with.status,
+            SolveStatus::Solved,
+            "the fallback should have recovered this"
+        );
+        assert!(!with.move_layers.is_empty());
+    }
+
+    /// The fallback must not disturb a search that already succeeded.
+    #[test]
+    fn fallback_leaves_a_successful_search_alone() {
+        let initial = [(0, at(0, 0))];
+        let target = [(0, at(0, 4))];
+        let base = solver(SolveOptions::default())
+            .solve(initial, target, [], None)
+            .expect("valid");
+        let with = solver(SolveOptions {
+            fallback_push_rotate: true,
+            ..Default::default()
+        })
+        .solve(initial, target, [], None)
+        .expect("valid");
+
+        assert_eq!(base.status, SolveStatus::Solved);
+        assert_eq!(with.status, SolveStatus::Solved);
+        assert_eq!(
+            base.move_layers.len(),
+            with.move_layers.len(),
+            "the fallback changed a result it should not have touched"
+        );
+    }
+}

--- a/crates/bloqade-lanes-search/tests/push_rotate.rs
+++ b/crates/bloqade-lanes-search/tests/push_rotate.rs
@@ -38,7 +38,7 @@ use bloqade_lanes_search::push_rotate::instances::generate;
 use bloqade_lanes_search::push_rotate::schedule::schedule;
 use bloqade_lanes_search::push_rotate::state::PlanState;
 use bloqade_lanes_search::push_rotate::{PlanError, plan, plan_with, solve_push_rotate};
-use bloqade_lanes_search::search::result::SolveStatus;
+use bloqade_lanes_search::search::result::{SolveResult, SolveStatus};
 use rand::rngs::SmallRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
@@ -148,6 +148,74 @@ fn check_end_to_end(
     );
 
     (batches.len(), p.moves.len())
+}
+
+/// Replay a `Solved` [`SolveResult`] through `AtomStateData` and assert the
+/// final placement matches the requested target.
+///
+/// Complements [`check_end_to_end`], which drives `plan` + `schedule`
+/// directly on an unblocked graph: this one validates the packaged
+/// `move_layers` from the `solve_push_rotate` surface — the path production
+/// callers consume — including instances with a non-empty blocked set,
+/// which no lane may touch.
+fn assert_solved_result_rearranges(
+    fx: &Fixture,
+    initial: &[(u32, LocationAddr)],
+    target: &[(u32, LocationAddr)],
+    blocked: &HashSet<u64>,
+    result: &SolveResult,
+    label: &str,
+) {
+    assert_eq!(result.status, SolveStatus::Solved, "{label}: not solved");
+
+    let mut state = AtomStateData::from_locations(initial);
+    let mut lanes_issued = 0usize;
+    for (bi, layer) in result.move_layers.iter().enumerate() {
+        let lanes = layer.decode();
+        lanes_issued += lanes.len();
+
+        let errors = fx.spec.check_lanes(&lanes);
+        assert!(
+            errors.is_empty(),
+            "{label}: operation {bi} is not a valid AOD move: {errors:?}"
+        );
+        let srcs: HashSet<u64> = lanes
+            .iter()
+            .map(|l| fx.index.endpoints(l).expect("lane resolves").0.encode())
+            .collect();
+        for lane in &lanes {
+            let (src, dst) = fx.index.endpoints(lane).expect("lane resolves");
+            assert!(
+                !blocked.contains(&src.encode()) && !blocked.contains(&dst.encode()),
+                "{label}: operation {bi} touches a blocked location"
+            );
+            assert!(
+                !srcs.contains(&dst.encode()),
+                "{label}: operation {bi} moves into a location another move leaves"
+            );
+        }
+
+        state = state
+            .apply_moves(&lanes, &fx.spec)
+            .unwrap_or_else(|| panic!("{label}: operation {bi} has an unresolvable lane"));
+        assert!(
+            state.collision.is_empty(),
+            "{label}: operation {bi} collided atoms: {:?}",
+            state.collision
+        );
+    }
+
+    let moved: u32 = state.move_count.values().sum();
+    assert_eq!(
+        moved as usize, lanes_issued,
+        "{label}: {lanes_issued} lanes issued but only {moved} atom moves took effect"
+    );
+
+    let want: HashMap<u32, LocationAddr> = target.iter().copied().collect();
+    assert_eq!(
+        state.qubit_to_locations, want,
+        "{label}: final placement does not match the requested target"
+    );
 }
 
 /// Instance from the reachable-by-construction generator: atoms are displaced
@@ -422,17 +490,7 @@ fn blocked_spectators_are_routed_around() {
     let target = [(0u32, LocationAddr::decode(carved.location_of(dest)))];
     let result = solve_push_rotate(&fx.index, &initial, &target, &blocked_locs, 10_000)
         .expect("valid config");
-    assert_eq!(result.status, SolveStatus::Solved);
-
-    for layer in &result.move_layers {
-        for lane in layer.decode() {
-            let (src, dst) = fx.index.endpoints(&lane).expect("lane resolves");
-            assert!(
-                !blocked_enc.contains(&src.encode()) && !blocked_enc.contains(&dst.encode()),
-                "emitted lane touches a blocked location"
-            );
-        }
-    }
+    assert_solved_result_rearranges(&fx, &initial, &target, &blocked_enc, &result, "spectators");
 }
 
 /// Verdicts agree with exhaustive search on small carved instances.
@@ -521,7 +579,19 @@ fn verdicts_match_brute_force_on_carved_instances() {
                      (n={n}, initial={initial_v:?}, target={target_v:?})"
                 );
             }
-            SolveStatus::Solved => {}
+            SolveStatus::Solved => {
+                // Not just "a solution exists" — the emitted layers must
+                // actually rearrange the atoms, through the same replay
+                // harness as the unblocked end-to-end tests.
+                assert_solved_result_rearranges(
+                    &fx,
+                    &to_locs(&initial_v),
+                    &to_locs(&target_v),
+                    &blocked_enc,
+                    &result,
+                    &format!("seed {seed}"),
+                );
+            }
             SolveStatus::BudgetExceeded => {
                 // In-regime give-ups are the known completeness gap —
                 // counted and bounded, not asserted away (see the test doc).

--- a/docs/superpowers/specs/2026-08-02-push-rotate-router-design.md
+++ b/docs/superpowers/specs/2026-08-02-push-rotate-router-design.md
@@ -1,0 +1,236 @@
+# Push and Rotate: a complete router as a reliability net
+
+**Status:** implemented — branch `feat/push-rotate-router`, stacked on
+`feat/move-feasibility` (which it depends on for the decomposition).
+**Date:** 2026-08-02
+**Author:** Phillip Weinberg (with Claude)
+
+## Summary
+
+`crates/bloqade-lanes-search/src/push_rotate/` implements Push and Rotate
+(de Wilde, ter Mors & Witteveen, *Push and Rotate: a Complete Multi-agent
+Pathfinding Algorithm*, JAIR 51 (2014) 443–492). It is **complete** at two or
+more empty locations: it finds a solution whenever one exists.
+
+It is exposed two ways:
+
+- `Strategy::PushRotate` — selectable, so it can be benchmarked next to the
+  search strategies.
+- `SolveOptions::fallback_push_rotate` — **default off**. When on, a search
+  returning anything other than `Solved` is retried with the planner.
+
+**It is a reliability net, not a primary strategy.** It produces more AOD
+operations than the search strategies on instances they can solve, and is
+roughly two orders of magnitude faster. The measurements and the reason it
+cannot be made competitive on operation count are below.
+
+## Why this exists
+
+The search strategies fail outright on some instances. On
+reachable-by-construction instances — atoms scattered, then displaced by a
+random walk of legal single-atom slides, so a solution provably exists:
+
+| group | astar | ids | entropy | push-rotate |
+|---|---|---|---|---|
+| physical/k8 | **0/5** | 5/5 | 5/5 | **5/5** |
+| physical/k16 | **0/5** | 5/5 | 5/5 | **5/5** |
+| logical/k8 | **3/5** | 5/5 | 5/5 | **5/5** |
+| logical/k16 | **1/5** | **4/5** | **4/5** | **5/5** |
+
+Wall time, per instance on physical/k16:
+
+| | median | max |
+|---|---|---|
+| ids | 1.76 ms | 1.97 ms |
+| entropy | 10.0 ms | 100.0 ms |
+| push-rotate | **0.20 ms** | **0.21 ms** |
+
+Its runtime is essentially flat in atom count (0.16 ms at k=1, 0.20 ms at
+k=16) and its max equals its median — it is rule-based, so there is no search
+variance. That is what makes it viable as a fallback: trying it costs nothing.
+
+Note that **IDS, not entropy, is the incumbent to beat**. It is the only
+search strategy that neither blows up nor degrades, and it is ~9x slower than
+the planner rather than 50x.
+
+## Why it is not a primary strategy
+
+Operation count, on the instances the searches *can* solve:
+
+| physical/k16 | ops | xfer_us |
+|---|---|---|
+| ids | 110 | 65266 |
+| entropy | 103 | 62098 |
+| push-rotate | 163 | 97506 |
+
+This is structural, not a tuning gap. The diagnosis, in the order it was
+established:
+
+1. **The dependency DAG is not the constraint.** Its longest path at k=16 is
+   **32** against 180 moves — a 5.6x reduction is available in the ordering —
+   but the scheduler only reaches 163. The `headroom` example reproduces this.
+2. **Geometry is the constraint, and specifically bus membership.**
+   Instrumenting the ready set: with ~6.8 moves ready simultaneously, the
+   largest subset sharing a bus group averages **1.57**, and the largest
+   same-row subset within a group averages 1.18. Rectangle *shape* was never
+   binding; concurrent moves are simply on different buses.
+3. **The move set, not the move order, is at fault.** The scheduler already
+   reorders freely across agents. What it cannot do is re-*choose*. Push and
+   Rotate routes atoms one at a time, so a plan is the union of *k*
+   independently selected shortest paths, and independently selected paths
+   through a bus-structured graph rarely share a bus.
+
+A tie-break between equally short paths is therefore too weak a lever: the
+paths of different atoms are chosen in separate BFS calls that never see each
+other. `AlignmentHeuristics` implements the best available version of it —
+score a step by how many other unfinished atoms could also progress on that
+bus — and buys 163 → 159 on physical/k16 and 257 → 240 on logical/k16. Real,
+but not the win.
+
+Closing the gap needs parallelism in the **move alphabet**, not in a
+heuristic. That is what the open entropy generator already does by proposing
+whole AOD rectangles as candidates, and it is why a fairly blunt search
+reaches 2.3 atoms per operation. Push and Rotate's `push`, `swap` and `rotate`
+are all defined over single-atom motion and its completeness proof rests on
+that, so changing the alphabet means a different algorithm — approximately the
+one entropy already is.
+
+## Design
+
+### Where it plugs in
+
+`solve_with_engine` in `search/target_solver.rs`, which is where a concrete
+target placement exists. `Strategy::PushRotate` bypasses the frontier
+machinery entirely; the fallback runs after `run_with_components` returns a
+non-`Solved` result.
+
+`Strategy::PushRotate` is honoured only on the **fixed-target** path. The
+loose-goal path deliberately leaves the target open for the Hungarian
+assignment, so there is nothing for a fixed-target router to aim at; it
+substitutes A* there rather than reaching the `unreachable!` in
+`run_strategy_v2`.
+
+### The three-way answer
+
+Because the planner is complete, its `Unsolvable` is a **proof**, unlike a
+search whose frontier merely drained. With the fallback on:
+
+| outcome | meaning |
+|---|---|
+| search succeeds | normal path |
+| search fails, planner succeeds | recovered; worse ops, but a schedule where there was none |
+| both fail | provably impossible on this device |
+
+On the double-failure path the planner's verdict is returned for exactly that
+reason.
+
+### Structure
+
+| module | contents |
+|---|---|
+| `mod.rs` | Algorithms 7–8: feasibility check and the `solve` loop |
+| `ops.rs` | Algorithms 4, 6, 10–13: push, swap, rotate and auxiliaries |
+| `state.rs` | placement + move log, with checkpoint/rollback |
+| `smooth.rs` | Algorithm 9: redundant-move removal |
+| `schedule.rs` | DAG list scheduler into AOD operations (the paper's `condense` is unspecified) |
+| `context.rs` | read-only context, including per-edge bus group and position |
+| `heuristics.rs` | the four §5 decision points, as a swappable trait |
+| `solver.rs` | `SolveResult` adapter |
+| `instances.rs` | reachable-by-construction instance generator for tests and benchmarks |
+
+The Kornhauser decomposition (Algorithms 1–3) is **not** here — it lives in
+`feasibility/`, shared with the infeasibility checker, because it is the same
+computation.
+
+### Heuristic seam
+
+`PlanHeuristics` covers the four places §5 identifies as free choices: agent
+order, shortest-path tie-break, clear target, swap vertex. `BatchPolicy`
+covers the scheduler's one. Methods return a *ranking key* rather than making
+the choice, and callers apply it as a tie-break on top of the existing rule —
+so a heuristic can reorder equally-good options but cannot select an illegal
+one or lengthen a path. A bad heuristic is a quality problem, never a
+correctness one.
+
+`DefaultHeuristics` is the trait defaults and is what every number above was
+measured with.
+
+## Deviations from the paper
+
+Four of these were bugs found by tests rather than by reading, and all four
+only reproduce on instances the physical spec rarely produces.
+
+1. **`swap` and `rotate` reverse only Π′.** In `swap` that is multipush+clear
+   (the exchange is appended separately); in `rotate` it is `clear_vertex`
+   alone. Reversing to the end of the log undoes the operation itself and
+   lands agents on non-adjacent vertices.
+2. **`rotate`'s cycle loop runs `len−1` times**, not `len−2` as a literal
+   reading gives. The final step vacates `v` for the reversal to refill.
+3. **`rotate` verifies the cycle is closed.** `q` in Algorithm 8 accumulates
+   vertices across successive agents, so a repeated vertex does not by itself
+   mean the suffix is a closed walk.
+4. **`smooth` deletes `NV(π)` inclusively.** Line 8's `while π′ ≠ NV(π)` stops
+   one short, leaving an agent moving to a vertex it never left; the prose and
+   Figure 16 both include the return.
+5. **`smooth` adds virtual start arrivals**, so a round trip back to an
+   agent's *initial* vertex is detectable. Algorithm 9 only sees moves, and an
+   initial position is not one.
+
+`smooth` turns out to remove ~1% on Gemini instances (2 moves of 182 at
+k=16). Push and Rotate's round trips are mostly *productive*: the swap
+reversal is what accomplishes the swap.
+
+## Testing
+
+`tests/push_rotate.rs`. Correct rearrangement and AOD validity are checked
+through `AtomStateData::apply_moves` and `ArchSpec::check_lanes` rather than a
+hand-rolled replay — a bug in a reimplemented simulator could mask exactly the
+bug it exists to catch. `AtomStateData` also earns its place by recording
+collisions (both qubits are dropped from the location maps, so asserting
+`collision` is empty catches any operation that would crash two atoms) and by
+*silently skipping* a lane whose source is empty, which is why total
+`move_count` is asserted against lanes issued.
+
+Coverage spans displacement instances, **pure permutations** (occupied sites
+unchanged, atoms shuffled among them — the harder case, forcing in-place
+exchange rather than pushing into free space), two-atom transpositions, both
+shipped specs, and the solver-level surface.
+
+## Two cautions worth carrying forward
+
+**"The incumbent failed" is not evidence the instance is hard.** An early
+finding that A* could not move a single atom one hop looked like a solver bug;
+it was a degenerate fixture — `examples/arch/full.json` gives all three of its
+words identical grid coordinates, so no well-defined AOD rectangle exists
+across them. Filed as
+[#859](https://github.com/QuEraComputing/bloqade-lanes/issues/859). Attribute
+every tier-1 win before claiming it.
+
+**Lane count is not a quality metric.** One operation moves a whole rectangle,
+so packing more atoms per operation *raises* the lane count while lowering
+real cost. Optimising for fewer lanes optimises for serialisation. Use `ops`
+and transport time.
+
+## Open questions
+
+- **Trigger rate on real circuits.** The failure rates above are on synthetic
+  instances. The fallback's value depends on how often the pipeline's actual
+  workload hits them, and IDS is more robust than the astar/entropy figures
+  suggest.
+- **Should the fallback default on?** It is off so this could land without
+  moving the committed baselines. Flipping it changes results for every case
+  the incumbents currently fail, so it wants its own reviewed PR with
+  regenerated baselines.
+- **Seeding rather than replacing.** The planner is fast and complete, so it
+  could hand a rectangle-aware search a valid witness to improve rather than a
+  blank start. Speculative; measure the fallback on real workloads first.
+
+## References
+
+- de Wilde, ter Mors & Witteveen (2014), JAIR 51:443–492.
+  <https://jair.org/index.php/jair/article/view/10913>
+- Reference C++ implementation, useful as a cross-check on the unspecified
+  `condense` pass:
+  <https://github.com/PathPlanning/Push-and-Rotate--CBS--PrioritizedPlanning>
+- `feasibility/` in this crate — the shared decomposition, and why atom
+  rearrangement reduces exactly to pebble motion here.

--- a/docs/superpowers/specs/2026-08-02-push-rotate-router-design.md
+++ b/docs/superpowers/specs/2026-08-02-push-rotate-router-design.md
@@ -112,17 +112,28 @@ substitutes A* there rather than reaching the `unreachable!` in
 
 ### The three-way answer
 
-Because the planner is complete, its `Unsolvable` is a **proof**, unlike a
-search whose frontier merely drained. With the fallback on:
+The planner's `Unsolvable` is a **proof**, unlike a search whose frontier
+merely drained — only genuinely proven verdicts (subgraph confinement, no
+path, a target for a nonexistent qubit) surface as `Unsolvable`; everything
+else the planner cannot do (out of its ≥ 2-empties-per-component regime,
+internal give-ups, scheduling artifacts) is reported as `BudgetExceeded`,
+which proves nothing. With the fallback on:
 
 | outcome | meaning |
 |---|---|
 | search succeeds | normal path |
 | search fails, planner succeeds | recovered; worse ops, but a schedule where there was none |
-| both fail | provably impossible on this device |
+| both fail, planner proves | provably impossible **given the blocked set** |
+| both fail, no proof | gave up — says nothing about solvability |
 
-On the double-failure path the planner's verdict is returned for exactly that
-reason.
+Two footnotes on the proof row. First, it is relative to `blocked`: with
+`block_spectators`, spectator atoms arrive encoded as blocked locations, so
+the honest reading is "no solution that leaves spectators untouched" —
+unblocking a spectator may make the instance solvable. Second, the planner
+does not prove every unsolvable in-regime instance: its proof checks use the
+containment form of the paper's line 5 (the `f = f'` equality is unsound
+under the feasibility module's deliberately conservative agent assignment),
+so some unsolvable instances land in the no-proof row.
 
 ### Structure
 

--- a/docs/superpowers/specs/2026-08-02-push-rotate-router-design.md
+++ b/docs/superpowers/specs/2026-08-02-push-rotate-router-design.md
@@ -85,7 +85,10 @@ paths of different atoms are chosen in separate BFS calls that never see each
 other. `AlignmentHeuristics` implements the best available version of it —
 score a step by how many other unfinished atoms could also progress on that
 bus — and buys 163 → 159 on physical/k16 and 257 → 240 on logical/k16. Real,
-but not the win.
+but not the win. (A separate flat preference for word buses was also tried;
+ablation showed it contributed nothing on top of the support term — identical
+operation counts with and without — so the support term is the whole
+heuristic.)
 
 Closing the gap needs parallelism in the **move alphabet**, not in a
 heuristic. That is what the open entropy generator already does by proposing

--- a/python/bloqade/lanes/bytecode/_native.pyi
+++ b/python/bloqade/lanes/bytecode/_native.pyi
@@ -938,6 +938,7 @@ class SearchStrategy:
     CASCADE_DFS: SearchStrategy
     CASCADE_ENTROPY: SearchStrategy
     ENTROPY: SearchStrategy
+    PUSH_ROTATE: SearchStrategy
 
     @property
     def name(self) -> str: ...

--- a/python/bloqade/lanes/heuristics/physical/_solver_dispatch.py
+++ b/python/bloqade/lanes/heuristics/physical/_solver_dispatch.py
@@ -27,4 +27,9 @@ _STRATEGY_MAP: dict[str, _native.SearchStrategy] = {
     "cascade-dfs": _native.SearchStrategy.CASCADE_DFS,
     "cascade-entropy": _native.SearchStrategy.CASCADE_ENTROPY,
     "entropy": _native.SearchStrategy.ENTROPY,
+    # Push and Rotate: complete, rule-based, not a search. Slower schedules
+    # than the search strategies where they succeed, but it succeeds where
+    # they do not. See `SolveOptions.fallback_push_rotate` to use it as a
+    # reliability net rather than a primary.
+    "push-rotate": _native.SearchStrategy.PUSH_ROTATE,
 }

--- a/python/bloqade/lanes/heuristics/physical/movement.py
+++ b/python/bloqade/lanes/heuristics/physical/movement.py
@@ -326,10 +326,12 @@ class PhysicalPlacementStrategy(MoveToPlacementStrategyABC):
             )
             self._rust_nodes_expanded_total += int(result.nodes_expanded)
             if remaining is not None:
-                # Invariant: the Rust solver expands ≥ 1 node per call (even
-                # when unsolvable), so the shared budget makes forward progress
-                # across candidates and this loop terminates.
-                remaining -= int(result.nodes_expanded)
+                # The search strategies expand ≥ 1 node per call (even when
+                # unsolvable), but PUSH_ROTATE is not a search and always
+                # reports 0 — charge at least 1 so the shared budget makes
+                # forward progress across candidates and this loop
+                # terminates under every strategy.
+                remaining -= max(1, int(result.nodes_expanded))
             if result.status == "solved":
                 winning_result = result
                 if should_trace and self.traversal.collect_entropy_trace:

--- a/python/bloqade/lanes/heuristics/physical/movement.py
+++ b/python/bloqade/lanes/heuristics/physical/movement.py
@@ -42,6 +42,7 @@ SearchStrategyName = Literal[
     "cascade-dfs",
     "cascade-entropy",
     "entropy",
+    "push-rotate",
 ]
 
 

--- a/python/bloqade/lanes/heuristics/physical/movement.py
+++ b/python/bloqade/lanes/heuristics/physical/movement.py
@@ -241,7 +241,9 @@ class PhysicalPlacementStrategy(MoveToPlacementStrategyABC):
 
     @property
     def rust_entropy_fallback_count(self) -> int:
-        """Number of solved Rust entropy stages that used sequential fallback."""
+        """Number of solved Rust entropy stages that used the budget-exhaustion
+        fallback (Push and Rotate, with the greedy sequential router as the
+        out-of-regime tertiary)."""
         return self._rust_entropy_fallback_count
 
     @property


### PR DESCRIPTION
## Summary

Adds a **Push and Rotate** router (de Wilde, ter Mors & Witteveen, JAIR 51, 2014) to `bloqade-lanes-search`: a rule-based, complete multi-agent pathfinding planner that composes with the existing solver surface, plus wiring that puts it to work in three places:

- **A standalone strategy** (`Strategy::PushRotate` / `solve_push_rotate`) — fixed-target routing, ~two orders of magnitude faster than the search strategies, at the cost of more AOD operations.
- **An opt-in reliability net** (`SolveOptions::fallback_push_rotate`, off by default): when a search strategy fails, the planner converts "gave up" into either a valid schedule or — within its regime — a *proof* that none exists.
- **The entropy driver's budget-exhaustion fallback**: the old greedy sequential router (which could not displace atoms out of each other's way) now runs Push and Rotate first, keeping the greedy router only for its one residual case (a direct slide into a single hole at `m = 1`, outside the planner's regime).

The planner builds on the Kornhauser decomposition shared with the feasibility oracle (#867), so the two can never disagree about an instance's structure.

## Verdict semantics

`SolveStatus::Unsolvable` from this router is a **proof**, and the fallback path promotes it over the search's verdict on that basis — so only genuine proofs may produce it:

| verdict | meaning |
|---|---|
| `Unsolvable` | proven: subgraph confinement (both time directions), no path, or a target for a nonexistent qubit |
| `BudgetExceeded` | not proven: out of the ≥ 2-empties-per-component regime, planner stuck, or scheduling artifact |

Two documented caveats: proofs are **relative to the blocked set** (spectators-as-blocked reads as "unsolvable without touching spectators"), and the planner does not prove *every* unsolvable in-regime instance — the paper's `f = f'` test is unsound under the deliberately conservative shared `assign_agents`, so the containment form is used; closing that gap needs a planner-specific paper-faithful assignment (follow-up).

## Invalid requests rejected at the boundary

Non-injective requests (two qubits sharing a target location, one qubit with two targets, two qubits on one initial location) are rejected as `ConfigError` at the solve entry points, before any feasibility, search, or planning pass — they are caller errors, never verdicts. The feasibility module's obstructions remain as defence in depth.

## Testing

- **End-to-end replay**: plans validated through `AtomStateData` (the same simulator the IR pipeline uses) — per-operation `check_lanes`, collision-freedom, lanes-issued == atom-moves, exact final placement — over walk instances, permutations, and both shipped Gemini specs, plus blocked-spectator instances and the packaged `move_layers` from the solver surface.
- **Brute-force property test**: 120 carved instances (≤ 8 vertices, blocked sets that often disconnect the graph) against a configuration-space BFS oracle: `Unsolvable` ⇒ oracle-unsolvable, `Solved` ⇒ replays to the goal, in-regime ∧ solvable ⇒ `Solved` (currently zero misses). This test caught and now pins three real bugs (unsound `f = f'`, over-restricted swap candidates, stale-`q` rotate aborts).
- Verdict-mapping, fallback-promotion, phantom-target, out-of-regime, and invalid-request tests at the solver surface.
- **Benchmarks**: both suites regenerated and compared — no deterministic differences; committed baselines unchanged (the router is opt-in and no benchmark case's outcome depended on the old fallback).

## Notes for review

- The design note (`docs/superpowers/specs/2026-08-02-push-rotate-router-design.md`) documents the five deviations from the paper with rationale, the heuristic seam ("rank, don't choose" — a bad heuristic is a quality problem, never a correctness one), and measured negative results.
- Deferred polish from pre-PR review: `GroupKey` dedup, `AlignmentHeuristics` cache-staleness guard, scheduler worklist.
- Non-breaking: new module + opt-in wiring; default solver behaviour unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)