### PR TITLE
feat(search): assemble conveyor chains into a single AOD operation

### DIFF
--- a/crates/bloqade-lanes-bytecode-python/src/errors.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/errors.rs
@@ -39,6 +39,25 @@ fn arch_spec_error_to_py(py: Python<'_>, error: &ArchSpecError) -> PyResult<PyOb
 }
 
 /// Convert a Vec<ArchSpecError> to a single Python ArchSpecError with an errors list.
+/// Build a [`LaneIndex`] from a Python-supplied [`ArchSpec`], rejecting a spec
+/// that fails structural validation.
+///
+/// Every path that turns a user-supplied spec into search machinery goes
+/// through here. The search layers treat per-bus acyclicity and endpoint
+/// uniqueness (#874) as *given* rather than checking them: rectangle growth
+/// exempts an occupied destination whose occupant moves in the same shot,
+/// which is what makes conveyor chains legal — and on a cyclic bus is exactly
+/// what would make a physically impossible rotation look legal too.
+pub fn validated_lane_index(
+    py: Python<'_>,
+    arch_spec: &bloqade_lanes_bytecode_core::arch::types::ArchSpec,
+) -> PyResult<bloqade_lanes_search::primitives::lane_index::LaneIndex> {
+    arch_spec
+        .validate()
+        .map_err(|errors| arch_spec_errors_to_py(py, errors))?;
+    Ok(bloqade_lanes_search::primitives::lane_index::LaneIndex::from_arch_spec(arch_spec))
+}
+
 pub fn arch_spec_errors_to_py(py: Python<'_>, errors: Vec<ArchSpecError>) -> PyErr {
     let module = match py.import(EXCEPTIONS_MODULE) {
         Ok(m) => m,

--- a/crates/bloqade-lanes-bytecode-python/src/search_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/search_python.rs
@@ -1315,11 +1315,32 @@ impl PySearchEngine {
         }
     }
 
-    /// Create a ``SearchEngine`` from an ArchSpec JSON string.
+    /// Create a ``SearchEngine`` from an ArchSpec JSON string, **without
+    /// validating the spec**.
+    ///
+    /// Prefer :meth:`from_json_validated`. The search layers assume per-bus
+    /// acyclicity and endpoint uniqueness rather than checking them, so an
+    /// unvalidated spec with a cyclic bus would be routed as if a rotation
+    /// were a legal AOD operation.
     #[staticmethod]
     fn from_json(arch_spec_json: &str) -> PyResult<Self> {
         let engine = SearchEngine::from_json(arch_spec_json)
             .map_err(|e| PyValueError::new_err(format!("invalid arch spec JSON: {e}")))?;
+        Ok(Self {
+            inner: Arc::new(engine),
+        })
+    }
+
+    /// Create a ``SearchEngine`` from an ArchSpec JSON string, rejecting a
+    /// spec that fails structural validation.
+    ///
+    /// Raises ``ArchSpecError`` (with every individual problem in its
+    /// ``errors`` list) for an invalid spec, or ``ValueError`` for malformed
+    /// JSON.
+    #[staticmethod]
+    fn from_json_validated(arch_spec_json: &str, py: Python<'_>) -> PyResult<Self> {
+        let engine = SearchEngine::from_json_validated(arch_spec_json)
+            .map_err(|e| crate::errors::arch_spec_load_error_to_py(py, &e))?;
         Ok(Self {
             inner: Arc::new(engine),
         })

--- a/crates/bloqade-lanes-bytecode-python/src/search_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/search_python.rs
@@ -577,8 +577,9 @@ impl PyEntropyScorer {
         beta: f64,
         gamma: f64,
         w_t: f64,
+        py: Python<'_>,
     ) -> PyResult<Self> {
-        let index = LaneIndex::from_arch_spec(&arch_spec.inner);
+        let index = crate::errors::validated_lane_index(py, &arch_spec.inner)?;
 
         let targets: Vec<(u32, u64)> = target
             .iter()
@@ -1308,11 +1309,17 @@ pub struct PySearchEngine {
 #[pymethods]
 impl PySearchEngine {
     /// Create a ``SearchEngine`` from a native ``ArchSpec`` object.
+    ///
+    /// Raises ``ArchSpecError`` (with every individual problem in its
+    /// ``errors`` list) for a spec that fails structural validation — the
+    /// search assumes per-bus acyclicity rather than checking it.
     #[staticmethod]
-    fn from_arch_spec(arch: &PyArchSpec) -> Self {
-        Self {
-            inner: Arc::new(SearchEngine::from_arch_spec(&arch.inner)),
-        }
+    fn from_arch_spec(arch: &PyArchSpec, py: Python<'_>) -> PyResult<Self> {
+        let engine = SearchEngine::from_arch_spec(&arch.inner)
+            .map_err(|errors| crate::errors::arch_spec_errors_to_py(py, errors))?;
+        Ok(Self {
+            inner: Arc::new(engine),
+        })
     }
 
     /// Create a ``SearchEngine`` from an ArchSpec JSON string, **without

--- a/crates/bloqade-lanes-bytecode-python/src/target_generator_dsl_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/target_generator_dsl_python.rs
@@ -27,12 +27,12 @@ pub struct PyTargetPolicyRunner {
 impl PyTargetPolicyRunner {
     #[new]
     #[pyo3(signature = (policy_path, arch_spec))]
-    fn new(policy_path: &str, arch_spec: PyRef<'_, PyArchSpec>) -> PyResult<Self> {
+    fn new(policy_path: &str, arch_spec: PyRef<'_, PyArchSpec>, py: Python<'_>) -> PyResult<Self> {
         let cfg = SandboxConfig::default();
         let inner = TargetPolicyRunner::from_path(policy_path, &cfg).map_err(map_err)?;
         Ok(Self {
             inner,
-            index: Arc::new(LaneIndex::from_arch_spec(&arch_spec.inner)),
+            index: Arc::new(crate::errors::validated_lane_index(py, &arch_spec.inner)?),
         })
     }
 

--- a/crates/bloqade-lanes-search/src/drivers/entropy.rs
+++ b/crates/bloqade-lanes-search/src/drivers/entropy.rs
@@ -3483,3 +3483,61 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod chain_assembly {
+    use super::*;
+    use crate::primitives::distance::DistanceTable;
+    use crate::test_utils::loc;
+    use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+    use std::collections::HashSet;
+
+    /// The entropy driver serialized conveyor chains before #887: it emitted
+    /// only the follower's single-lane move because rectangle growth discarded
+    /// the leader. With growth repairing the chain, both hops ride in one
+    /// candidate — and it outranks the follower-only option, since its score
+    /// is the sum of both entries'.
+    #[test]
+    fn entropy_generates_a_chain_candidate() {
+        let spec: ArchSpec = serde_json::from_str(&crate::test_utils::chain_arch_json()).unwrap();
+        let index = LaneIndex::new(spec);
+        let config = Config::new([(0, loc(0, 0)), (1, loc(0, 1))]).unwrap();
+        let target_encoded = vec![(0u32, loc(0, 1).encode()), (1u32, loc(0, 2).encode())];
+        let target_locs: Vec<u64> = target_encoded.iter().map(|&(_, e)| e).collect();
+        let dist_table = DistanceTable::new(&target_locs, &index);
+        let blocked = HashSet::new();
+        let ctx = SearchContext {
+            index: &index,
+            dist_table: &dist_table,
+            blocked: &blocked,
+            targets: &target_encoded,
+            cz_pairs: None,
+        };
+        let params = EntropyParams {
+            max_movesets_per_group: 16,
+            ..EntropyParams::default()
+        };
+
+        let out = generate_candidates(&config, 1, &params, &ctx, 0, None);
+        let chain = out.iter().find(|c| {
+            c.new_config.location_of(0) == Some(loc(0, 1))
+                && c.new_config.location_of(1) == Some(loc(0, 2))
+        });
+        assert!(
+            chain.is_some(),
+            "entropy must offer the one-shot chain; got {:?}",
+            out.iter()
+                .map(|c| (
+                    c.move_set.len(),
+                    c.new_config.location_of(0).map(|l| l.site_id),
+                    c.new_config.location_of(1).map(|l| l.site_id),
+                ))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            chain.expect("checked above").move_set.len(),
+            2,
+            "the chain must be a single two-lane operation"
+        );
+    }
+}

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -748,18 +748,15 @@ mod tests {
         );
     }
 
-    /// Documents a **known gap** (issue #887): admitting
-    /// chain candidates is necessary but not sufficient — the heuristic
-    /// selection still picks movers independently, so it does not co-select
-    /// the atom ahead and never assembles the chain into one AOD shot. Here it
-    /// emits only the follower's move; the leader waits for the next step, so
-    /// routing stays correct but takes two operations instead of one.
+    /// Chains now assemble into a single AOD shot (issue #887).
     ///
-    /// `ExhaustiveGenerator` *does* assemble this chain (see
-    /// `generate_admits_conveyor_chain`) because it enumerates every
-    /// rectangle rather than selecting greedily.
+    /// Selection still picks movers independently — nothing here co-selects
+    /// the atom ahead. What changed is one layer down: rectangle growth
+    /// repairs a chain by pulling in the follower's cell, so both hops ride in
+    /// one move set. Previously only the follower's move was emitted, leaving
+    /// the leader to wait a step.
     #[test]
-    fn heuristic_selection_does_not_yet_assemble_chains() {
+    fn heuristic_selection_assembles_chains() {
         let index = make_chain_index();
         // q0: site 0 → 1 (occupied by q1), q1: site 1 → 2 (free).
         let config = Config::new([(0, loc(0, 0)), (1, loc(0, 1))]).unwrap();
@@ -779,15 +776,12 @@ mod tests {
                 && c.new_config.location_of(1) == Some(loc(0, 2))
         });
         assert!(
-            !shifts_both,
-            "chain assembly is not implemented yet — if this now passes, the \
-             follow-up landed and this test should assert the chain instead"
+            shifts_both,
+            "both atoms must shift along the chain in one move set; got {:?}",
+            out.iter()
+                .map(|c| (c.new_config.location_of(0), c.new_config.location_of(1)))
+                .collect::<Vec<_>>()
         );
-        // The follower's move is still generated, so the search makes progress.
-        let follower_moves = out
-            .iter()
-            .any(|c| c.new_config.location_of(1) == Some(loc(0, 2)));
-        assert!(follower_moves, "the unobstructed atom must still move");
     }
 
     fn make_ctx<'a>(

--- a/crates/bloqade-lanes-search/src/ops/aod_grid.rs
+++ b/crates/bloqade-lanes-search/src/ops/aod_grid.rs
@@ -320,18 +320,17 @@ impl<'a> BusGridContext<'a> {
     ) -> bool {
         // Grow in place and undo exactly what we inserted, rather than
         // snapshotting the sets: this is the hottest loop in candidate
-        // generation, and the three buffers below stay unallocated unless a
+        // generation. The requested point is tracked in a bool, exactly as it
+        // was before repairs existed, so the allocation-free rollback #882
+        // tuned for still holds on the common path. The buffers below record
+        // only *repair-induced* inserts, so they stay unallocated unless a
         // chain actually needs repairing — which cannot happen on an
         // endpoint-disjoint bus, so the shipped specs pay nothing for this.
+        let inserted_x = xs.insert(x);
+        let inserted_y = ys.insert(y);
         let mut added_x: Vec<u64> = Vec::new();
         let mut added_y: Vec<u64> = Vec::new();
         let mut repairs: Vec<u64> = Vec::new();
-        if xs.insert(x) {
-            added_x.push(x);
-        }
-        if ys.insert(y) {
-            added_y.push(y);
-        }
 
         loop {
             repairs.clear();
@@ -367,10 +366,16 @@ impl<'a> BusGridContext<'a> {
             }
         }
 
-        for x in added_x {
+        for rx in added_x {
+            xs.remove(&rx);
+        }
+        for ry in added_y {
+            ys.remove(&ry);
+        }
+        if inserted_x {
             xs.remove(&x);
         }
-        for y in added_y {
+        if inserted_y {
             ys.remove(&y);
         }
         false

--- a/crates/bloqade-lanes-search/src/ops/aod_grid.rs
+++ b/crates/bloqade-lanes-search/src/ops/aod_grid.rs
@@ -3,6 +3,11 @@
 //! Ports the Python `BusContext.build_aod_grids()` algorithm: a greedy
 //! sequential pass forms initial rectangular clusters, then an iterative
 //! merge pass combines compatible clusters into larger rectangles.
+//!
+//! The rectangles this module produces are **alternative candidates** — the
+//! search takes one per step — rather than a schedule of operations to run
+//! together. See [`BusGridContext::build_aod_grids`] for the full contract,
+//! including why they neither cover every mover nor stay disjoint.
 
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -17,6 +22,22 @@ use crate::primitives::lane_index::LaneIndex;
 /// The rectangle covers the Cartesian product X × Y.
 /// Coordinates are stored as `f64::to_bits()` for cheap equality.
 type Cluster = (BTreeSet<u64>, BTreeSet<u64>);
+
+/// Whether a rectangle is executable, and if not, whether *growing* it could
+/// make it so. See [`BusGridContext::rect_outcome`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RectOutcome {
+    /// Every cell satisfies both occupancy rules.
+    Valid,
+    /// Fails only because some destination's occupant moves in this group but
+    /// its own cell lies outside the rectangle. Pulling those cells in may
+    /// repair it — this is the conveyor-chain case.
+    Repairable,
+    /// Fails for a reason growth cannot fix: an unresolvable cell, a
+    /// stationary atom on a filler source, or a destination held by an atom
+    /// that does not move at all.
+    Invalid,
+}
 
 /// The execution model's **uniform destination rule** (issue #866): a lane's
 /// destination is available when it is unoccupied, or when its occupant is
@@ -111,6 +132,33 @@ impl<'a> BusGridContext<'a> {
     /// The destination half of that is [`destination_is_available`]'s rule,
     /// specialized here to a lazily-built sorted source index for speed.
     fn is_valid_rect(&self, xs: &BTreeSet<u64>, ys: &BTreeSet<u64>, movers: &HashSet<u64>) -> bool {
+        matches!(self.rect_outcome(xs, ys, movers, None), RectOutcome::Valid)
+    }
+
+    /// Validate the X × Y rectangle, distinguishing failures that *growing* the
+    /// rectangle could repair from those it never could.
+    ///
+    /// The distinction exists because this predicate is **non-monotone**: the
+    /// destination rule exempts an occupied destination whose occupant is one
+    /// of *this rectangle's own* moving sources, so adding cells can turn an
+    /// invalid rectangle valid. A conveyor chain is exactly that case — the
+    /// leader's cell alone is invalid because the follower is not yet a source
+    /// of the rectangle. (Growth can never invalidate an already-passing cell:
+    /// the source rule and cell resolution are per-cell, and the only
+    /// rectangle-dependent term, the source set, only grows.)
+    ///
+    /// When `repairs` is `Some`, the encoded source locations whose cells would
+    /// supply the missing exemptions are appended to it — those are the
+    /// positions [`Self::try_add_point`] pulls in. Passing `None` keeps the hot
+    /// path allocation-free and early-exiting, which is what
+    /// [`Self::is_valid_rect`] does.
+    fn rect_outcome(
+        &self,
+        xs: &BTreeSet<u64>,
+        ys: &BTreeSet<u64>,
+        movers: &HashSet<u64>,
+        mut repairs: Option<&mut Vec<u64>>,
+    ) -> RectOutcome {
         // Resolve every cell's (src, dst) once into a reused scratch buffer.
         let mut cells = self.cells_scratch.borrow_mut();
         cells.clear();
@@ -118,10 +166,10 @@ impl<'a> BusGridContext<'a> {
         for &x in xs {
             for &y in ys {
                 let Some(&src_enc) = self.maps.pos_to_src.get(&(x, y)) else {
-                    return false;
+                    return RectOutcome::Invalid;
                 };
                 let Some(&dst_enc) = self.maps.src_to_dst.get(&src_enc) else {
-                    return false;
+                    return RectOutcome::Invalid;
                 };
                 cells.push((src_enc, dst_enc));
             }
@@ -135,13 +183,15 @@ impl<'a> BusGridContext<'a> {
         // binary search instead of a nested scan.
         let mut srcs = self.srcs_scratch.borrow_mut();
         let mut srcs_ready = false;
+        let mut repairable = false;
 
         for &(src_enc, dst_enc) in cells.iter() {
             if !movers.contains(&src_enc) && self.occupied_locs.contains(&src_enc) {
-                return false;
+                return RectOutcome::Invalid;
             }
             if self.occupied_locs.contains(&dst_enc) {
-                let dst_is_rect_mover = movers.contains(&dst_enc) && {
+                let occupant_moves = movers.contains(&dst_enc);
+                let in_rect = occupant_moves && {
                     if !srcs_ready {
                         srcs.clear();
                         srcs.extend(cells.iter().map(|&(s, _)| s));
@@ -150,12 +200,29 @@ impl<'a> BusGridContext<'a> {
                     }
                     srcs.binary_search(&dst_enc).is_ok()
                 };
-                if !dst_is_rect_mover {
-                    return false;
+                if in_rect {
+                    continue;
+                }
+                // The occupant moves, but its own cell is outside this
+                // rectangle: pulling that cell in would satisfy the rule.
+                // Anything else is a stationary atom in the way, which no
+                // amount of growth can fix.
+                match (occupant_moves, repairs.as_deref_mut()) {
+                    (true, Some(out)) => {
+                        repairable = true;
+                        out.push(dst_enc);
+                    }
+                    (true, None) => return RectOutcome::Repairable,
+                    (false, _) => return RectOutcome::Invalid,
                 }
             }
         }
-        true
+
+        if repairable {
+            RectOutcome::Repairable
+        } else {
+            RectOutcome::Valid
+        }
     }
 
     /// Convert a cluster's X × Y rectangle to a vector of encoded lane addresses.
@@ -176,10 +243,43 @@ impl<'a> BusGridContext<'a> {
     /// Build AOD-compatible rectangular grids from scored entry lanes.
     ///
     /// `entries` maps `encoded_src → encoded_lane` for the scored/selected
-    /// moving atoms. Returned grids may also include empty filler lanes so each
-    /// lane set remains a complete AOD rectangle.
+    /// moving atoms. Each returned lane set is a complete X × Y rectangle on
+    /// this one bus group: an AOD addresses rows and columns independently, so
+    /// selecting a column drives it at *every* selected row. Empty **filler
+    /// lanes** are therefore included where needed to complete the product —
+    /// they carry no atom but let a rectangle grow to cover more movers.
     ///
-    /// Returns a list of lane sets, each forming a valid AOD rectangle.
+    /// # What the result is, precisely
+    ///
+    /// The returned rectangles are **alternatives**, not a schedule. Every
+    /// caller turns each rectangle into its own search candidate — one edge out
+    /// of the current node — and the search picks *one*. They are not steps to
+    /// execute together.
+    ///
+    /// Two properties are worth stating because neither is guaranteed, and the
+    /// original design intent was that both would be:
+    ///
+    /// - **Not a complete covering.** A mover that cannot sit in any valid
+    ///   rectangle — its destination is held by a stationary atom, say — is
+    ///   silently omitted. `greedy_init` stops once a pass places nothing new,
+    ///   dropping whatever is left.
+    /// - **Not pairwise disjoint** (since issue #887). Repairing a chain pulls
+    ///   the blocking mover's cell into the rectangle being grown, even when an
+    ///   earlier rectangle already covered that mover, so the same atom may
+    ///   appear in several alternatives. Under alternatives semantics that is
+    ///   harmless — it simply means the atom has several possible moves — but
+    ///   it does mean the rectangles no longer partition the movers.
+    ///
+    /// # If you want to execute several rectangles together
+    ///
+    /// Parallelising across bus groups needs the chosen rectangles to be
+    /// **atom-disjoint**, or the same atom is picked up by two AOD operations
+    /// at once. This output does not provide that, and it cannot be obtained by
+    /// filtering: removing an atom from a rectangle may break the Cartesian
+    /// product *and* strip an exemption another cell depended on (dropping a
+    /// chain's follower invalidates its leader). Such a caller must therefore
+    /// *regenerate* with the reserved atoms treated as immovable from the
+    /// start, rather than subtracting them afterwards.
     pub(crate) fn build_aod_grids(&self, entries: &HashMap<u64, u64>) -> Vec<Vec<u64>> {
         if entries.is_empty() {
             return Vec::new();
@@ -196,6 +296,84 @@ impl<'a> BusGridContext<'a> {
             .map(|(xs, ys)| self.rect_to_lanes(xs, ys))
             .filter(|lanes| !lanes.is_empty())
             .collect()
+    }
+
+    /// Grow the rectangle to cover `(x, y)`, pulling in whatever else that
+    /// requires, and report whether it stayed executable.
+    ///
+    /// Adding a point is never adding one cell: the rectangle is the complete
+    /// Cartesian product, so a new column is driven at every selected row and
+    /// vice versa. Every forced cell is validated, and when the only failures
+    /// are destinations whose occupants move in this group, those occupants'
+    /// own cells are pulled in too — repeating to a fixpoint, since each
+    /// repair can force further cells of its own.
+    ///
+    /// Terminates because every iteration adds at least one new coordinate to
+    /// a finite set, and rolls the rectangle back untouched on failure.
+    fn try_add_point(
+        &self,
+        xs: &mut BTreeSet<u64>,
+        ys: &mut BTreeSet<u64>,
+        movers: &HashSet<u64>,
+        x: u64,
+        y: u64,
+    ) -> bool {
+        // Grow in place and undo exactly what we inserted, rather than
+        // snapshotting the sets: this is the hottest loop in candidate
+        // generation, and the three buffers below stay unallocated unless a
+        // chain actually needs repairing — which cannot happen on an
+        // endpoint-disjoint bus, so the shipped specs pay nothing for this.
+        let mut added_x: Vec<u64> = Vec::new();
+        let mut added_y: Vec<u64> = Vec::new();
+        let mut repairs: Vec<u64> = Vec::new();
+        if xs.insert(x) {
+            added_x.push(x);
+        }
+        if ys.insert(y) {
+            added_y.push(y);
+        }
+
+        loop {
+            repairs.clear();
+            match self.rect_outcome(xs, ys, movers, Some(&mut repairs)) {
+                RectOutcome::Valid => return true,
+                RectOutcome::Invalid => break,
+                RectOutcome::Repairable => {
+                    // Pull in each blocking occupant's own cell. If no repair
+                    // adds a coordinate we lack, the rectangle cannot
+                    // converge and we stop.
+                    let mut grew = false;
+                    for src_enc in repairs.iter() {
+                        let Some(&(rx, ry)) = self.maps.src_to_pos.get(src_enc) else {
+                            // The occupant moves on this bus but has no
+                            // position in this grid (another zone or bus
+                            // group), so its cell can never join.
+                            grew = false;
+                            break;
+                        };
+                        if xs.insert(rx) {
+                            added_x.push(rx);
+                            grew = true;
+                        }
+                        if ys.insert(ry) {
+                            added_y.push(ry);
+                            grew = true;
+                        }
+                    }
+                    if !grew {
+                        break;
+                    }
+                }
+            }
+        }
+
+        for x in added_x {
+            xs.remove(&x);
+        }
+        for y in added_y {
+            ys.remove(&y);
+        }
+        false
     }
 
     /// Form initial clusters via greedy sequential expansion.
@@ -225,18 +403,7 @@ impl<'a> BusGridContext<'a> {
                     continue;
                 }
 
-                // Tentatively grow the rectangle in place; roll back on an
-                // invalid result. Equivalent to validating a cloned copy,
-                // without the two BTreeSet clones per entry.
-                let inserted_x = xs.insert(x);
-                let inserted_y = ys.insert(y);
-                if !self.is_valid_rect(&xs, &ys, movers) {
-                    if inserted_x {
-                        xs.remove(&x);
-                    }
-                    if inserted_y {
-                        ys.remove(&y);
-                    }
+                if !self.try_add_point(&mut xs, &mut ys, movers, x, y) {
                     leftover.push((src_enc, lane_enc));
                 }
             }
@@ -356,31 +523,428 @@ mod tests {
         );
     }
 
-    /// **Known gap (issue #887).** `greedy_init` grows a rectangle one entry at
-    /// a time and sets aside any entry whose *intermediate* rectangle is
-    /// invalid. For a chain the intermediate state is exactly what fails: the
-    /// leader is rejected before the follower is ever added, so the valid
-    /// 2-cell rectangle is never tried.
+    /// Growth repairs the chain (issue #887): the leader's cell is invalid on
+    /// its own, so `try_add_point` pulls in the follower's cell — the exact
+    /// thing that supplies the missing exemption — and the complete rectangle
+    /// is emitted as one AOD shot.
     ///
-    /// The ordering is the fix: feeding entries follower-first (reverse
-    /// topological order along the bus relation, which #874 guarantees is
-    /// acyclic) makes each intermediate rectangle valid. Endpoint-disjoint
-    /// buses have no chains, so their entry order — and behavior — is
-    /// unaffected either way.
+    /// Before the repair closure, `greedy_init` set the leader aside the
+    /// moment its *intermediate* rectangle failed, and only the follower's
+    /// single-cell rectangle survived.
     #[test]
-    fn greedy_init_cannot_assemble_a_chain_rectangle() {
+    fn greedy_init_assembles_a_chain_rectangle() {
         let ctx = chain_context();
         let entries: HashMap<u64, u64> = [(10u64, 101u64), (20, 102)].into_iter().collect();
         let grids = ctx.build_aod_grids(&entries);
-        let assembled_chain = grids.iter().any(|g| g.contains(&101) && g.contains(&102));
-        assert!(
-            !assembled_chain,
-            "if this now passes, chain assembly landed (#887) — assert the \
-             chain is emitted instead"
+        assert_eq!(grids.len(), 1, "expected one rectangle: {grids:?}");
+        let mut lanes = grids[0].clone();
+        lanes.sort_unstable();
+        assert_eq!(
+            lanes,
+            vec![101, 102],
+            "both chain hops must ride in one rectangle"
         );
-        // Only the follower's own single-cell rectangle survives.
-        assert_eq!(grids.len(), 1);
-        assert_eq!(grids[0], vec![102]);
+    }
+
+    /// The repair is not a blanket pass for occupied destinations: it only
+    /// fires when the occupant actually moves in this group. Here the atom
+    /// ahead has no lane at all, so no amount of growth helps and the
+    /// rectangle is rejected outright.
+    #[test]
+    fn growth_does_not_repair_a_stationary_blocker() {
+        const A: u64 = 10;
+        const B: u64 = 20;
+        const C: u64 = 30;
+        // Same geometry as `chain_context`, but B is occupied by an atom that
+        // is *not* offered as a mover.
+        let ctx = make_context_with_endpoints(
+            &[((0, 0), A), ((1, 0), B)],
+            &[(A, 101, B), (B, 102, C)],
+            &[A, B],
+        );
+        // Only A is a mover; B stays put.
+        let entries: HashMap<u64, u64> = [(A, 101u64)].into_iter().collect();
+        let grids = ctx.build_aod_grids(&entries);
+        assert!(
+            grids.is_empty(),
+            "landing on a stationary atom must stay rejected: {grids:?}"
+        );
+    }
+
+    /// Sorted lanes of every emitted grid, for order-insensitive assertions.
+    fn sorted_grids(grids: &[Vec<u64>]) -> Vec<Vec<u64>> {
+        let mut out: Vec<Vec<u64>> = grids
+            .iter()
+            .map(|g| {
+                let mut g = g.clone();
+                g.sort_unstable();
+                g
+            })
+            .collect();
+        out.sort();
+        out
+    }
+
+    /// A three-hop chain `a→b→c→d` with atoms on a, b and c. Repair has to
+    /// cascade twice: pulling in b exposes b's own blocked destination, which
+    /// pulls in c.
+    #[test]
+    fn growth_repairs_a_three_hop_chain() {
+        const A: u64 = 10;
+        const B: u64 = 20;
+        const C: u64 = 30;
+        const D: u64 = 40;
+        let ctx = make_context_with_endpoints(
+            &[((0, 0), A), ((1, 0), B), ((2, 0), C)],
+            &[(A, 101, B), (B, 102, C), (C, 103, D)],
+            &[A, B, C],
+        );
+        let entries: HashMap<u64, u64> = [(A, 101u64), (B, 102), (C, 103)].into_iter().collect();
+        assert_eq!(
+            sorted_grids(&ctx.build_aod_grids(&entries)),
+            vec![vec![101, 102, 103]],
+            "all three hops must ride in one rectangle"
+        );
+    }
+
+    /// The outcome must not depend on the order entries happen to be visited
+    /// in: a chain assembles whether the leader or the follower is seen first.
+    #[test]
+    fn chain_assembly_is_entry_order_independent() {
+        const A: u64 = 10;
+        const B: u64 = 20;
+        const C: u64 = 30;
+        let ctx = make_context_with_endpoints(
+            &[((0, 0), A), ((1, 0), B)],
+            &[(A, 101, B), (B, 102, C)],
+            &[A, B],
+        );
+        // `entries` is a HashMap, so build both insertion orders explicitly.
+        let leader_first: HashMap<u64, u64> = [(A, 101u64), (B, 102)].into_iter().collect();
+        let follower_first: HashMap<u64, u64> = [(B, 102u64), (A, 101)].into_iter().collect();
+        assert_eq!(
+            sorted_grids(&ctx.build_aod_grids(&leader_first)),
+            sorted_grids(&ctx.build_aod_grids(&follower_first))
+        );
+        assert_eq!(
+            sorted_grids(&ctx.build_aod_grids(&leader_first)),
+            vec![vec![101, 102]]
+        );
+    }
+
+    /// A chain whose *head* is blocked by a stationary atom cannot move at
+    /// all: the cascade reaches the head, finds a non-mover in the way, and
+    /// unwinds. No partial rectangle may be emitted — a partial one would
+    /// drive the trailing atoms into their neighbours.
+    #[test]
+    fn a_blocked_head_rejects_the_whole_chain() {
+        const A: u64 = 10;
+        const B: u64 = 20;
+        const C: u64 = 30;
+        const D: u64 = 40;
+        let ctx = make_context_with_endpoints(
+            &[((0, 0), A), ((1, 0), B), ((2, 0), C)],
+            &[(A, 101, B), (B, 102, C), (C, 103, D)],
+            // D is occupied by an atom that is never offered as a mover.
+            &[A, B, C, D],
+        );
+        let entries: HashMap<u64, u64> = [(A, 101u64), (B, 102), (C, 103)].into_iter().collect();
+        assert!(
+            ctx.build_aod_grids(&entries).is_empty(),
+            "a chain with nowhere to go must emit nothing"
+        );
+    }
+
+    /// An independent mover on the same row simply extends the rectangle:
+    /// adding its column forces only its own cell, which is free.
+    #[test]
+    fn a_compatible_extra_point_joins_the_chain_rectangle() {
+        const A: u64 = 10;
+        const B: u64 = 20;
+        const C: u64 = 30;
+        const E: u64 = 50;
+        const F: u64 = 60;
+        let ctx = make_context_with_endpoints(
+            &[((0, 0), A), ((1, 0), B), ((2, 0), E)],
+            &[(A, 101, B), (B, 102, C), (E, 104, F)],
+            &[A, B, E],
+        );
+        let entries: HashMap<u64, u64> = [(A, 101u64), (B, 102), (E, 104)].into_iter().collect();
+        assert_eq!(
+            sorted_grids(&ctx.build_aod_grids(&entries)),
+            vec![vec![101, 102, 104]],
+            "an unobstructed neighbour rides along in the same shot"
+        );
+    }
+
+    /// **Cascade** — the case a reverse-topological *sort* would get wrong.
+    ///
+    /// Two rows. Repairing the leader in row 0 pulls in column 1, which forces
+    /// the cell at (1, row 1) as well; that cell's own destination is occupied
+    /// by a third mover, forcing column 2, and so on. The rectangle only
+    /// becomes valid once the whole cascade is resolved, which is why the fix
+    /// has to iterate to a fixpoint rather than just order the entries.
+    #[test]
+    fn growth_repairs_a_multi_row_cascade() {
+        // Row 0: a0 → b0 → c0.  Row 1: a1 → b1 → c1.
+        // Atoms sit on a0, b0, a1, b1; the c column is free.
+        const A0: u64 = 10;
+        const B0: u64 = 20;
+        const C0: u64 = 30;
+        const A1: u64 = 11;
+        const B1: u64 = 21;
+        const C1: u64 = 31;
+        let ctx = make_context_with_endpoints(
+            &[((0, 0), A0), ((1, 0), B0), ((0, 1), A1), ((1, 1), B1)],
+            &[(A0, 101, B0), (B0, 102, C0), (A1, 111, B1), (B1, 112, C1)],
+            &[A0, B0, A1, B1],
+        );
+
+        // Offer only the two leaders first in iteration order; the followers
+        // must be pulled in by the repair loop, in both rows.
+        let entries: HashMap<u64, u64> = [(A0, 101u64), (B0, 102), (A1, 111), (B1, 112)]
+            .into_iter()
+            .collect();
+        let grids = ctx.build_aod_grids(&entries);
+        assert_eq!(grids.len(), 1, "expected one 2×2 rectangle: {grids:?}");
+        let mut lanes = grids[0].clone();
+        lanes.sort_unstable();
+        assert_eq!(
+            lanes,
+            vec![101, 102, 111, 112],
+            "every cell of the 2×2 rectangle must ride together"
+        );
+    }
+
+    /// A wider cascade: three columns × two rows, every row a chain. Repairing
+    /// row 0 drags in columns that force row 1's cells, which need repairs of
+    /// their own — the closure has to settle all six cells at once.
+    #[test]
+    fn growth_repairs_a_three_by_two_cascade() {
+        // Row 0: a0→b0→c0→(free).  Row 1: a1→b1→c1→(free).
+        let (a0, b0, c0, free0) = (10u64, 20, 30, 40);
+        let (a1, b1, c1, free1) = (11u64, 21, 31, 41);
+        let ctx = make_context_with_endpoints(
+            &[
+                ((0, 0), a0),
+                ((1, 0), b0),
+                ((2, 0), c0),
+                ((0, 1), a1),
+                ((1, 1), b1),
+                ((2, 1), c1),
+            ],
+            &[
+                (a0, 101, b0),
+                (b0, 102, c0),
+                (c0, 103, free0),
+                (a1, 111, b1),
+                (b1, 112, c1),
+                (c1, 113, free1),
+            ],
+            &[a0, b0, c0, a1, b1, c1],
+        );
+        let entries: HashMap<u64, u64> = [
+            (a0, 101u64),
+            (b0, 102),
+            (c0, 103),
+            (a1, 111),
+            (b1, 112),
+            (c1, 113),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            sorted_grids(&ctx.build_aod_grids(&entries)),
+            vec![vec![101, 102, 103, 111, 112, 113]],
+            "all six cells of the 3×2 rectangle must ride together"
+        );
+    }
+
+    /// An extra mover whose column has **no site in the second row** cannot
+    /// join a two-row rectangle: the forced cell does not resolve. It must be
+    /// rolled back cleanly and end up in its own cluster, leaving the chain
+    /// rectangle intact — a non-fitting point must never corrupt or block the
+    /// chain that already assembled.
+    #[test]
+    fn a_point_that_cannot_fit_gets_its_own_cluster() {
+        let (a0, b0, c0) = (10u64, 20, 30);
+        let (a1, b1, c1) = (11u64, 21, 31);
+        // `e` sits at column 2 of row 0 only — there is no position at (2, 1),
+        // so widening the 2-row rectangle to include it leaves a hole.
+        let (e, f) = (50u64, 60);
+        let ctx = make_context_with_endpoints(
+            &[
+                ((0, 0), a0),
+                ((1, 0), b0),
+                ((0, 1), a1),
+                ((1, 1), b1),
+                ((2, 0), e),
+            ],
+            &[
+                (a0, 101, b0),
+                (b0, 102, c0),
+                (a1, 111, b1),
+                (b1, 112, c1),
+                (e, 104, f),
+            ],
+            &[a0, b0, a1, b1, e],
+        );
+        let entries: HashMap<u64, u64> = [(a0, 101u64), (b0, 102), (a1, 111), (b1, 112), (e, 104)]
+            .into_iter()
+            .collect();
+
+        let grids = sorted_grids(&ctx.build_aod_grids(&entries));
+        assert!(
+            grids.contains(&vec![101, 102, 111, 112]),
+            "the 2×2 chain must still assemble: {grids:?}"
+        );
+        assert!(
+            grids.contains(&vec![104]),
+            "the non-fitting mover must still get its own rectangle: {grids:?}"
+        );
+        assert_eq!(grids.len(), 2, "and nothing else: {grids:?}");
+    }
+
+    /// Two chains on different rows *and* different columns cannot share a
+    /// rectangle — the Cartesian product would demand cells that do not
+    /// exist — so each becomes its own AOD operation. This is the limit of
+    /// what one shot can batch: chains combine only when their rows and
+    /// columns line up into a full grid.
+    #[test]
+    fn two_misaligned_chains_form_separate_rectangles() {
+        // Row 0 chain occupies columns 0–1; row 1 chain occupies columns 2–3.
+        let (a0, b0, free0) = (10u64, 20, 30);
+        let (a1, b1, free1) = (11u64, 21, 31);
+        let ctx = make_context_with_endpoints(
+            &[((0, 0), a0), ((1, 0), b0), ((2, 1), a1), ((3, 1), b1)],
+            &[
+                (a0, 101, b0),
+                (b0, 102, free0),
+                (a1, 111, b1),
+                (b1, 112, free1),
+            ],
+            &[a0, b0, a1, b1],
+        );
+        let entries: HashMap<u64, u64> = [(a0, 101u64), (b0, 102), (a1, 111), (b1, 112)]
+            .into_iter()
+            .collect();
+        assert_eq!(
+            sorted_grids(&ctx.build_aod_grids(&entries)),
+            vec![vec![101, 102], vec![111, 112]],
+            "misaligned chains cannot share one rectangle"
+        );
+    }
+
+    /// A repair may pull in a mover that an **earlier cluster already claimed**.
+    /// That is legal and intended: each rectangle is an *alternative* candidate
+    /// the search chooses between, not a step executed alongside the others, so
+    /// the same atom may appear in several of them.
+    ///
+    /// Here the follower `b` first joins a rectangle with `p` (a neighbour in
+    /// its own column), and is then pulled into a second rectangle when the
+    /// leader `a` — set aside in the first pass — repairs itself.
+    #[test]
+    fn a_repair_may_reuse_a_mover_from_an_earlier_cluster() {
+        // Visit order is by encoded source, so p (5) is seen before a (10).
+        let (p, p_dst) = (5u64, 55);
+        let (a, b, c) = (10u64, 20, 30);
+        let ctx = make_context_with_endpoints(
+            // (0,1) is a hole: no site there, so no rectangle may span both
+            // column 0 and row 1.
+            &[((1, 1), p), ((0, 0), a), ((1, 0), b)],
+            &[(p, 105, p_dst), (a, 101, b), (b, 102, c)],
+            &[p, a, b],
+        );
+        let entries: HashMap<u64, u64> = [(p, 105u64), (a, 101), (b, 102)].into_iter().collect();
+
+        let grids = sorted_grids(&ctx.build_aod_grids(&entries));
+        assert!(
+            grids.contains(&vec![102, 105]),
+            "b should first ride with p: {grids:?}"
+        );
+        assert!(
+            grids.contains(&vec![101, 102]),
+            "and b's cell is reused when a repairs itself: {grids:?}"
+        );
+        assert_eq!(grids.len(), 2, "exactly two alternatives: {grids:?}");
+    }
+
+    /// The result is **not a covering**: a mover that fits in no valid
+    /// rectangle is silently dropped rather than emitted alone or reported.
+    /// Callers that assume every offered mover comes back in some rectangle
+    /// would be wrong — the search relies on this only as a source of
+    /// candidates, so an unplaceable atom simply yields no candidate for it.
+    #[test]
+    fn unplaceable_movers_are_omitted_not_reported() {
+        let (a, b) = (10u64, 20);
+        let (e, f) = (50u64, 60);
+        let ctx = make_context_with_endpoints(
+            &[((0, 0), a), ((1, 0), e)],
+            &[(a, 101, b), (e, 104, f)],
+            // `b` is free so `a` can move; `f` holds a stationary atom, so `e`
+            // is stuck no matter how the rectangle grows.
+            &[a, e, f],
+        );
+        let entries: HashMap<u64, u64> = [(a, 101u64), (e, 104)].into_iter().collect();
+
+        let grids = sorted_grids(&ctx.build_aod_grids(&entries));
+        assert_eq!(
+            grids,
+            vec![vec![101]],
+            "the movable atom is offered; the stuck one vanishes silently"
+        );
+    }
+
+    /// **Limit of the algorithm, documented deliberately.** The grid layer has
+    /// no acyclicity check: handed a *rotation* (`a→b, b→a`, both occupied) it
+    /// assembles it happily, because each atom's destination is vacated by the
+    /// other in the same shot — locally the rule is satisfied.
+    ///
+    /// Nothing here prevents that; what prevents it is `ArchSpec::validate`
+    /// rejecting cyclic buses outright (#874), so a rotation can never reach
+    /// this code from a legal spec. This test exists to make that dependency
+    /// visible: if the arch-level check were ever weakened, the search would
+    /// silently emit physically impossible rotations rather than failing.
+    #[test]
+    fn the_grid_layer_relies_on_arch_level_acyclicity() {
+        const A: u64 = 10;
+        const B: u64 = 20;
+        let ctx = make_context_with_endpoints(
+            &[((0, 0), A), ((1, 0), B)],
+            // A rotation: a→b and b→a.
+            &[(A, 101, B), (B, 102, A)],
+            &[A, B],
+        );
+        let entries: HashMap<u64, u64> = [(A, 101u64), (B, 102)].into_iter().collect();
+        assert_eq!(
+            sorted_grids(&ctx.build_aod_grids(&entries)),
+            vec![vec![101, 102]],
+            "the grid layer cannot tell a rotation from a chain — #874 must"
+        );
+    }
+
+    /// The same question from the other direction: an extra mover that *is*
+    /// geometrically compatible but whose destination is held by a stationary
+    /// atom. Growth cannot repair it, so it must be rolled back without
+    /// disturbing the chain — and must not be emitted on its own either.
+    #[test]
+    fn a_blocked_extra_point_does_not_disturb_the_chain() {
+        let (a, b, c) = (10u64, 20, 30);
+        let (e, f) = (50u64, 60);
+        let ctx = make_context_with_endpoints(
+            &[((0, 0), a), ((1, 0), b), ((2, 0), e)],
+            &[(a, 101, b), (b, 102, c), (e, 104, f)],
+            // `f` holds a stationary atom, so `e` has nowhere to go.
+            &[a, b, e, f],
+        );
+        let entries: HashMap<u64, u64> = [(a, 101u64), (b, 102), (e, 104)].into_iter().collect();
+
+        let grids = sorted_grids(&ctx.build_aod_grids(&entries));
+        assert_eq!(
+            grids,
+            vec![vec![101, 102]],
+            "the chain assembles; the blocked mover is dropped, not batched"
+        );
     }
 
     /// Helper: build a BusGridContext from raw position/lane/collision data.

--- a/crates/bloqade-lanes-search/src/ops/aod_grid.rs
+++ b/crates/bloqade-lanes-search/src/ops/aod_grid.rs
@@ -577,6 +577,119 @@ mod tests {
     }
 
     /// Sorted lanes of every emitted grid, for order-insensitive assertions.
+    /// **Shadowed occupant, repairable-looking but unrepairable.**
+    ///
+    /// `pos_to_src` deliberately tolerates two sources at one grid position
+    /// (last-insert-wins — the `full.json` fixture stacks every word at
+    /// identical coordinates). Repair works in *position* space: it looks up
+    /// the blocking occupant's `(x, y)` and pulls those coordinates in. When
+    /// another source won that position, the new cell resolves to the winner
+    /// and the occupant still never becomes a rectangle source — so the same
+    /// repair is requested again from an unchanged rectangle.
+    ///
+    /// The `grew` guard is what stops that: a repair round that adds no new
+    /// coordinate abandons the rectangle. Reaching any assertion below is
+    /// itself the termination proof; a regression here hangs rather than
+    /// fails.
+    #[test]
+    fn repair_gives_up_when_the_occupants_cell_is_shadowed() {
+        const A: u64 = 10;
+        const B: u64 = 20;
+        const C: u64 = 30;
+        const D: u64 = 40;
+        const E: u64 = 50;
+        // B and C share position (1, 0); C is inserted last, so the cell there
+        // resolves to C and B can never join the rectangle as a source.
+        let ctx = make_context_with_endpoints(
+            &[((0, 0), A), ((1, 0), B), ((1, 0), C)],
+            &[(A, 101, B), (B, 102, E), (C, 103, D)],
+            &[A, B, C],
+        );
+        let entries: HashMap<u64, u64> = [(A, 101u64), (B, 102), (C, 103)].into_iter().collect();
+        let grids = ctx.build_aod_grids(&entries);
+
+        assert!(
+            grids.iter().all(|g| !g.contains(&101)),
+            "A lands on B, whose cell is shadowed by C, so A's hop must not be \
+             assembled: {grids:?}"
+        );
+        // The unobstructed cell is still usable, so this degrades to the
+        // pre-#887 behaviour rather than losing the whole bus.
+        assert_eq!(
+            sorted_grids(&grids),
+            vec![vec![103]],
+            "the cell that does resolve must still be offered"
+        );
+    }
+
+    /// The same geometry, exercised directly against [`BusGridContext::try_add_point`]
+    /// so the guard is pinned rather than inferred from the end-to-end result.
+    ///
+    /// Asserts all three properties the shadowed case depends on: the seed cell
+    /// really is `Repairable` (so repair is entered, not skipped), growth then
+    /// fails, and the rollback restores both sets exactly — including the
+    /// coordinate the failed repair inserted.
+    #[test]
+    fn a_shadowed_repair_rolls_back_every_inserted_coordinate() {
+        const A: u64 = 10;
+        const B: u64 = 20;
+        const C: u64 = 30;
+        const D: u64 = 40;
+        const E: u64 = 50;
+        let ctx = make_context_with_endpoints(
+            &[((0, 0), A), ((1, 0), B), ((1, 0), C)],
+            &[(A, 101, B), (B, 102, E), (C, 103, D)],
+            &[A, B, C],
+        );
+        let movers: HashSet<u64> = [A, B, C].into_iter().collect();
+
+        // The seed cell is repairable, not already valid — otherwise this
+        // would never reach the repair loop and would prove nothing.
+        let xs_seed: BTreeSet<u64> = [0].into_iter().collect();
+        let ys_seed: BTreeSet<u64> = [0].into_iter().collect();
+        assert_eq!(
+            ctx.rect_outcome(&xs_seed, &ys_seed, &movers, None),
+            RectOutcome::Repairable,
+            "the seed must need repair for this test to mean anything"
+        );
+
+        let mut xs: BTreeSet<u64> = BTreeSet::new();
+        let mut ys: BTreeSet<u64> = BTreeSet::new();
+        assert!(
+            !ctx.try_add_point(&mut xs, &mut ys, &movers, 0, 0),
+            "repair cannot converge when the occupant's cell is shadowed"
+        );
+        assert!(
+            xs.is_empty() && ys.is_empty(),
+            "rollback must undo the seed *and* the coordinate repair inserted, \
+             leaving xs={xs:?} ys={ys:?}"
+        );
+    }
+
+    /// The same shadowing, but the source that won the position is *stationary*.
+    /// Pulling its coordinates in produces a cell with an immovable atom on it,
+    /// which is `Invalid` rather than `Repairable` — growth must stop at once
+    /// instead of iterating.
+    #[test]
+    fn a_shadowing_stationary_atom_rejects_the_rectangle() {
+        const A: u64 = 10;
+        const B: u64 = 20;
+        const C: u64 = 30;
+        const D: u64 = 40;
+        const E: u64 = 50;
+        let ctx = make_context_with_endpoints(
+            &[((0, 0), A), ((1, 0), B), ((1, 0), C)],
+            &[(A, 101, B), (B, 102, E), (C, 103, D)],
+            &[A, B, C],
+        );
+        // C is occupied but never offered as a mover.
+        let entries: HashMap<u64, u64> = [(A, 101u64), (B, 102)].into_iter().collect();
+        assert!(
+            ctx.build_aod_grids(&entries).is_empty(),
+            "every cell on this bus resolves onto a stationary atom"
+        );
+    }
+
     fn sorted_grids(grids: &[Vec<u64>]) -> Vec<Vec<u64>> {
         let mut out: Vec<Vec<u64>> = grids
             .iter()

--- a/crates/bloqade-lanes-search/src/search/engine.rs
+++ b/crates/bloqade-lanes-search/src/search/engine.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, OnceLock};
 
 use bloqade_lanes_bytecode_core::arch::query::ArchSpecLoadError;
 use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+use bloqade_lanes_bytecode_core::arch::validate::ArchSpecError;
 
 use crate::drivers::entropy::BlendedColumnCache;
 use crate::ops::entangling::{self, WordPairDistances};
@@ -95,11 +96,22 @@ impl SearchEngine {
         Ok(Self::from_index(LaneIndex::new(arch_spec)))
     }
 
-    /// Construct from a borrowed [`ArchSpec`]. Avoids the JSON
-    /// round-trip that callers holding a wrapper around an `ArchSpec`
-    /// would otherwise pay to materialize an owned spec.
-    pub fn from_arch_spec(arch_spec: &ArchSpec) -> Self {
-        Self::from_index(LaneIndex::from_arch_spec(arch_spec))
+    /// Construct from a borrowed [`ArchSpec`], rejecting a spec that does not
+    /// satisfy [`ArchSpec::validate`]. Avoids the JSON round-trip that callers
+    /// holding a wrapper around an `ArchSpec` would otherwise pay to
+    /// materialize an owned spec.
+    ///
+    /// Validates for the same reason [`Self::from_json_validated`] does, and
+    /// it matters more here: this is the constructor the Python placement
+    /// layers use, so an unchecked version would let a user-supplied spec
+    /// reach the search with a cyclic bus and have a physically impossible
+    /// rotation routed as a legal AOD operation.
+    ///
+    /// [`Self::from_index`] remains the unchecked escape hatch, for callers
+    /// that have already validated or are building a fixture by hand.
+    pub fn from_arch_spec(arch_spec: &ArchSpec) -> Result<Self, Vec<ArchSpecError>> {
+        arch_spec.validate()?;
+        Ok(Self::from_index(LaneIndex::from_arch_spec(arch_spec)))
     }
 
     /// Construct from an existing [`LaneIndex`].

--- a/crates/bloqade-lanes-search/src/search/engine.rs
+++ b/crates/bloqade-lanes-search/src/search/engine.rs
@@ -11,6 +11,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, OnceLock};
 
+use bloqade_lanes_bytecode_core::arch::query::ArchSpecLoadError;
 use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
 
 use crate::drivers::entropy::BlendedColumnCache;
@@ -65,12 +66,32 @@ impl std::fmt::Debug for SearchEngine {
 }
 
 impl SearchEngine {
-    /// Construct from an [`ArchSpec`] JSON string.
+    /// Construct from an [`ArchSpec`] JSON string **without validating it**.
     ///
     /// Parses the JSON, builds the lane index (precomputes all lane
     /// lookups, endpoints, and positions).
+    ///
+    /// Prefer [`Self::from_json_validated`]: this constructor performs no
+    /// structural validation, so it will happily build an engine on a spec
+    /// whose buses are cyclic or have duplicate endpoints — invariants the
+    /// search relies on rather than checks (see
+    /// [`crate::ops::aod_grid`], which cannot tell a rotation from a chain).
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         let arch_spec = serde_json::from_str(json)?;
+        Ok(Self::from_index(LaneIndex::new(arch_spec)))
+    }
+
+    /// Construct from an [`ArchSpec`] JSON string, rejecting a spec that does
+    /// not satisfy [`ArchSpec::validate`].
+    ///
+    /// This is the loader every caller should use. The search layers treat
+    /// per-bus acyclicity and endpoint uniqueness (#874) as *given*: rectangle
+    /// growth exempts an occupied destination whose occupant moves in the same
+    /// shot, which is what makes conveyor chains legal — and, on a cyclic bus,
+    /// what would make a physically impossible rotation look legal too.
+    /// Validating at load is what keeps that assumption true.
+    pub fn from_json_validated(json: &str) -> Result<Self, ArchSpecLoadError> {
+        let arch_spec = ArchSpec::from_json_validated(json)?;
         Ok(Self::from_index(LaneIndex::new(arch_spec)))
     }
 
@@ -141,5 +162,44 @@ impl SearchEngine {
                 dist_table,
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::example_arch_json;
+    use bloqade_lanes_bytecode_core::arch::addr::SiteRef;
+
+    /// A spec whose bus is a rotation must be refused at load. Nothing below
+    /// this point can catch it: rectangle growth exempts an occupied
+    /// destination whose occupant moves in the same shot, which is exactly
+    /// what a rotation looks like locally, so the search would route it as a
+    /// legal AOD operation (see `ops::aod_grid`'s
+    /// `the_grid_layer_relies_on_arch_level_acyclicity`).
+    #[test]
+    fn from_json_validated_rejects_a_cyclic_bus() {
+        let mut spec: ArchSpec =
+            serde_json::from_str(example_arch_json()).expect("arch json parses");
+        let bus = &mut spec.zones[0].site_buses[0];
+        bus.src = vec![SiteRef(0), SiteRef(1)];
+        bus.dst = vec![SiteRef(1), SiteRef(0)];
+        let json = serde_json::to_string(&spec).expect("spec serializes");
+
+        let err =
+            SearchEngine::from_json_validated(&json).expect_err("a cyclic bus must be rejected");
+        assert!(
+            matches!(err, ArchSpecLoadError::Validation(_)),
+            "expected a validation error, got {err:?}"
+        );
+
+        // The unvalidated constructor still accepts it — which is precisely
+        // why callers must use the validating one.
+        assert!(SearchEngine::from_json(&json).is_ok());
+    }
+
+    #[test]
+    fn from_json_validated_accepts_a_legal_spec() {
+        assert!(SearchEngine::from_json_validated(example_arch_json()).is_ok());
     }
 }

--- a/python/bloqade/lanes/arch/gemini/logical/spec.py
+++ b/python/bloqade/lanes/arch/gemini/logical/spec.py
@@ -13,5 +13,5 @@ def _load_spec_json() -> str:
 
 
 def get_arch_spec() -> ArchSpec:
-    rust_spec = _RustArchSpec.from_json(_load_spec_json())
+    rust_spec = _RustArchSpec.from_json_validated(_load_spec_json())
     return ArchSpec(rust_spec)

--- a/python/bloqade/lanes/arch/gemini/physical/spec.py
+++ b/python/bloqade/lanes/arch/gemini/physical/spec.py
@@ -22,7 +22,7 @@ def _load_spec_json() -> str:
 
 def get_arch_spec() -> ArchSpec:
     """Physical arch spec for logical compilation (transversal Steane code)."""
-    rust_spec = _RustArchSpec.from_json(_load_spec_json())
+    rust_spec = _RustArchSpec.from_json_validated(_load_spec_json())
     return ArchSpec(rust_spec)
 
 

--- a/python/bloqade/lanes/bytecode/_native.pyi
+++ b/python/bloqade/lanes/bytecode/_native.pyi
@@ -1360,7 +1360,25 @@ class SearchEngine:
 
     @staticmethod
     def from_json(arch_spec_json: str) -> SearchEngine:
-        """Create a ``SearchEngine`` from an ArchSpec JSON string."""
+        """Create a ``SearchEngine`` from an ArchSpec JSON string, **without
+        validating the spec**.
+
+        Prefer :meth:`from_json_validated`. The search layers assume per-bus
+        acyclicity and endpoint uniqueness rather than checking them, so an
+        unvalidated spec with a cyclic bus would be routed as if a rotation
+        were a legal AOD operation.
+        """
+        ...
+
+    @staticmethod
+    def from_json_validated(arch_spec_json: str) -> SearchEngine:
+        """Create a ``SearchEngine`` from an ArchSpec JSON string, rejecting a
+        spec that fails structural validation.
+
+        Raises ``ArchSpecError`` (with every individual problem in its
+        ``errors`` list) for an invalid spec, or ``ValueError`` for malformed
+        JSON.
+        """
         ...
 
     def __repr__(self) -> str: ...

--- a/python/bloqade/lanes/bytecode/_native.pyi
+++ b/python/bloqade/lanes/bytecode/_native.pyi
@@ -1355,7 +1355,14 @@ class SearchEngine:
 
     @staticmethod
     def from_arch_spec(arch: ArchSpec) -> SearchEngine:
-        """Create a ``SearchEngine`` from a native ``ArchSpec`` object."""
+        """Create a ``SearchEngine`` from a native ``ArchSpec`` object.
+
+        Raises ``ArchSpecError`` (with every individual problem in its
+        ``errors`` list) for a spec that fails structural validation: the
+        search assumes per-bus acyclicity rather than checking it, so a cyclic
+        bus would otherwise be routed as if a rotation were a legal AOD
+        operation.
+        """
         ...
 
     @staticmethod


### PR DESCRIPTION
Closes #887.

Two related changes: rectangle growth learns to assemble conveyor chains, and
the arch spec is validated wherever it enters the search — the invariant that
makes chain assembly safe to do.

## 1. Chain assembly (#887)

Rectangle growth in `build_aod_grids` assumed `is_valid_rect` was monotone:
`greedy_init` added one entry at a time and set aside anything whose
*intermediate* rectangle failed. A conveyor chain's prefix is exactly what
fails — the leader's cell alone is invalid because the follower is not yet one
of the rectangle's sources — so the valid complete rectangle was never tried.
Every consumer routing through `build_aod_grids` (heuristic generator, entropy
driver, DSL pipeline) therefore serialised chains into one AOD operation per
hop, even though #866/#876 had already made the execution model accept them.

`rect_outcome` replaces the boolean check with a single-pass
`Valid` / `Repairable` / `Invalid` result that records which movers' cells
would supply a missing exemption. `try_add_point` grows the rectangle, pulls
those cells in, and re-validates to a fixpoint, since each repair forces a new
row or column whose own cells may need repairing in turn.

### Cost

`try_add_point` tracks the requested point in a `bool` and undoes exactly the
coordinates it inserted, so the allocation-free rollback #882 tuned for is
preserved on the common path. The repair buffers allocate only when a chain
actually needs repairing, which cannot happen on an endpoint-disjoint bus.

Measured on a synthetic all-chain row (debug build): repair costs 1.1–2.3x the
disjoint baseline with no widening trend, because a chain assembles in one
`try_add_point` call and later entries hit the already-covered skip. The
pre-existing grow-and-revalidate cost is itself quadratic in rectangle size;
this adds a bounded constant, not an order of magnitude.

## 2. Spec validation at every entry to the search

The search layers treat per-bus acyclicity and endpoint uniqueness (#874) as
*given* rather than checking them — and chain assembly leans on exactly that.
Rectangle growth exempts an occupied destination whose occupant moves in the
same shot, which is what makes a chain legal; on a cyclic bus it is also what
would make a physically impossible rotation look legal. So the invariant has
to hold at load.

`SearchEngine::from_json_validated` adds a checked JSON loader, and the bundled
Gemini specs now use it. But every Python placement site builds its engine from
an already-parsed `ArchSpec`, so four paths still took one unchecked:
`SearchEngine.from_arch_spec`, the entropy solver constructor, the target
generator DSL, and `PolicyRunner.from_arch_spec`. A user loading a custom
architecture via the unvalidated `ArchSpec.from_json` reached the search
regardless.

`from_arch_spec` now validates and returns `Result`; it had a single caller, so
making the checked form the default cost nothing. `from_index` stays as the
documented escape hatch. The binding paths that build a `LaneIndex` directly go
through one `validated_lane_index` helper, so a future entry point has an
obvious thing to call rather than another chance to forget.

Confirmed on the real path: a spec with a self-looping site bus now raises
`ArchSpecError` with the individual problems in its `errors` list, where it
previously produced a working engine.

## Verification

Both benchmark suites report **no differences**, which is expected rather than a
null result: the bundled specs are endpoint-disjoint, so no chain candidate can
arise and the new code path is never entered. The win shows up on specs with
overlapping buses, where it measured roughly a 20% reduction in move count on a
98-atom Ising kernel.

- 21 Rust test targets, 1831 Python tests
- clippy and fmt clean on the CI-gated crates; pyright clean
- `just benchmark-physical` and `just benchmark-logical`: no differences

The two tests that pinned the gap are flipped to assert assembly, joined by
coverage of the limits: three-hop chains, 2x2 and 3x2 cascades, entry-order
independence, blocked heads rejecting the whole chain, and misaligned chains.

Three further tests cover a corner worth naming, since repair works in
*position* space: `pos_to_src` deliberately tolerates two sources at one grid
position (last-insert-wins — the `full.json` fixture stacks every word at
identical coordinates). When another source won the position, a repair pulls in
coordinates that resolve to the winner, the blocking occupant never becomes a
rectangle source, and the same repair is requested from an unchanged rectangle.
The `grew` guard abandons the rectangle instead of spinning, and rollback undoes
every inserted coordinate — verified load-bearing by mutation (dropping the
repair-rollback leaves `xs={1}` and fails the test).

## Note on scope

An earlier revision also added a post-hoc pass that merged adjacent move layers.
It was dropped: the serialisation that motivated it turned out to come from the
benchmark architecture splitting one rigid displacement across 16 buses, not
from the compiler. Fixing the spec removed the need, and dropping the pass also
removed two review findings it had introduced.