### PR TITLE
fix(search): align search layers on the uniform destination rule

### DIFF
--- a/crates/bloqade-lanes-search/src/feasibility/mod.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/mod.rs
@@ -403,10 +403,10 @@ mod tests {
         let bus = &mut spec.zones[0].site_buses[0];
         bus.src = (0..5).map(SiteRef).collect();
         bus.dst = (1..6).map(SiteRef).collect();
+        let validation = spec.validate();
         assert!(
-            spec.validate().is_ok(),
-            "conveyor-chain fixture must be a legal spec: {:?}",
-            spec.validate()
+            validation.is_ok(),
+            "conveyor-chain fixture must be a legal spec: {validation:?}"
         );
         serde_json::to_string(&spec).expect("spec serializes")
     }
@@ -619,10 +619,10 @@ mod tests {
             ),
         ] {
             let spec: ArchSpec = serde_json::from_str(json).expect("arch json parses");
+            let validation = spec.validate();
             assert!(
-                spec.validate().is_ok(),
-                "{name} spec must satisfy the reduction precondition: {:?}",
-                spec.validate()
+                validation.is_ok(),
+                "{name} spec must satisfy the reduction precondition: {validation:?}"
             );
         }
     }

--- a/crates/bloqade-lanes-search/src/feasibility/mod.rs
+++ b/crates/bloqade-lanes-search/src/feasibility/mod.rs
@@ -17,29 +17,26 @@
 //!    legal AOD operation — `ArchSpec::check_lanes` only applies the
 //!    complete-rectangle geometry constraint to groups of more than one lane.
 //!    So single-pebble moves are available.
-//! 2. Every bus is a matching between *disjoint* source and destination sets,
-//!    so a multi-lane move is a set of vertex-disjoint edges whose
-//!    destinations must all already be empty. Such a move serializes into
-//!    independent single-pebble moves in any order, and no move can rotate a
-//!    cycle of atoms with no empty vertex.
+//! 2. Every bus's src→dst relation is acyclic and endpoint-unique — a bus is
+//!    by definition a set of explicit transports along graph edges, never a
+//!    permutation. A multi-lane move is therefore either a set of
+//!    vertex-disjoint edges (when the src and dst sets are disjoint) or a
+//!    conveyor chain `x→y, y→z` whose final destination is empty. Both
+//!    serialize into independent single-pebble moves — the chain in reverse
+//!    topological order, each site vacated before the atom behind it arrives
+//!    — so no move can rotate a cycle of atoms with no empty vertex.
 //!
 //! Together these mean the set of reachable configurations under AOD moves is
 //! identical to the set reachable under one-atom-at-a-time pebble motion —
 //! AOD parallelism changes the schedule, not what is reachable. Point 2 is a
-//! property of the shipped architecture specs rather than of the format, so
-//! [`validate_bus_disjointness`] checks it explicitly; if it ever fails, the
-//! reduction in this module is invalid. In debug builds, [`check`] and
-//! [`build_decomposition`] assert it on entry (together with
-//! `ArchSpec::validate`); release builds skip the check and trust the caller
-//! to pass a validated spec.
+//! validated format invariant as of issue #874: `ArchSpec::validate` rejects a
+//! cyclic bus (`ArchSpecError::CyclicBus`) along with duplicate endpoints, so
+//! the property holds for any spec this module can legally be handed. In debug
+//! builds [`check`] and [`build_decomposition`] re-assert it on entry; release
+//! builds skip the walk and trust the caller to pass a validated spec.
 //!
-//! Strictly, the reduction needs less than disjointness: a bus is by
-//! definition a set of explicit transports along graph edges, never a
-//! permutation, so the load-bearing property is that no bus's src→dst
-//! relation contains a cycle (a chain `x→y, y→z` serializes in reverse
-//! topological order and is pebble-equivalent; only a rotation is not).
-//! Overlapping-but-acyclic buses, and relaxing this module's guard
-//! accordingly, are tracked in issue #866.
+//! Note that overlapping-but-acyclic buses are *legal* here (issue #866): the
+//! reduction never needed endpoint disjointness, only the absence of cycles.
 //!
 //! ## What this does and does not prove
 //!
@@ -66,8 +63,6 @@ pub mod decomposition;
 pub mod graph;
 
 use std::collections::{HashMap, HashSet};
-
-use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
 
 use crate::feasibility::decomposition::{
     Decomposition, find_precedence_cycle, subgraph_priorities,
@@ -178,65 +173,23 @@ impl Feasibility {
     }
 }
 
-/// Verify that every bus maps a source set disjoint from its destination set.
+/// Debug-build guard for the assumption the pebble-motion reduction rests on:
+/// a structurally valid architecture, which since issue #874 includes per-bus
+/// src→dst acyclicity and endpoint uniqueness (see the module docs).
 ///
-/// The whole pebble-motion reduction rests on this: it is what rules out an
-/// AOD move rotating a cycle of atoms with no empty vertex. Returns one
-/// message per violating bus; an empty vector means the property holds.
-pub fn validate_bus_disjointness(arch: &ArchSpec) -> Vec<String> {
-    let mut errors = Vec::new();
-
-    for (zone_id, zone) in arch.zones.iter().enumerate() {
-        for (bus_id, bus) in zone.site_buses.iter().enumerate() {
-            let src: HashSet<u16> = bus.src.iter().map(|s| s.0).collect();
-            if bus.dst.iter().any(|d| src.contains(&d.0)) {
-                errors.push(format!(
-                    "zone {zone_id} site_bus {bus_id}: src and dst sets overlap"
-                ));
-            }
-        }
-        for (bus_id, bus) in zone.word_buses.iter().enumerate() {
-            let src: HashSet<u16> = bus.src.iter().map(|s| s.0).collect();
-            if bus.dst.iter().any(|d| src.contains(&d.0)) {
-                errors.push(format!(
-                    "zone {zone_id} word_bus {bus_id}: src and dst sets overlap"
-                ));
-            }
-        }
-    }
-    for (bus_id, bus) in arch.zone_buses.iter().enumerate() {
-        let src: HashSet<(u8, u16)> = bus.src.iter().map(|s| (s.zone_id, s.word_id)).collect();
-        if bus
-            .dst
-            .iter()
-            .any(|d| src.contains(&(d.zone_id, d.word_id)))
-        {
-            errors.push(format!("zone_bus {bus_id}: src and dst sets overlap"));
-        }
-    }
-
-    errors
-}
-
-/// Debug-build guard for the assumptions the pebble-motion reduction rests
-/// on: a structurally valid architecture whose buses keep their source and
-/// destination sets disjoint (see the module docs).
+/// Overlapping-but-acyclic (conveyor) buses are legal here — they serialize in
+/// reverse topological order and are pebble-equivalent. Only a rotation would
+/// invalidate the reduction, and `ArchSpec::validate` rejects those outright,
+/// so checking structural validity is now exactly the right precondition.
 ///
 /// Release builds skip this entirely — callers are expected to pass a
-/// validated spec (e.g. loaded via `ArchSpec::from_json_validated`). The
-/// disjointness requirement relaxes to per-bus acyclicity once that becomes
-/// a validated format invariant (issue #866).
+/// validated spec (e.g. loaded via `ArchSpec::from_json_validated`).
 fn debug_assert_valid_arch(_index: &LaneIndex) {
     #[cfg(debug_assertions)]
-    {
-        if let Err(errors) = _index.arch_spec().validate() {
-            panic!("feasibility requires a structurally valid ArchSpec: {errors:?}");
-        }
-        let overlaps = validate_bus_disjointness(_index.arch_spec());
-        assert!(
-            overlaps.is_empty(),
-            "feasibility reduction requires src/dst-disjoint buses \
-             (relaxation to acyclicity tracked in issue #866): {overlaps:?}"
+    if let Err(errors) = _index.arch_spec().validate() {
+        panic!(
+            "feasibility requires a structurally valid ArchSpec \
+             (per-bus acyclicity is load-bearing for the reduction): {errors:?}"
         );
     }
 }
@@ -432,7 +385,31 @@ fn decomposition_obstruction(
 mod tests {
     use super::*;
     use crate::test_utils::{example_arch_json, loc};
+    use bloqade_lanes_bytecode_core::arch::addr::{LocationAddr as TestLocationAddr, SiteRef};
     use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+
+    /// Decode an encoded graph vertex location into a `LocationAddr`.
+    fn decode_loc(enc: u64) -> TestLocationAddr {
+        TestLocationAddr::decode(enc)
+    }
+
+    /// The example arch with site bus 0 turned into a conveyor chain
+    /// (0→1, 1→2, 2→3, 3→4, 4→5): the destination set overlaps the source
+    /// set on {1,2,3,4}, but the relation is acyclic and endpoint-unique, so
+    /// it is a legal bus (#874) and a legal input to the reduction (#866).
+    fn overlapping_chain_arch_json() -> String {
+        let mut spec: ArchSpec =
+            serde_json::from_str(example_arch_json()).expect("arch json parses");
+        let bus = &mut spec.zones[0].site_buses[0];
+        bus.src = (0..5).map(SiteRef).collect();
+        bus.dst = (1..6).map(SiteRef).collect();
+        assert!(
+            spec.validate().is_ok(),
+            "conveyor-chain fixture must be a legal spec: {:?}",
+            spec.validate()
+        );
+        serde_json::to_string(&spec).expect("spec serializes")
+    }
 
     /// Brute force over the configuration space: is there a reachable state
     /// where every targeted agent sits on its goal simultaneously? Ground
@@ -622,8 +599,11 @@ mod tests {
     }
 
     #[test]
-    fn shipped_gemini_specs_have_disjoint_bus_endpoints() {
-        // The pebble-motion reduction is only valid while this holds.
+    fn shipped_gemini_specs_satisfy_the_reduction_precondition() {
+        // The reduction needs per-bus src→dst acyclicity, which
+        // `ArchSpec::validate` enforces as of #874. (These specs happen to
+        // keep their endpoints disjoint too, but that is incidental — the
+        // reduction never required it.)
         for (name, json) in [
             (
                 "physical",
@@ -639,29 +619,40 @@ mod tests {
             ),
         ] {
             let spec: ArchSpec = serde_json::from_str(json).expect("arch json parses");
-            assert_eq!(
-                validate_bus_disjointness(&spec),
-                Vec::<String>::new(),
-                "{name} spec must have src/dst-disjoint buses"
+            assert!(
+                spec.validate().is_ok(),
+                "{name} spec must satisfy the reduction precondition: {:?}",
+                spec.validate()
             );
         }
     }
 
-    /// The debug-build guard must refuse a spec whose bus endpoints overlap:
-    /// the reduction is not justified there, so silently returning verdicts
-    /// would be unsound. Relaxing this to per-bus acyclicity is issue #866.
+    /// A spec whose bus overlaps its endpoints *acyclically* (a conveyor
+    /// chain) is legal: the chain serializes in reverse topological order, so
+    /// the pebble-motion reduction still holds and the guard must accept it.
+    /// This is the #866 relaxation — the old guard rejected this spec.
+    #[test]
+    fn overlapping_acyclic_bus_is_accepted() {
+        let index = index_from(&overlapping_chain_arch_json());
+        let initial = Config::new([(0, loc(0, 0))]).expect("config");
+        // Reaching a verdict at all is the assertion: the debug guard runs on
+        // entry to `check` and must not panic on a chain bus.
+        let _verdict = check(&index, &initial, &[], &HashSet::new());
+    }
+
+    /// The debug-build guard must still refuse a spec whose bus *rotates*: a
+    /// cycle has no empty vertex to serialize through, so pebble motion can
+    /// never reproduce it and `Infeasible` verdicts would stop being proofs.
     #[test]
     #[cfg(debug_assertions)]
-    #[should_panic(expected = "src/dst-disjoint")]
-    fn debug_guard_rejects_overlapping_bus() {
+    #[should_panic(expected = "structurally valid ArchSpec")]
+    fn debug_guard_rejects_cyclic_bus() {
         let mut spec: ArchSpec =
             serde_json::from_str(example_arch_json()).expect("arch json parses");
-        // Point the first destination at the second source, forming the
-        // acyclic chain 0→1→6. Structural validation still passes (the
-        // relation stays cycle-free and endpoint-unique, per issue #874);
-        // disjointness does not.
+        // Turn site bus 0 into a rotation: 0→1, 1→0.
         let bus = &mut spec.zones[0].site_buses[0];
-        bus.dst[0] = bus.src[1];
+        bus.src = vec![SiteRef(0), SiteRef(1)];
+        bus.dst = vec![SiteRef(1), SiteRef(0)];
         let index = LaneIndex::new(spec);
         let initial = Config::new([(0, loc(0, 0))]).expect("config");
         let _ = check(&index, &initial, &[], &HashSet::new());
@@ -922,6 +913,65 @@ mod tests {
         let index = gemini_physical();
         for seed in 0..5 {
             assert_no_false_positive(&index, 24, 300, seed);
+        }
+    }
+
+    /// Soundness on an overlapping-bus spec: with endpoint disjointness
+    /// relaxed to acyclicity (#866), the reduction must still never call a
+    /// reachable-by-construction instance infeasible on a conveyor-chain bus.
+    #[test]
+    fn never_reports_reachable_instances_infeasible_on_overlapping_bus_spec() {
+        let index = index_from(&overlapping_chain_arch_json());
+        for seed in 0..25 {
+            assert_no_false_positive(&index, 3, 40, seed);
+        }
+    }
+
+    /// Brute-force cross-check on the chain spec: the decomposition verdict
+    /// must agree with exhaustive search over the reachable configuration
+    /// space, exactly as it does for disjoint-bus specs.
+    #[test]
+    fn decomposition_verdicts_match_brute_force_on_overlapping_bus_spec() {
+        let index = index_from(&overlapping_chain_arch_json());
+        let graph = LaneGraph::build(&index, &HashSet::new());
+        let movable: Vec<VertexId> = (0..graph.len()).filter(|&v| graph.degree(v) > 0).collect();
+        assert!(movable.len() >= 4, "fixture needs a connected region");
+
+        // Two atoms, every ordered (start, goal) combination inside the region
+        // the chain bus wires up: `Infeasible` must imply genuinely unsolvable.
+        for &a0 in movable.iter().take(4) {
+            for &a1 in movable.iter().take(4) {
+                if a0 == a1 {
+                    continue;
+                }
+                for &t0 in movable.iter().take(4) {
+                    for &t1 in movable.iter().take(4) {
+                        if t0 == t1 {
+                            continue;
+                        }
+                        let initial = Config::new([
+                            (0, decode_loc(graph.location_of(a0))),
+                            (1, decode_loc(graph.location_of(a1))),
+                        ])
+                        .expect("distinct vertices give a valid config");
+                        let targets =
+                            [(0u32, graph.location_of(t0)), (1u32, graph.location_of(t1))];
+                        if !check(&index, &initial, &targets, &HashSet::new()).is_infeasible() {
+                            continue;
+                        }
+                        let mut occupant: Vec<Option<u32>> = vec![None; graph.len()];
+                        occupant[a0] = Some(0);
+                        occupant[a1] = Some(1);
+                        let goals: HashMap<u32, VertexId> =
+                            [(0u32, t0), (1u32, t1)].into_iter().collect();
+                        assert!(
+                            !instance_solvable(&graph, &occupant, &goals),
+                            "reported Infeasible for a solvable instance: \
+                             atoms {a0},{a1} → targets {t0},{t1}"
+                        );
+                    }
+                }
+            }
         }
     }
 

--- a/crates/bloqade-lanes-search/src/generators/exhaustive.rs
+++ b/crates/bloqade-lanes-search/src/generators/exhaustive.rs
@@ -92,7 +92,6 @@ struct ExpandContext<'a> {
 /// Per-triplet data built during rectangle enumeration.
 struct TripletData {
     pos_to_info: HashMap<(u64, u64), (LocationAddr, LaneAddr)>,
-    invalid_locs: HashSet<u64>,
 }
 
 /// Enumerate all valid AOD rectangles for a set of lanes and push results.
@@ -106,27 +105,19 @@ fn rectangles_to_move_sets(
     let mut pos_to_info: HashMap<(u64, u64), (LocationAddr, LaneAddr)> = HashMap::new();
     let mut unique_x: BTreeSet<u64> = BTreeSet::new();
     let mut unique_y: BTreeSet<u64> = BTreeSet::new();
-    let mut invalid_locs: HashSet<u64> = HashSet::new();
 
     for &lane in lanes {
-        let (src, dst) = match ctx.index.endpoints(&lane) {
-            Some(ep) => ep,
-            None => continue,
+        let Some((src, _dst)) = ctx.index.endpoints(&lane) else {
+            continue;
         };
-        let (x, y) = match ctx.index.position(src) {
-            Some(p) => p,
-            None => continue,
+        let Some((x, y)) = ctx.index.position(src) else {
+            continue;
         };
         let xb = x.to_bits();
         let yb = y.to_bits();
         pos_to_info.insert((xb, yb), (src, lane));
         unique_x.insert(xb);
         unique_y.insert(yb);
-
-        let src_enc = src.encode();
-        if ctx.occupied.contains(&src_enc) && ctx.occupied.contains(&dst.encode()) {
-            invalid_locs.insert(src_enc);
-        }
     }
 
     let sorted_xs: Vec<u64> = unique_x.into_iter().collect();
@@ -141,10 +132,7 @@ fn rectangles_to_move_sets(
         .unwrap_or(sorted_ys.len())
         .min(sorted_ys.len());
 
-    let td = TripletData {
-        pos_to_info,
-        invalid_locs,
-    };
+    let td = TripletData { pos_to_info };
 
     for nx in 1..=max_nx {
         let mut x_indices = vec![0usize; nx];
@@ -181,30 +169,43 @@ fn try_rectangle(
 ) {
     let mut lane_addrs: Vec<LaneAddr> = Vec::new();
     let mut moves: Vec<(u32, LocationAddr)> = Vec::new();
-    let mut has_atom = false;
+    // Every cell's (src, dst) plus the sources this rectangle actually moves
+    // an atom out of — the group's mover set, needed to judge destinations.
+    let mut cells: Vec<(u64, u64)> = Vec::with_capacity(x_subset.len() * y_subset.len());
+    let mut mover_srcs: HashSet<u64> = HashSet::new();
 
     for &xb in x_subset {
         for &yb in y_subset {
             let Some(&(src, lane)) = td.pos_to_info.get(&(xb, yb)) else {
                 return;
             };
-            let src_enc = src.encode();
-            if td.invalid_locs.contains(&src_enc) {
+            let Some((_, dst)) = ctx.index.endpoints(&lane) else {
                 return;
-            }
+            };
+            let src_enc = src.encode();
             lane_addrs.push(lane);
+            cells.push((src_enc, dst.encode()));
 
             if let Some(&qid) = ctx.loc_to_qubit.get(&src_enc) {
-                has_atom = true;
-                if let Some((_, dst)) = ctx.index.endpoints(&lane) {
-                    moves.push((qid, dst));
-                }
+                mover_srcs.insert(src_enc);
+                moves.push((qid, dst));
             }
         }
     }
 
-    if !has_atom {
+    if moves.is_empty() {
         return;
+    }
+
+    // Uniform destination rule (#866): every cell's destination — mover and
+    // empty-source filler alike — must be free or vacated by this same
+    // rectangle. Judged against the pre-move occupancy once the whole mover
+    // set is known, which is why it cannot be a per-lane prefilter: a
+    // conveyor chain is only legal *because* the atom ahead moves too.
+    for &(_, dst_enc) in &cells {
+        if !crate::ops::aod_grid::destination_is_available(dst_enc, &ctx.occupied, &mover_srcs) {
+            return;
+        }
     }
 
     let move_set = MoveSet::new(lane_addrs);
@@ -380,11 +381,11 @@ mod tests {
     }
 
     #[test]
-    fn generate_collision_prefilter() {
+    fn generate_rejects_move_onto_stationary_atom() {
         let index = make_index();
         // Qubit 0 at site 0, qubit 1 at site 5 (destination of site 0 forward).
-        // The pre-filter should mark site 0 as invalid for forward moves
-        // (src occupied, dst occupied).
+        // Qubit 1 has no lane of its own on this bus, so it cannot vacate in
+        // the same shot: the uniform destination rule rejects the rectangle.
         let config = Config::new([(0, loc(0, 0)), (1, loc(0, 5))]).unwrap();
         let generator = ExhaustiveGenerator::new(None, None);
 
@@ -394,7 +395,72 @@ mod tests {
         let collision = out
             .iter()
             .any(|c| c.new_config.location_of(0) == Some(loc(0, 5)));
-        assert!(!collision, "collision should be pre-filtered");
+        assert!(!collision, "landing on a stationary atom must be rejected");
+    }
+
+    fn make_chain_index() -> LaneIndex {
+        let spec: ArchSpec = serde_json::from_str(&crate::test_utils::chain_arch_json()).unwrap();
+        LaneIndex::new(spec)
+    }
+
+    /// On a conveyor-chain bus (0→1, 1→2, …) two adjacent atoms can shift
+    /// together in one shot: the leading atom's destination is occupied, but
+    /// its occupant moves in the same rectangle. Before #876 the whole
+    /// rectangle was discarded because both endpoints were occupied.
+    #[test]
+    fn generate_admits_conveyor_chain() {
+        let index = make_chain_index();
+        let config = Config::new([(0, loc(0, 0)), (1, loc(0, 1))]).unwrap();
+        let generator = ExhaustiveGenerator::new(None, None);
+
+        let targets_raw: Vec<(u32, u64)> = vec![(0, loc(0, 1).encode())];
+        let target_locs: Vec<u64> = vec![loc(0, 1).encode()];
+        let dist_table = DistanceTable::new(&target_locs, &index);
+        let blocked = HashSet::new();
+        let ctx = make_ctx(&index, &dist_table, &targets_raw, &blocked);
+        let mut state = SearchState::default();
+        let mut out = Vec::new();
+        generator.generate(&config, NodeId(0), &ctx, &mut state, &mut out);
+
+        let has_chain = out.iter().any(|c| {
+            c.move_set.len() >= 2
+                && c.new_config.location_of(0) == Some(loc(0, 1))
+                && c.new_config.location_of(1) == Some(loc(0, 2))
+        });
+        assert!(
+            has_chain,
+            "conveyor chain 0→1, 1→2 must be generated as one simultaneous move set"
+        );
+    }
+
+    /// The chain exemption is not a blanket pass for occupied destinations:
+    /// the atom ahead must actually move. Here site 1 holds an atom with no
+    /// lane in the group (site 1's own lane is not part of a 1-cell rectangle
+    /// at site 0), so the single-cell rectangle at site 0 stays invalid.
+    #[test]
+    fn generate_chain_still_rejects_stationary_leader() {
+        let index = make_chain_index();
+        // Qubit 1 sits on site 4 — the end of the chain, which has no
+        // outgoing lane on this bus — so qubit 0's 3→4 lane can never fire.
+        let config = Config::new([(0, loc(0, 3)), (1, loc(0, 4))]).unwrap();
+        let generator = ExhaustiveGenerator::new(None, None);
+
+        let targets_raw: Vec<(u32, u64)> = vec![(0, loc(0, 4).encode())];
+        let target_locs: Vec<u64> = vec![loc(0, 4).encode()];
+        let dist_table = DistanceTable::new(&target_locs, &index);
+        let blocked = HashSet::new();
+        let ctx = make_ctx(&index, &dist_table, &targets_raw, &blocked);
+        let mut state = SearchState::default();
+        let mut out = Vec::new();
+        generator.generate(&config, NodeId(0), &ctx, &mut state, &mut out);
+
+        let lands_on_occupant = out
+            .iter()
+            .any(|c| c.new_config.location_of(0) == Some(loc(0, 4)));
+        assert!(
+            !lands_on_occupant,
+            "the atom ahead has no lane on this bus, so the move must be rejected"
+        );
     }
 
     #[test]

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -257,10 +257,35 @@ impl HeuristicGenerator {
     }
 }
 
+/// Whether the atom occupying `dst` could vacate in the same AOD shot as
+/// `lane`: it has an outgoing lane on the same
+/// `(move_type, bus_id, direction)` group, the only way two lanes can execute
+/// simultaneously (`ArchSpec::check_lanes` requires one bus per group).
+///
+/// This is the selection-time half of the uniform destination rule (#866).
+/// [`crate::ops::aod_grid::destination_is_available`] states the rule against a
+/// known mover set; at scoring time that set does not exist yet, so this
+/// admits a conveyor chain as a *candidate* and
+/// `BusGridContext::is_valid_rect` adjudicates once the rectangle's actual
+/// movers are known.
+///
+/// Necessarily `false` on endpoint-disjoint buses — a destination there is
+/// never a source of the same bus — so the shipped Gemini specs produce
+/// exactly the same candidates as the previous unconditional occupancy filter.
+fn occupant_can_vacate(dst: LocationAddr, lane: &LaneAddr, index: &LaneIndex) -> bool {
+    index.outgoing_lanes(dst).iter().any(|l| {
+        l.move_type == lane.move_type && l.bus_id == lane.bus_id && l.direction == lane.direction
+    })
+}
+
 /// Yield `(lane, destination)` pairs for every outgoing lane from `loc`
 /// whose destination is currently unoccupied. Shared traversal for all
 /// escape-move generation paths. Order is preserved (filter_map on a slice
 /// iterator is order-preserving), which is required for behavior-neutrality.
+///
+/// Deliberately strict about occupancy: every caller turns each pair into a
+/// **single-lane** move set, and a lone lane has no companion mover that
+/// could vacate its destination, so the chain exemption cannot apply here.
 fn escape_targets<'a>(
     loc: LocationAddr,
     occupied: &'a HashSet<u64>,
@@ -378,7 +403,16 @@ impl MoveGenerator for HeuristicGenerator {
                     continue;
                 };
                 let dst_enc = dst.encode();
-                if occupied.contains(&dst_enc) {
+                // Uniform destination rule (#866) at selection time: a blocked
+                // site never frees up, and an atom-occupied site is a candidate
+                // destination only when its occupant could vacate in the same
+                // shot. `is_valid_rect` makes the final call against the
+                // rectangle's real mover set; this only widens what reaches it,
+                // and only on overlapping-bus specs.
+                if ctx.blocked.contains(&dst_enc) {
+                    continue;
+                }
+                if occupied.contains(&dst_enc) && !occupant_can_vacate(dst, &lane, ctx.index) {
                     continue;
                 }
 
@@ -654,9 +688,85 @@ mod tests {
         LaneIndex::new(spec)
     }
 
+    fn make_chain_index() -> LaneIndex {
+        let spec: ArchSpec = serde_json::from_str(&crate::test_utils::chain_arch_json()).unwrap();
+        LaneIndex::new(spec)
+    }
+
     fn make_table(targets: &[(u32, LocationAddr)], index: &LaneIndex) -> DistanceTable {
         let locs: Vec<u64> = targets.iter().map(|&(_, l)| l.encode()).collect();
         DistanceTable::new(&locs, index)
+    }
+
+    /// The relaxed destination filter (#876): a destination occupied by an
+    /// atom that could vacate on the *same* bus group is a legal candidate;
+    /// one whose occupant has no such lane is not.
+    #[test]
+    fn occupant_can_vacate_only_on_a_shared_bus_group() {
+        // Conveyor chain 0→1, 1→2, …: the atom on site 1 has its own lane on
+        // this bus, so it can vacate in the same shot.
+        let chain = make_chain_index();
+        let lane_0 = lane(0, 0, 0);
+        assert!(
+            occupant_can_vacate(loc(0, 1), &lane_0, &chain),
+            "site 1 is a source of the same chain bus"
+        );
+        // Site 4 is the end of the chain — no outgoing lane on this bus.
+        assert!(
+            !occupant_can_vacate(loc(0, 4), &lane(0, 3, 0), &chain),
+            "the chain's final destination cannot vacate"
+        );
+
+        // On the endpoint-disjoint example arch a destination is never a
+        // source of the same bus, so the exemption can never fire — which is
+        // why this relaxation leaves the shipped Gemini specs untouched.
+        let disjoint = make_index();
+        assert!(
+            !occupant_can_vacate(loc(0, 5), &lane_0, &disjoint),
+            "disjoint buses have no shared src/dst site"
+        );
+    }
+
+    /// Documents a **known gap** (issue #887): admitting
+    /// chain candidates is necessary but not sufficient — the heuristic
+    /// selection still picks movers independently, so it does not co-select
+    /// the atom ahead and never assembles the chain into one AOD shot. Here it
+    /// emits only the follower's move; the leader waits for the next step, so
+    /// routing stays correct but takes two operations instead of one.
+    ///
+    /// `ExhaustiveGenerator` *does* assemble this chain (see
+    /// `generate_admits_conveyor_chain`) because it enumerates every
+    /// rectangle rather than selecting greedily.
+    #[test]
+    fn heuristic_selection_does_not_yet_assemble_chains() {
+        let index = make_chain_index();
+        // q0: site 0 → 1 (occupied by q1), q1: site 1 → 2 (free).
+        let config = Config::new([(0, loc(0, 0)), (1, loc(0, 1))]).unwrap();
+        let targets = [(0u32, loc(0, 1)), (1u32, loc(0, 2))];
+        let dist_table = make_table(&targets, &index);
+        let targets_raw: Vec<(u32, u64)> = targets.iter().map(|&(q, l)| (q, l.encode())).collect();
+        let blocked = HashSet::new();
+        let ctx = make_ctx(&index, &dist_table, &targets_raw, &blocked);
+
+        let generator = HeuristicGenerator::new();
+        let mut state = SearchState::default();
+        let mut out = Vec::new();
+        generator.generate(&config, NodeId(0), &ctx, &mut state, &mut out);
+
+        let shifts_both = out.iter().any(|c| {
+            c.new_config.location_of(0) == Some(loc(0, 1))
+                && c.new_config.location_of(1) == Some(loc(0, 2))
+        });
+        assert!(
+            !shifts_both,
+            "chain assembly is not implemented yet — if this now passes, the \
+             follow-up landed and this test should assert the chain instead"
+        );
+        // The follower's move is still generated, so the search makes progress.
+        let follower_moves = out
+            .iter()
+            .any(|c| c.new_config.location_of(1) == Some(loc(0, 2)));
+        assert!(follower_moves, "the unobstructed atom must still move");
     }
 
     fn make_ctx<'a>(

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -259,8 +259,12 @@ impl HeuristicGenerator {
 
 /// Whether the atom occupying `dst` could vacate in the same AOD shot as
 /// `lane`: it has an outgoing lane on the same
-/// `(move_type, bus_id, direction)` group, the only way two lanes can execute
-/// simultaneously (`ArchSpec::check_lanes` requires one bus per group).
+/// `(zone_id, move_type, bus_id, direction)` group, the only way two lanes can
+/// execute simultaneously. All four fields are exactly what
+/// `ArchSpec::check_lane_group_consistency` requires of a group — matching
+/// fewer of them would admit a "vacating" occupant whose lane could never
+/// legally share the group, which matters on multi-zone specs where a
+/// `ZoneBus` lane's own zone differs from its destination's.
 ///
 /// This is the selection-time half of the uniform destination rule (#866).
 /// [`crate::ops::aod_grid::destination_is_available`] states the rule against a
@@ -274,7 +278,10 @@ impl HeuristicGenerator {
 /// exactly the same candidates as the previous unconditional occupancy filter.
 fn occupant_can_vacate(dst: LocationAddr, lane: &LaneAddr, index: &LaneIndex) -> bool {
     index.outgoing_lanes(dst).iter().any(|l| {
-        l.move_type == lane.move_type && l.bus_id == lane.bus_id && l.direction == lane.direction
+        l.zone_id == lane.zone_id
+            && l.move_type == lane.move_type
+            && l.bus_id == lane.bus_id
+            && l.direction == lane.direction
     })
 }
 

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -259,19 +259,26 @@ impl HeuristicGenerator {
 
 /// Whether the atom occupying `dst` could vacate in the same AOD shot as
 /// `lane`: it has an outgoing lane on the same
-/// `(zone_id, move_type, bus_id, direction)` group, the only way two lanes can
-/// execute simultaneously. All four fields are exactly what
-/// `ArchSpec::check_lane_group_consistency` requires of a group.
+/// `(zone_id, move_type, bus_id, direction)` group — the four fields
+/// `ArchSpec::check_lane_group_consistency` requires a group to share, so a
+/// candidate admitted here is one the validator will accept.
 ///
-/// The `zone_id` term only ever bites for `ZoneBus` lanes: site and word buses
-/// are intra-zone, so a lane and its destination share a zone automatically.
-/// A single `zone_bus` may however connect more than two zones across its
-/// pairs, and a chain through it (`z0w0 → z1w0`, `z1w0 → z2w0`) has a
-/// different `zone_id` per hop — so it can never be one AOD shot, whatever
-/// the occupancy says. The worst case of comparing `zone_id` here is therefore
-/// that such a cross-zone chain gets **serialized** into one operation per
-/// hop, which is what the ISA requires anyway; omitting it would only
-/// manufacture candidates that `check_lanes` later rejects.
+/// The `zone_id` term only bites for `ZoneBus` lanes: site and word buses are
+/// intra-zone, so a lane and its destination share a zone automatically. A
+/// single `zone_bus` may serve several zones across its pairs, and for such a
+/// lane `zone_id` is the *source's* zone, so a chain through it
+/// (`z0w0 → z1w0`, then `z1w0 → z2w0`) carries a different `zone_id` per hop.
+///
+/// Consequence, stated honestly: those hops get **serialized** into one
+/// operation each. Serialization is permitted by the architecture — but so is
+/// batching them, since one zone bus may carry transfers among more than two
+/// zones in a single shot. This predicate is therefore deliberately *stricter
+/// than the architecture*, matching today's group-consistency rule rather than
+/// the hardware's capability. The reason to keep it that way for now is that
+/// `check_lane_group_consistency` rejects a mixed-`zone_id` group, so
+/// generating such candidates would produce plans that fail the
+/// solver-boundary replay outright. Unlocking the batching means relaxing that
+/// rule for zone buses first, then relaxing this in step.
 ///
 /// This is the selection-time half of the uniform destination rule (#866).
 /// [`crate::ops::aod_grid::destination_is_available`] states the rule against a

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -261,10 +261,17 @@ impl HeuristicGenerator {
 /// `lane`: it has an outgoing lane on the same
 /// `(zone_id, move_type, bus_id, direction)` group, the only way two lanes can
 /// execute simultaneously. All four fields are exactly what
-/// `ArchSpec::check_lane_group_consistency` requires of a group — matching
-/// fewer of them would admit a "vacating" occupant whose lane could never
-/// legally share the group, which matters on multi-zone specs where a
-/// `ZoneBus` lane's own zone differs from its destination's.
+/// `ArchSpec::check_lane_group_consistency` requires of a group.
+///
+/// The `zone_id` term only ever bites for `ZoneBus` lanes: site and word buses
+/// are intra-zone, so a lane and its destination share a zone automatically.
+/// A single `zone_bus` may however connect more than two zones across its
+/// pairs, and a chain through it (`z0w0 → z1w0`, `z1w0 → z2w0`) has a
+/// different `zone_id` per hop — so it can never be one AOD shot, whatever
+/// the occupancy says. The worst case of comparing `zone_id` here is therefore
+/// that such a cross-zone chain gets **serialized** into one operation per
+/// hop, which is what the ISA requires anyway; omitting it would only
+/// manufacture candidates that `check_lanes` later rejects.
 ///
 /// This is the selection-time half of the uniform destination rule (#866).
 /// [`crate::ops::aod_grid::destination_is_available`] states the rule against a

--- a/crates/bloqade-lanes-search/src/ops/aod_grid.rs
+++ b/crates/bloqade-lanes-search/src/ops/aod_grid.rs
@@ -18,6 +18,30 @@ use crate::primitives::lane_index::LaneIndex;
 /// Coordinates are stored as `f64::to_bits()` for cheap equality.
 type Cluster = (BTreeSet<u64>, BTreeSet<u64>);
 
+/// The execution model's **uniform destination rule** (issue #866): a lane's
+/// destination is available when it is unoccupied, or when its occupant is
+/// itself one of the group's moving sources — it vacates in the same
+/// simultaneous shot, so a conveyor chain `x→y, y→z` is legal.
+///
+/// The rule applies to empty-source *filler* lanes exactly as it does to
+/// movers: the AOD trap site arrives at every lane's destination whether or
+/// not that lane carried an atom, so landing on a stationary atom is a fault
+/// either way. This mirrors
+/// `AtomStateData::validate_moves`'s `DestinationOccupiedByStationaryAtom`
+/// check, which is the normative statement of the same rule.
+///
+/// [`BusGridContext::is_valid_rect`] applies this rule inline against a
+/// lazily-built sorted source index (it is the hottest loop in candidate
+/// generation); every other caller should use this helper so the two cannot
+/// drift apart.
+pub(crate) fn destination_is_available(
+    dst_enc: u64,
+    occupied: &HashSet<u64>,
+    group_mover_srcs: &HashSet<u64>,
+) -> bool {
+    !occupied.contains(&dst_enc) || group_mover_srcs.contains(&dst_enc)
+}
+
 /// Context for building AOD-compatible rectangular grids on one bus group.
 ///
 /// Built from ALL lanes on the bus (via [`LaneIndex::lanes_for`]), not just
@@ -83,6 +107,9 @@ impl<'a> BusGridContext<'a> {
     /// occupied by another atom moving in the same rectangle. A non-mover source
     /// may only fill the rectangle when both its source and destination avoid
     /// stationary atoms.
+    ///
+    /// The destination half of that is [`destination_is_available`]'s rule,
+    /// specialized here to a lazily-built sorted source index for speed.
     fn is_valid_rect(&self, xs: &BTreeSet<u64>, ys: &BTreeSet<u64>, movers: &HashSet<u64>) -> bool {
         // Resolve every cell's (src, dst) once into a reused scratch buffer.
         let mut cells = self.cells_scratch.borrow_mut();

--- a/crates/bloqade-lanes-search/src/ops/aod_grid.rs
+++ b/crates/bloqade-lanes-search/src/ops/aod_grid.rs
@@ -315,6 +315,74 @@ impl<'a> BusGridContext<'a> {
 mod tests {
     use super::*;
 
+    /// A conveyor chain `a→b, b→c` where the atoms sit on `a` and `b`.
+    ///
+    /// `is_valid_rect` accepts the **complete** 2-cell rectangle: `a`'s
+    /// destination `b` is occupied, but `b` is one of the rectangle's own
+    /// moving sources, so it vacates in the same shot. Yet `build_aod_grids`
+    /// still fails to emit it — see
+    /// [`greedy_init_cannot_assemble_a_chain_rectangle`] — which is why no
+    /// generator assembles chains today (issue #887).
+    fn chain_context() -> BusGridContext<'static> {
+        // Positions: a=(0,0), b=(1,0) — same row, adjacent columns.
+        // Lanes: a→b, b→c. Atoms occupy a and b; c is free.
+        const A: u64 = 10;
+        const B: u64 = 20;
+        const C: u64 = 30;
+        make_context_with_endpoints(
+            &[((0, 0), A), ((1, 0), B)],
+            &[(A, 101, B), (B, 102, C)],
+            &[A, B],
+        )
+    }
+
+    /// The rule itself admits a chain: the full rectangle is valid.
+    #[test]
+    fn is_valid_rect_accepts_a_complete_chain_rectangle() {
+        let ctx = chain_context();
+        let movers: HashSet<u64> = [10u64, 20].into_iter().collect();
+        let xs: BTreeSet<u64> = [0u64, 1].into_iter().collect();
+        let ys: BTreeSet<u64> = [0u64].into_iter().collect();
+        assert!(
+            ctx.is_valid_rect(&xs, &ys, &movers),
+            "a→b, b→c is legal: b vacates in the same shot"
+        );
+        // ...but the leader's cell *alone* is not, because b is not yet one of
+        // the rectangle's sources. This non-monotonicity is the trap below.
+        let xs_leader: BTreeSet<u64> = [0u64].into_iter().collect();
+        assert!(
+            !ctx.is_valid_rect(&xs_leader, &ys, &movers),
+            "the chain's prefix is invalid in isolation"
+        );
+    }
+
+    /// **Known gap (issue #887).** `greedy_init` grows a rectangle one entry at
+    /// a time and sets aside any entry whose *intermediate* rectangle is
+    /// invalid. For a chain the intermediate state is exactly what fails: the
+    /// leader is rejected before the follower is ever added, so the valid
+    /// 2-cell rectangle is never tried.
+    ///
+    /// The ordering is the fix: feeding entries follower-first (reverse
+    /// topological order along the bus relation, which #874 guarantees is
+    /// acyclic) makes each intermediate rectangle valid. Endpoint-disjoint
+    /// buses have no chains, so their entry order — and behavior — is
+    /// unaffected either way.
+    #[test]
+    fn greedy_init_cannot_assemble_a_chain_rectangle() {
+        let ctx = chain_context();
+        let entries: HashMap<u64, u64> = [(10u64, 101u64), (20, 102)].into_iter().collect();
+        let grids = ctx.build_aod_grids(&entries);
+        let assembled_chain = grids.iter().any(|g| g.contains(&101) && g.contains(&102));
+        assert!(
+            !assembled_chain,
+            "if this now passes, chain assembly landed (#887) — assert the \
+             chain is emitted instead"
+        );
+        // Only the follower's own single-cell rectangle survives.
+        assert_eq!(grids.len(), 1);
+        assert_eq!(grids[0], vec![102]);
+    }
+
     /// Helper: build a BusGridContext from raw position/lane/collision data.
     fn make_context(
         positions: &[((u64, u64), u64)], // ((x, y), src_encoded)

--- a/crates/bloqade-lanes-search/src/push_rotate/solver.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/solver.rs
@@ -143,7 +143,12 @@ pub fn solve_push_rotate_with(
     // it leaves the router, so a condenser that batched two atoms into one
     // operation illegally fails here instead of downstream. The push-rotate
     // integration test asserted this by hand; it is now the production path.
-    crate::search::verify::assert_move_layers_executable(&root, &move_layers, index.arch_spec());
+    crate::search::verify::assert_move_layers_executable(
+        &root,
+        &move_layers,
+        index.arch_spec(),
+        &goal_config,
+    );
 
     // `nodes_expanded` is 0 by construction: this is not a search. Cost is the
     // operation count, matching `UniformCost` over the emitted layers so the

--- a/crates/bloqade-lanes-search/src/push_rotate/solver.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/solver.rs
@@ -138,6 +138,13 @@ pub fn solve_push_rotate_with(
             .map(|&(q, v)| (q, LocationAddr::decode(graph.location_of(v)))),
     )?;
 
+    // Same contract as the frontier drivers (see `search::verify`): the
+    // packaged plan is replayed through the canonical execution model before
+    // it leaves the router, so a condenser that batched two atoms into one
+    // operation illegally fails here instead of downstream. The push-rotate
+    // integration test asserted this by hand; it is now the production path.
+    crate::search::verify::assert_move_layers_executable(&root, &move_layers, index.arch_spec());
+
     // `nodes_expanded` is 0 by construction: this is not a search. Cost is the
     // operation count, matching `UniformCost` over the emitted layers so the
     // value is comparable with the frontier drivers'.

--- a/crates/bloqade-lanes-search/src/search/mod.rs
+++ b/crates/bloqade-lanes-search/src/search/mod.rs
@@ -10,6 +10,8 @@
 //! - [`move_search`] — `MoveSearch` composition layer.
 //! - [`target_solver`] — `TargetSolver` (single-candidate solver wrapping
 //!   `SearchEngine` + `MoveSearch`).
+//! - [`verify`] — canonical execution-model replay applied to every packaged
+//!   plan, so an inexecutable move set fails at its source (issue #866).
 
 pub mod engine;
 pub mod move_search;
@@ -17,3 +19,4 @@ pub mod options;
 pub mod restarts;
 pub mod result;
 pub mod target_solver;
+pub(crate) mod verify;

--- a/crates/bloqade-lanes-search/src/search/restarts.rs
+++ b/crates/bloqade-lanes-search/src/search/restarts.rs
@@ -46,6 +46,7 @@ pub(crate) fn extract(
                 result.graph.config(result.graph.root()),
                 &move_layers,
                 ctx.index.arch_spec(),
+                &goal_config,
             );
             SolveResult::solved(
                 goal_config,

--- a/crates/bloqade-lanes-search/src/search/restarts.rs
+++ b/crates/bloqade-lanes-search/src/search/restarts.rs
@@ -26,12 +26,27 @@ use crate::search::result::{SolveResult, SolveStatus};
 use crate::traits::{Goal, Heuristic, MoveGenerator};
 
 /// Extract a [`SolveResult`] from a [`SearchResult`].
-pub(crate) fn extract(result: SearchResult, deadlocks: u32, max_exp: Option<u32>) -> SolveResult {
+///
+/// Every solved plan is replayed through the canonical execution model before
+/// it leaves the solver (see [`crate::search::verify`]): `Config::with_moves`
+/// performs no occupancy validation, so this is where a generator that emits
+/// an inexecutable move set gets caught, rather than downstream in the IR.
+pub(crate) fn extract(
+    result: SearchResult,
+    deadlocks: u32,
+    max_exp: Option<u32>,
+    ctx: &SearchContext,
+) -> SolveResult {
     match result.goal {
         Some(goal_id) => {
             let move_layers = result.solution_path().unwrap_or_default();
             let goal_config = result.graph.config(goal_id).clone();
             let cost = result.graph.g_score(goal_id);
+            crate::search::verify::assert_move_layers_executable(
+                result.graph.config(result.graph.root()),
+                &move_layers,
+                ctx.index.arch_spec(),
+            );
             SolveResult::solved(
                 goal_config,
                 move_layers,
@@ -162,13 +177,13 @@ where
                 let move_gen = make_generator(seed, deadlock_policy);
                 let mut f = IdsFrontier::new(h_sum);
                 let result = run_frontier(&root, &move_gen, goal, ctx, &mut f, budget, None);
-                extract(result, move_gen.deadlock_count(), budget)
+                extract(result, move_gen.deadlock_count(), budget, ctx)
             }
             InnerStrategy::Dfs => {
                 let move_gen = make_generator(seed, deadlock_policy);
                 let mut f = DfsFrontier::new(h_sum);
                 let result = run_frontier(&root, &move_gen, goal, ctx, &mut f, budget, None);
-                extract(result, move_gen.deadlock_count(), budget)
+                extract(result, move_gen.deadlock_count(), budget, ctx)
             }
             InnerStrategy::Entropy => {
                 let entropy_params = crate::drivers::entropy::EntropyParams {
@@ -202,7 +217,7 @@ where
                         entropy_tables,
                     )
                 };
-                let mut solve = extract(result, 0, budget);
+                let mut solve = extract(result, 0, budget, ctx);
                 solve.entropy_trace = entropy_trace;
                 solve
             }
@@ -253,6 +268,7 @@ where
             astar_result,
             astar_move_gen.deadlock_count(),
             max_expansions,
+            ctx,
         );
 
         if astar_solve.status == SolveStatus::Solved {
@@ -281,7 +297,7 @@ where
                     budget,
                     weight,
                 );
-                extract(result, move_gen.deadlock_count(), budget)
+                extract(result, move_gen.deadlock_count(), budget, ctx)
             }
         }
     };

--- a/crates/bloqade-lanes-search/src/search/verify.rs
+++ b/crates/bloqade-lanes-search/src/search/verify.rs
@@ -20,6 +20,9 @@
 //! that produced the plan, and runs in every build: the invariant it protects
 //! (issue #866) is a correctness property, not a debugging aid.
 
+use std::collections::HashMap;
+
+use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
 use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
 use bloqade_lanes_bytecode_core::atom_state::AtomStateData;
 
@@ -28,17 +31,14 @@ use crate::primitives::graph::MoveSet;
 
 /// Replay `layers` from `root` through the canonical execution model.
 ///
-/// Returns a diagnostic naming the first layer that cannot execute, or `Ok`
-/// when the whole plan is executable.
-pub(crate) fn verify_move_layers(
+/// Returns the placement the plan actually lands on — `qubit → location`, as
+/// resolved by lane endpoints rather than by [`Config::with_moves`] — or a
+/// diagnostic naming the first layer that cannot execute.
+pub(crate) fn replay_move_layers(
     root: &Config,
     layers: &[MoveSet],
     arch: &ArchSpec,
-) -> Result<(), String> {
-    if layers.is_empty() {
-        return Ok(());
-    }
-
+) -> Result<HashMap<u32, LocationAddr>, String> {
     let atoms: Vec<_> = root.iter().collect();
     let mut state = AtomStateData::from_locations(&atoms);
 
@@ -52,7 +52,49 @@ pub(crate) fn verify_move_layers(
             .map_err(|errors| format_layer_error(layer_idx, layers.len(), &errors))?;
     }
 
-    Ok(())
+    Ok(state.qubit_to_locations)
+}
+
+/// Replay `layers` from `root` and check the result against the placement the
+/// solver reports as its goal.
+///
+/// Executability alone is not enough: `Config::with_moves` overwrites a
+/// qubit's location with whatever the generator passed, without checking that
+/// the qubit was at the lane's source or that the lane leads where the
+/// generator claims. A plan can therefore be perfectly executable while the
+/// reported `goal_config` is wrong — a teleported qubit, or a move credited to
+/// the wrong atom. Comparing the replayed placement against `expected_goal`
+/// closes that gap, and is the only check that actually exercises
+/// lane-endpoint semantics end to end.
+pub(crate) fn verify_move_layers(
+    root: &Config,
+    layers: &[MoveSet],
+    arch: &ArchSpec,
+    expected_goal: &Config,
+) -> Result<(), String> {
+    let replayed = replay_move_layers(root, layers, arch)?;
+
+    let claimed: HashMap<u32, LocationAddr> = expected_goal.iter().collect();
+    if replayed == claimed {
+        return Ok(());
+    }
+
+    // Report every qubit that disagrees, sorted for a stable diagnostic.
+    let mut qubits: Vec<u32> = replayed.keys().chain(claimed.keys()).copied().collect();
+    qubits.sort_unstable();
+    qubits.dedup();
+    let mut details = String::new();
+    for qubit in qubits {
+        let (got, want) = (replayed.get(&qubit), claimed.get(&qubit));
+        if got != want {
+            details.push_str(&format!(
+                "\n  - qubit {qubit}: plan lands on {got:?}, solver reports {want:?}"
+            ));
+        }
+    }
+    Err(format!(
+        "replaying the plan does not reproduce the reported goal placement:{details}"
+    ))
 }
 
 fn format_layer_error<E: std::fmt::Display>(idx: usize, total: usize, errors: &[E]) -> String {
@@ -70,11 +112,16 @@ fn format_layer_error<E: std::fmt::Display>(idx: usize, total: usize, errors: &[
 /// the plan — not a user error — so it fails loudly rather than returning a
 /// plan that would corrupt atom state (or, since #877, be rejected with a
 /// much vaguer message once it reaches the IR analysis).
-pub(crate) fn assert_move_layers_executable(root: &Config, layers: &[MoveSet], arch: &ArchSpec) {
-    if let Err(diagnostic) = verify_move_layers(root, layers, arch) {
+pub(crate) fn assert_move_layers_executable(
+    root: &Config,
+    layers: &[MoveSet],
+    arch: &ArchSpec,
+    expected_goal: &Config,
+) {
+    if let Err(diagnostic) = verify_move_layers(root, layers, arch, expected_goal) {
         panic!(
-            "solver produced a plan that cannot execute (this is a bug in the \
-             move generator, not in the request): {diagnostic}"
+            "solver produced an invalid plan (this is a bug in the move \
+             generator, not in the request): {diagnostic}"
         );
     }
 }
@@ -104,21 +151,26 @@ mod tests {
     }
 
     #[test]
-    fn accepts_an_executable_plan() {
+    fn accepts_an_executable_plan_reaching_the_reported_goal() {
         let index = index();
         let root = Config::new([(0, loc(0, 0))]).expect("config");
         let layers = vec![MoveSet::new(vec![site_lane(0, 0)])];
+        // Site bus 0 maps site 0 → site 5.
+        let goal = Config::new([(0, loc(0, 5))]).expect("config");
         assert_eq!(
-            verify_move_layers(&root, &layers, index.arch_spec()),
+            verify_move_layers(&root, &layers, index.arch_spec(), &goal),
             Ok(())
         );
     }
 
     #[test]
-    fn empty_plan_is_vacuously_executable() {
+    fn empty_plan_must_report_the_root_placement() {
         let index = index();
         let root = Config::new([(0, loc(0, 0))]).expect("config");
-        assert_eq!(verify_move_layers(&root, &[], index.arch_spec()), Ok(()));
+        assert_eq!(
+            verify_move_layers(&root, &[], index.arch_spec(), &root),
+            Ok(())
+        );
     }
 
     #[test]
@@ -128,7 +180,9 @@ mod tests {
         // no lane of its own in the group, so the layer cannot execute.
         let root = Config::new([(0, loc(0, 0)), (1, loc(0, 5))]).expect("config");
         let layers = vec![MoveSet::new(vec![site_lane(0, 0)])];
-        let err = verify_move_layers(&root, &layers, index.arch_spec())
+        // Executability is checked before the placement comparison, so the
+        // expected goal passed here is irrelevant — use the root.
+        let err = verify_move_layers(&root, &layers, index.arch_spec(), &root)
             .expect_err("landing on a stationary atom must be rejected");
         assert!(err.contains("move layer 0 of 1"), "{err}");
         assert!(err.contains("occupied by qubit 1"), "{err}");
@@ -144,8 +198,43 @@ mod tests {
             MoveSet::new(vec![site_lane(0, 0)]),
             MoveSet::new(vec![site_lane(0, 1)]),
         ];
-        let err = verify_move_layers(&root, &layers, index.arch_spec())
+        let err = verify_move_layers(&root, &layers, index.arch_spec(), &root)
             .expect_err("second layer must be rejected");
         assert!(err.contains("move layer 1 of 2"), "{err}");
+    }
+
+    /// The check Copilot asked for on #888: a plan can be perfectly executable
+    /// while the placement the solver *reports* is wrong, because
+    /// `Config::with_moves` overwrites a qubit's location without consulting
+    /// lane endpoints. Here the lane moves qubit 0 to site 5, but the reported
+    /// goal claims site 6.
+    #[test]
+    fn rejects_an_executable_plan_that_misreports_the_goal() {
+        let index = index();
+        let root = Config::new([(0, loc(0, 0))]).expect("config");
+        let layers = vec![MoveSet::new(vec![site_lane(0, 0)])];
+        let wrong_goal = Config::new([(0, loc(0, 6))]).expect("config");
+
+        let err = verify_move_layers(&root, &layers, index.arch_spec(), &wrong_goal)
+            .expect_err("a misreported goal placement must be rejected");
+        assert!(
+            err.contains("does not reproduce the reported goal"),
+            "{err}"
+        );
+        assert!(err.contains("qubit 0"), "{err}");
+    }
+
+    /// A plan that silently drops an atom (reports fewer qubits than it moves)
+    /// is caught by the same comparison.
+    #[test]
+    fn rejects_a_goal_missing_a_qubit() {
+        let index = index();
+        let root = Config::new([(0, loc(0, 0)), (1, loc(0, 1))]).expect("config");
+        let layers = vec![MoveSet::new(vec![site_lane(0, 0)])];
+        let goal = Config::new([(0, loc(0, 5))]).expect("config");
+
+        let err = verify_move_layers(&root, &layers, index.arch_spec(), &goal)
+            .expect_err("a dropped qubit must be rejected");
+        assert!(err.contains("qubit 1"), "{err}");
     }
 }

--- a/crates/bloqade-lanes-search/src/search/verify.rs
+++ b/crates/bloqade-lanes-search/src/search/verify.rs
@@ -1,0 +1,151 @@
+//! Canonical execution-model replay for packaged solve results.
+//!
+//! The search crate carries its own compact state representation
+//! ([`Config`]) and trusts generators to produce executable move sets:
+//! [`Config::with_moves`] is a documented no-validation per-qubit overwrite,
+//! so a generator bug — or a policy that routes an atom onto an occupied site
+//! — yields a plan that silently corrupts atom state downstream rather than
+//! failing here.
+//!
+//! This module closes that gap at the one place every plan passes through:
+//! before a [`SolveResult`](crate::search::result::SolveResult) is handed
+//! back, its layers are replayed from the root configuration through the
+//! canonical execution model in `bloqade-lanes-bytecode-core`
+//! ([`AtomStateData::validate_moves`] + [`AtomStateData::apply_validated`]) —
+//! the same code the IR analysis and bytecode validator use. A plan that
+//! cannot execute is therefore caught at its source, with the offending layer
+//! named, instead of surfacing as a confusing IR-level error later.
+//!
+//! The replay is O(layers × lanes) per solve, negligible next to the search
+//! that produced the plan, and runs in every build: the invariant it protects
+//! (issue #866) is a correctness property, not a debugging aid.
+
+use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+use bloqade_lanes_bytecode_core::atom_state::AtomStateData;
+
+use crate::primitives::config::Config;
+use crate::primitives::graph::MoveSet;
+
+/// Replay `layers` from `root` through the canonical execution model.
+///
+/// Returns a diagnostic naming the first layer that cannot execute, or `Ok`
+/// when the whole plan is executable.
+pub(crate) fn verify_move_layers(
+    root: &Config,
+    layers: &[MoveSet],
+    arch: &ArchSpec,
+) -> Result<(), String> {
+    if layers.is_empty() {
+        return Ok(());
+    }
+
+    let atoms: Vec<_> = root.iter().collect();
+    let mut state = AtomStateData::from_locations(&atoms);
+
+    for (layer_idx, move_set) in layers.iter().enumerate() {
+        let lanes = move_set.decode();
+        let validated = state
+            .validate_moves(&lanes, arch)
+            .map_err(|errors| format_layer_error(layer_idx, layers.len(), &errors))?;
+        state = state
+            .apply_validated(&validated)
+            .map_err(|errors| format_layer_error(layer_idx, layers.len(), &errors))?;
+    }
+
+    Ok(())
+}
+
+fn format_layer_error<E: std::fmt::Display>(idx: usize, total: usize, errors: &[E]) -> String {
+    let details = errors
+        .iter()
+        .map(|e| format!("\n  - {e}"))
+        .collect::<Vec<_>>()
+        .join("");
+    format!("move layer {idx} of {total} cannot execute:{details}")
+}
+
+/// Panic with a full diagnostic when a packaged plan is not executable.
+///
+/// Reaching this is a bug in the generator, policy, or router that produced
+/// the plan — not a user error — so it fails loudly rather than returning a
+/// plan that would corrupt atom state (or, since #877, be rejected with a
+/// much vaguer message once it reaches the IR analysis).
+pub(crate) fn assert_move_layers_executable(root: &Config, layers: &[MoveSet], arch: &ArchSpec) {
+    if let Err(diagnostic) = verify_move_layers(root, layers, arch) {
+        panic!(
+            "solver produced a plan that cannot execute (this is a bug in the \
+             move generator, not in the request): {diagnostic}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::lane_index::LaneIndex;
+    use crate::test_utils::{example_arch_json, loc};
+    use bloqade_lanes_bytecode_core::arch::addr::{Direction, LaneAddr, MoveType};
+
+    fn index() -> LaneIndex {
+        let spec: ArchSpec = serde_json::from_str(example_arch_json()).expect("arch json parses");
+        LaneIndex::new(spec)
+    }
+
+    /// Site bus 0 on the example arch maps sites 0..5 → 5..10 within a word.
+    fn site_lane(word_id: u32, site_id: u32) -> LaneAddr {
+        LaneAddr {
+            direction: Direction::Forward,
+            move_type: MoveType::SiteBus,
+            zone_id: 0,
+            word_id,
+            site_id,
+            bus_id: 0,
+        }
+    }
+
+    #[test]
+    fn accepts_an_executable_plan() {
+        let index = index();
+        let root = Config::new([(0, loc(0, 0))]).expect("config");
+        let layers = vec![MoveSet::new(vec![site_lane(0, 0)])];
+        assert_eq!(
+            verify_move_layers(&root, &layers, index.arch_spec()),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn empty_plan_is_vacuously_executable() {
+        let index = index();
+        let root = Config::new([(0, loc(0, 0))]).expect("config");
+        assert_eq!(verify_move_layers(&root, &[], index.arch_spec()), Ok(()));
+    }
+
+    #[test]
+    fn rejects_a_move_onto_a_stationary_atom() {
+        let index = index();
+        // Qubit 1 sits on site 5 — the destination of site 0's lane — and has
+        // no lane of its own in the group, so the layer cannot execute.
+        let root = Config::new([(0, loc(0, 0)), (1, loc(0, 5))]).expect("config");
+        let layers = vec![MoveSet::new(vec![site_lane(0, 0)])];
+        let err = verify_move_layers(&root, &layers, index.arch_spec())
+            .expect_err("landing on a stationary atom must be rejected");
+        assert!(err.contains("move layer 0 of 1"), "{err}");
+        assert!(err.contains("occupied by qubit 1"), "{err}");
+    }
+
+    #[test]
+    fn reports_the_offending_layer_index() {
+        let index = index();
+        // Layer 0 is fine (0 → 5); layer 1 then drives site 1 → 6 while qubit
+        // 1 still occupies site 6.
+        let root = Config::new([(0, loc(0, 0)), (1, loc(0, 1)), (2, loc(0, 6))]).expect("config");
+        let layers = vec![
+            MoveSet::new(vec![site_lane(0, 0)]),
+            MoveSet::new(vec![site_lane(0, 1)]),
+        ];
+        let err = verify_move_layers(&root, &layers, index.arch_spec())
+            .expect_err("second layer must be rejected");
+        assert!(err.contains("move layer 1 of 2"), "{err}");
+    }
+}

--- a/crates/bloqade-lanes-search/src/test_utils.rs
+++ b/crates/bloqade-lanes-search/src/test_utils.rs
@@ -51,10 +51,10 @@ pub fn chain_arch_json() -> String {
     let bus = &mut spec.zones[0].site_buses[0];
     bus.src = (0..4).map(SiteRef).collect();
     bus.dst = (1..5).map(SiteRef).collect();
+    let validation = spec.validate();
     assert!(
-        spec.validate().is_ok(),
-        "conveyor-chain fixture must be a legal spec: {:?}",
-        spec.validate()
+        validation.is_ok(),
+        "conveyor-chain fixture must be a legal spec: {validation:?}"
     );
     serde_json::to_string(&spec).expect("spec serializes")
 }

--- a/crates/bloqade-lanes-search/src/test_utils.rs
+++ b/crates/bloqade-lanes-search/src/test_utils.rs
@@ -32,6 +32,33 @@ pub fn full_arch_json() -> &'static str {
     include_str!("../../../examples/arch/full.json")
 }
 
+/// The example arch with site bus 0 rewired as a **conveyor chain**:
+/// `0→1, 1→2, 2→3, 3→4` along one row of a word.
+///
+/// The destination set `{1,2,3,4}` overlaps the source set `{0,1,2,3}`, but
+/// the relation is acyclic and endpoint-unique, so this is a legal bus
+/// (issue #874) — and the only kind of spec on which the chain-handling paths
+/// of the generators and the AOD grid layer are reachable (issue #866). The
+/// shipped Gemini specs keep their endpoints disjoint, where a destination is
+/// never a source of the same bus and the chain code is dead.
+#[allow(dead_code)]
+pub fn chain_arch_json() -> String {
+    use bloqade_lanes_bytecode_core::arch::addr::SiteRef;
+    use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+
+    let mut spec: ArchSpec =
+        serde_json::from_str(example_arch_json()).expect("example arch json parses");
+    let bus = &mut spec.zones[0].site_buses[0];
+    bus.src = (0..4).map(SiteRef).collect();
+    bus.dst = (1..5).map(SiteRef).collect();
+    assert!(
+        spec.validate().is_ok(),
+        "conveyor-chain fixture must be a legal spec: {:?}",
+        spec.validate()
+    );
+    serde_json::to_string(&spec).expect("spec serializes")
+}
+
 /// Minimal two-zone architecture with a single inter-zone `zone_bus`.
 ///
 /// Zone 0 ("gate") holds word 0 and zone 1 ("memory") holds word 1, each a


### PR DESCRIPTION
Closes #876. Completes Phase 3 of #866 — see the [audit](https://github.com/QuEraComputing/bloqade-lanes/issues/866#issuecomment-5196424415) and [agreed architecture](https://github.com/QuEraComputing/bloqade-lanes/issues/866#issuecomment-5196425263). Builds on #874/#875 (#880) and the consumer migration (#883). Branched off #882 and rebased onto main now that it has landed.

## 1. Generators agree on one destination rule (#876)

Three layers disagreed about whether a lane may target an occupied destination:

| Layer | Before | After |
|---|---|---|
| `is_valid_rect` | accepted if the occupant moves in the same rectangle | unchanged (the reference behavior) |
| Heuristic generator | rejected **every** atom-occupied destination — the exemption was dead code for movers | rejects only when the occupant cannot vacate on the same bus group |
| Exhaustive generator | rejected src-occupied ∧ dst-occupied by discarding the **whole rectangle**; **never checked empty-source filler destinations** | applies the rule per rectangle, once the real mover set is known |

The rule is now stated once, in `ops::aod_grid::destination_is_available`: *an occupied destination is legal iff its occupant vacates in the same group* — the search-side mirror of `validate_moves`' `DestinationOccupiedByStationaryAtom`. It applies to filler lanes too, since the AOD trap arrives at every destination whether or not the lane carried an atom (the check exhaustive was missing).

Two deliberate non-changes: `escape_targets` stays strict, because every caller builds a **single-lane** move set where no companion mover can vacate anything; and `GreedyGenerator` stays chain-incapable, since following a chain needs multi-agent pathfinding rather than single-atom BFS.

**Provably a no-op on the shipped specs.** Lane groups are single-bus, and on an endpoint-disjoint bus no destination is ever a source of the same bus — so the exemption can never fire. Confirmed empirically: the logical benchmark gate reports **zero** deterministic-column diffs.

## 2. Feasibility guard relaxed to acyclicity (#866 Phase 3)

The pebble-motion reduction never needed endpoint disjointness — only the absence of cycles: a conveyor chain serializes into single-pebble moves in reverse topological order, each site vacated before the atom behind it arrives. Only a rotation is not pebble-equivalent, and `ArchSpec::validate` has rejected those since #874, which makes structural validity exactly the right precondition. `validate_bus_disjointness` is deleted; the debug guard just calls `validate()`.

New soundness coverage on a synthetic conveyor-chain spec: random-walk no-false-positive over 25 seeds, and a brute-force cross-check that every `Infeasible` verdict is genuinely unsolvable. The old "reject overlap" test is replaced by *accept acyclic overlap* + *still reject a cycle*.

## 3. Solver-boundary replay

`Config::with_moves` is a documented no-validation overwrite, so a generator bug — or the DSL `bfs_path` fallback routing an atom onto an occupied goal — yielded a plan that corrupted atom state downstream rather than failing at its source. Every packaged plan is now replayed from the root config through `AtomStateData::validate_moves` + `apply_validated` at both `SolveResult` sites (`restarts::extract`, push-rotate router), panicking with the offending layer named. O(layers × lanes) per solve, negligible beside the search; runs in all builds. The push-rotate integration test asserted this by hand — that is now the production path, and it passes unchanged.

## Scope note: chains are expressible, not yet exploited

Worth reading before reviewing. This PR makes the layers *agree* and makes chains legal and validated end-to-end. It does **not** make every generator *assemble* them:

- `ExhaustiveGenerator` **does** assemble a conveyor chain into one AOD shot (it enumerates every rectangle).
- `HeuristicGenerator` admits chain lanes as candidates but its selection picks movers independently and never co-selects the atom ahead, so the chain is not assembled — the follower moves and the leader waits a step. Routing stays correct, just one operation slower.

I wrote that test expecting it to pass; it failed, so the gap is filed as **#887** with a per-layer evidence table, and the test now pins current behavior with a pointer to it (it will fail loudly when chain assembly lands, prompting the assertion to be flipped).

## Verification

- Rust: 21 workspace test targets pass (search crate 361 → all green); clippy `-D warnings` clean on core + cli + search; fmt clean.
- Python: full suite **1831 passed**, on the rebased tree.
- Benchmarks: **logical gate passes with zero deterministic diffs**; no wall-time regression from the replay. Physical suite left to CI per maintainer direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
