### PR TITLE
fix(search): batch conveyor chains in the push-rotate condenser

### DIFF
--- a/crates/bloqade-lanes-search/src/push_rotate/mod.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/mod.rs
@@ -26,8 +26,11 @@
 //! The planner emits **single-atom moves**, one per step. That is not a usable
 //! AOD schedule on its own — turning it into one is the condenser's job
 //! (phase 2b), which merges consecutive moves into complete X×Y rectangle
-//! batches. Sound by construction: a legal AOD move is exactly a set of
-//! vertex-disjoint single moves into empty destinations.
+//! batches. Sound by construction: a legal AOD move is a set of single moves
+//! on one bus group whose sources form the rectangle and whose destinations
+//! are each free — or vacated by another move of the same operation, which is
+//! what lets a conveyor chain ride in one shot (see [`schedule`]'s chain
+//! dependencies).
 
 pub mod context;
 pub mod heuristics;

--- a/crates/bloqade-lanes-search/src/push_rotate/schedule.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/schedule.rs
@@ -13,11 +13,22 @@
 //! precedence edge. Together with each agent's own move order that is
 //! sufficient for validity: a move's destination is vacated before it enters.
 //!
-//! The edges are *strict* — a move cannot enter a vertex in the same operation
-//! that another leaves it. That would need the vertex to be both a source and
-//! a destination of one bus group, and every bus has disjoint source and
-//! destination sets (see the `feasibility` module in the open crate for why
-//! that property holds and why it matters).
+//! Most of those edges are **strict**: the successor's operation must come
+//! after the predecessor's. One pattern is not. When the predecessor *vacates*
+//! the vertex the successor *enters*, and both moves ride the same bus group,
+//! the execution model's uniform destination rule (issue #866) makes the pair
+//! legal in one operation — that is precisely a conveyor chain hop. Those are
+//! recorded as **chain** dependencies, meaning "the same operation or a later
+//! one, never an earlier one": a batch may include such a move only if every
+//! outstanding chain dependency of it is in the same batch.
+//!
+//! Chain dependencies only arise where one bus's source and destination sets
+//! overlap. That is legal — per-bus acyclicity, not endpoint disjointness, is
+//! the invariant `ArchSpec::validate` enforces (issue #874) — and at least one
+//! architecture uses it deliberately to widen its move options. The shipped
+//! Gemini specs do keep their endpoints disjoint, and there no vertex can be
+//! both a source and a destination of one bus group, so every edge is strict
+//! and this scheduler behaves exactly as it did before the relaxation.
 //!
 //! ## Batching
 //!
@@ -25,14 +36,18 @@
 //! `(move_type, bus_id, zone_id, direction)` group whose source positions form
 //! a complete X×Y rectangle — the Cartesian product of their distinct x and y
 //! values. So each scheduling step takes the ready set, partitions it by bus
-//! group, and picks the largest rectangle available. Every emitted batch is
-//! re-validated with `ArchSpec::check_lanes`, which is the authoritative rule.
+//! group, and picks the largest rectangle that carries its chain dependencies
+//! with it. Every emitted batch is then re-validated with
+//! `AtomStateData::validate_moves` against the replayed placement — the
+//! canonical executability check, `ArchSpec::check_lanes` geometry *plus* the
+//! occupancy rules — and a group it rejects degrades to a single move.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::feasibility::graph::{LaneGraph, VertexId};
 use crate::primitives::lane_index::LaneIndex;
 use bloqade_lanes_bytecode_core::arch::addr::{LaneAddr, LocationAddr};
+use bloqade_lanes_bytecode_core::atom_state::AtomStateData;
 
 use crate::push_rotate::context::GroupKey;
 use crate::push_rotate::state::Move;
@@ -110,45 +125,34 @@ pub fn schedule_with(
         src_pos.push((x.to_bits(), y.to_bits()));
     }
 
-    // ── Dependency edges ───────────────────────────────────────────
-    // Per vertex, chain the moves touching it in input order; per agent,
-    // chain its own moves. Both are captured by "last event at X".
-    let mut succ: Vec<Vec<usize>> = vec![Vec::new(); n];
-    let mut indeg = vec![0usize; n];
-    let mut last_at_vertex: HashMap<VertexId, usize> = HashMap::new();
-    let mut last_of_agent: HashMap<u32, usize> = HashMap::new();
-
-    let add_edge = |a: usize, b: usize, succ: &mut Vec<Vec<usize>>, indeg: &mut Vec<usize>| {
-        if a != b && !succ[a].contains(&b) {
-            succ[a].push(b);
-            indeg[b] += 1;
-        }
-    };
-
-    for (i, m) in moves.iter().enumerate() {
-        for v in [m.from, m.to] {
-            if let Some(&prev) = last_at_vertex.get(&v) {
-                add_edge(prev, i, &mut succ, &mut indeg);
-            }
-        }
-        // Register after adding edges so a move touching the same vertex
-        // twice does not depend on itself.
-        last_at_vertex.insert(m.from, i);
-        last_at_vertex.insert(m.to, i);
-
-        if let Some(&prev) = last_of_agent.get(&m.agent) {
-            add_edge(prev, i, &mut succ, &mut indeg);
-        }
-        last_of_agent.insert(m.agent, i);
-    }
+    let Deps {
+        succ,
+        mut indeg,
+        chain_preds,
+    } = build_deps(moves, &lanes);
 
     // ── List scheduling ────────────────────────────────────────────
     let arch = index.arch_spec();
-    let mut ready: Vec<usize> = (0..n).filter(|&i| indeg[i] == 0).collect();
     let mut scheduled = vec![false; n];
+    let mut done = 0usize;
     let mut out: Vec<Batch> = Vec::new();
+    // Occupancy of the plan's movers, advanced one operation at a time, so a
+    // batch can be judged by the execution model rather than by geometry
+    // alone.
+    let mut state = mover_state(graph, moves);
 
-    while !ready.is_empty() {
+    while done < n {
+        let ready = ready_set(&scheduled, &indeg, &chain_preds);
+        // Every edge runs forward through the plan, so the lowest unscheduled
+        // move has no unscheduled predecessor of either kind: the ready set is
+        // never empty, and always holds at least one move with nothing
+        // outstanding. Such a move is legal on its own — the plan put it after
+        // whatever vacated its destination — which makes it the fallback when
+        // no batch survives.
+        debug_assert!(!ready.is_empty(), "dependency graph had a cycle");
+        let needs = outstanding_chain_preds(&ready, &scheduled, &chain_preds);
+        let solo = ready.iter().copied().find(|i| !needs.contains_key(i))?;
+
         // Partition the ready set by bus group and take the biggest legal
         // rectangle across all groups.
         let mut by_group: HashMap<GroupKey, Vec<usize>> = HashMap::new();
@@ -160,7 +164,7 @@ pub fn schedule_with(
         let mut keys: Vec<&GroupKey> = by_group.keys().collect();
         keys.sort_unstable();
         for k in keys {
-            let pick = largest_rectangle(&by_group[k], &src_pos);
+            let pick = largest_rectangle(&by_group[k], &src_pos, &needs);
             if pick.is_empty() {
                 continue;
             }
@@ -175,49 +179,221 @@ pub fn schedule_with(
             }
         }
         if best.is_empty() {
-            // Should not happen — a single move is always a 1×1 rectangle.
-            best = vec![*ready.iter().min().expect("ready is non-empty")];
+            // Every group's rectangle was stranded by a chain dependency it
+            // could not carry; one move at a time still makes progress.
+            best = vec![solo];
         }
 
-        // Authoritative check. If the arch rejects the group, fall back to
-        // emitting one move, which is always legal.
-        let batch_lanes: Vec<LaneAddr> = best.iter().map(|&i| lanes[i]).collect();
-        let best = if batch_lanes.len() > 1 && !arch.check_lanes(&batch_lanes).is_empty() {
-            vec![best[0]]
-        } else {
-            best
-        };
+        // Authoritative check: lane-group geometry *and* the occupancy rules,
+        // against the replayed placement. If the execution model rejects the
+        // group, fall back to emitting one move, which is always legal.
+        let mut batch = best;
+        let mut batch_lanes: Vec<LaneAddr> = batch.iter().map(|&i| lanes[i]).collect();
+        let mut validated = state.validate_moves(&batch_lanes, arch).ok();
+        if validated.is_none() && batch.len() > 1 {
+            let one = batch
+                .iter()
+                .copied()
+                .find(|i| !needs.contains_key(i))
+                .unwrap_or(solo);
+            batch = vec![one];
+            batch_lanes = vec![lanes[one]];
+            validated = state.validate_moves(&batch_lanes, arch).ok();
+        }
+        // A single move the execution model refuses means the plan itself does
+        // not execute — a planner bug, not something to schedule around.
+        state = state.apply_validated(&validated?).ok()?;
 
-        let batch_lanes: Vec<LaneAddr> = best.iter().map(|&i| lanes[i]).collect();
-        out.push(Batch {
-            moves: best.iter().map(|&i| moves[i]).collect(),
-            lanes: batch_lanes,
-        });
-
-        for &i in &best {
+        for &i in &batch {
             scheduled[i] = true;
+            done += 1;
             for &s in &succ[i] {
                 indeg[s] -= 1;
             }
         }
-        ready = (0..n).filter(|&i| !scheduled[i] && indeg[i] == 0).collect();
+        out.push(Batch {
+            moves: batch.iter().map(|&i| moves[i]).collect(),
+            lanes: batch_lanes,
+        });
     }
 
-    debug_assert!(scheduled.iter().all(|&s| s), "dependency graph had a cycle");
     Some(out)
 }
 
-/// Largest subset of `cand` whose source positions form a complete X×Y grid.
+/// The precedence structure of a move list.
+struct Deps {
+    /// Strict successors: `succ[i]` cannot start until `i`'s operation is done.
+    succ: Vec<Vec<usize>>,
+    /// Count of unscheduled strict predecessors.
+    indeg: Vec<usize>,
+    /// Predecessors that may instead ride along in the same operation — see
+    /// [`is_conveyor_pair`] and the module docs.
+    chain_preds: Vec<Vec<usize>>,
+}
+
+/// Order the move list: per vertex, chain the moves touching it in input order;
+/// per agent, chain its own moves. Both are captured by "last event at X".
+fn build_deps(moves: &[Move], lanes: &[LaneAddr]) -> Deps {
+    let n = moves.len();
+    let mut succ: Vec<Vec<usize>> = vec![Vec::new(); n];
+    let mut indeg = vec![0usize; n];
+    let mut chain_preds: Vec<Vec<usize>> = vec![Vec::new(); n];
+    let mut last_at_vertex: HashMap<VertexId, usize> = HashMap::new();
+    let mut last_of_agent: HashMap<u32, usize> = HashMap::new();
+
+    let add_edge = |a: usize, b: usize, succ: &mut Vec<Vec<usize>>, indeg: &mut Vec<usize>| {
+        if a != b && !succ[a].contains(&b) {
+            succ[a].push(b);
+            indeg[b] += 1;
+        }
+    };
+
+    for (i, m) in moves.iter().enumerate() {
+        // Conveyor pairs are collected rather than recorded straight away: the
+        // same two moves can meet at both of `i`'s endpoints, or be one agent's
+        // consecutive steps, and a strict edge between them always wins over a
+        // chain dependency.
+        let mut conveyor: Vec<usize> = Vec::new();
+        for v in [m.from, m.to] {
+            if let Some(&prev) = last_at_vertex.get(&v) {
+                if is_conveyor_pair(&moves[prev], m, v, &lanes[prev], &lanes[i]) {
+                    conveyor.push(prev);
+                } else {
+                    add_edge(prev, i, &mut succ, &mut indeg);
+                }
+            }
+        }
+        // Register after adding edges so a move touching the same vertex twice
+        // does not depend on itself.
+        last_at_vertex.insert(m.from, i);
+        last_at_vertex.insert(m.to, i);
+
+        if let Some(&prev) = last_of_agent.get(&m.agent) {
+            add_edge(prev, i, &mut succ, &mut indeg);
+        }
+        last_of_agent.insert(m.agent, i);
+
+        for prev in conveyor {
+            if !succ[prev].contains(&i) && !chain_preds[i].contains(&prev) {
+                chain_preds[i].push(prev);
+            }
+        }
+    }
+
+    Deps {
+        succ,
+        indeg,
+        chain_preds,
+    }
+}
+
+/// Does `later` enter the vertex `at` in the same breath that `earlier` leaves
+/// it — the conveyor case the uniform destination rule permits?
+///
+/// Sharing a bus group is required because one AOD operation drives exactly
+/// one; distinct agents because a single atom cannot ride two lanes at once.
+fn is_conveyor_pair(
+    earlier: &Move,
+    later: &Move,
+    at: VertexId,
+    earlier_lane: &LaneAddr,
+    later_lane: &LaneAddr,
+) -> bool {
+    earlier.from == at
+        && later.to == at
+        && earlier.agent != later.agent
+        && group_key(earlier_lane) == group_key(later_lane)
+}
+
+/// Where the plan's movers start out, as an [`AtomStateData`] to replay.
+///
+/// An atom that never moves is invisible here, and that is sufficient: the
+/// planner only ever steps onto a vertex it has established is empty, so a
+/// stationary atom cannot be sitting on any move's destination. The only
+/// occupant a batch has to reason about is another mover.
+///
+/// Agent ids stand in for qubit ids — the mapping is a bijection and this
+/// state never leaves the scheduler.
+fn mover_state(graph: &LaneGraph, moves: &[Move]) -> AtomStateData {
+    let mut first: HashMap<u32, LocationAddr> = HashMap::new();
+    for m in moves {
+        first
+            .entry(m.agent)
+            .or_insert_with(|| LocationAddr::decode(graph.location_of(m.from)));
+    }
+    let atoms: Vec<(u32, LocationAddr)> = first.into_iter().collect();
+    AtomStateData::from_locations(&atoms)
+}
+
+/// Moves that may go in the next operation, in plan order.
+///
+/// A move qualifies once every strict predecessor is scheduled and every chain
+/// predecessor is either scheduled or itself in the set — a chain dependency
+/// can be met inside the same operation, but only by a move that can actually
+/// be in it.
+fn ready_set(scheduled: &[bool], indeg: &[usize], chain_preds: &[Vec<usize>]) -> Vec<usize> {
+    let n = scheduled.len();
+    let mut ready: Vec<bool> = (0..n).map(|i| !scheduled[i] && indeg[i] == 0).collect();
+    // One forward pass reaches the fixpoint: a chain predecessor always sits
+    // earlier in the plan than its successor, so a withdrawal is already
+    // visible by the time the pass reaches whatever depended on it.
+    for i in 0..n {
+        if ready[i] && chain_preds[i].iter().any(|&j| !scheduled[j] && !ready[j]) {
+            ready[i] = false;
+        }
+    }
+    (0..n).filter(|&i| ready[i]).collect()
+}
+
+/// Per ready move, the chain predecessors it still has to share an operation
+/// with. Moves with nothing outstanding are left out, so the map is empty on
+/// an endpoint-disjoint spec.
+fn outstanding_chain_preds(
+    ready: &[usize],
+    scheduled: &[bool],
+    chain_preds: &[Vec<usize>],
+) -> HashMap<usize, Vec<usize>> {
+    let mut needs: HashMap<usize, Vec<usize>> = HashMap::new();
+    for &i in ready {
+        let pending: Vec<usize> = chain_preds[i]
+            .iter()
+            .copied()
+            .filter(|&j| !scheduled[j])
+            .collect();
+        if !pending.is_empty() {
+            needs.insert(i, pending);
+        }
+    }
+    needs
+}
+
+/// Largest subset of `cand` whose source positions form a complete X×Y grid
+/// and which carries every outstanding chain dependency in `needs`.
 ///
 /// Enumerates subsets of the distinct y values and, for each, intersects the
 /// x values present on those rows — the largest `|rows| × |common x|` wins.
 /// Exponential in the number of distinct rows, which is why it is capped;
 /// observed rectangles on Gemini top out at 3×3.
-fn largest_rectangle(cand: &[usize], src_pos: &[(u64, u64)]) -> Vec<usize> {
+///
+/// Returns empty when nothing in `cand` can be batched without leaving a
+/// chain dependency behind.
+fn largest_rectangle(
+    cand: &[usize],
+    src_pos: &[(u64, u64)],
+    needs: &HashMap<usize, Vec<usize>>,
+) -> Vec<usize> {
     const MAX_ROWS_EXHAUSTIVE: usize = 12;
 
-    if cand.len() <= 1 {
-        return cand.to_vec();
+    if cand.is_empty() {
+        return Vec::new();
+    }
+    if cand.len() == 1 {
+        // A lone move has nothing to satisfy a chain dependency with.
+        return if needs.contains_key(&cand[0]) {
+            Vec::new()
+        } else {
+            cand.to_vec()
+        };
     }
     // rows: y -> { x -> move index }
     let mut rows: Vec<(u64, HashMap<u64, usize>)> = Vec::new();
@@ -240,11 +416,14 @@ fn largest_rectangle(cand: &[usize], src_pos: &[(u64, u64)]) -> Vec<usize> {
         // Degrade to the single best row rather than enumerate 2^n.
         let best = rows
             .iter()
-            .max_by_key(|(_, m)| m.len())
-            .expect("rows is non-empty");
-        let mut xs: Vec<(&u64, &usize)> = best.1.iter().collect();
+            .enumerate()
+            .max_by_key(|(_, (_, m))| m.len())
+            .expect("rows is non-empty")
+            .0;
+        let mut xs: Vec<u64> = rows[best].1.keys().copied().collect();
         xs.sort_unstable();
-        return xs.into_iter().map(|(_, &i)| i).collect();
+        close_rectangle(&rows, &[best], &mut xs, needs);
+        return cells(&rows, &[best], &xs);
     }
 
     let mut best: Vec<usize> = Vec::new();
@@ -255,21 +434,70 @@ fn largest_rectangle(cand: &[usize], src_pos: &[(u64, u64)]) -> Vec<usize> {
         for &r in &chosen[1..] {
             common.retain(|x| rows[r].1.contains_key(x));
         }
+        common.sort_unstable();
+        close_rectangle(&rows, &chosen, &mut common, needs);
+        // The trimmed product is the exact size of this candidate, so a tie
+        // keeps the earlier mask — as it did before chains were relaxed.
         if common.len() * chosen.len() <= best.len() {
             continue;
         }
-        common.sort_unstable();
-        let mut pick: Vec<usize> = Vec::with_capacity(common.len() * chosen.len());
-        for &r in &chosen {
-            for x in &common {
-                pick.push(rows[r].1[x]);
-            }
-        }
-        if pick.len() > best.len() {
-            best = pick;
-        }
+        best = cells(&rows, &chosen, &common);
     }
     best
+}
+
+/// The moves at `chosen` rows × `xs` columns, row-major.
+fn cells(rows: &[(u64, HashMap<u64, usize>)], chosen: &[usize], xs: &[u64]) -> Vec<usize> {
+    let mut pick: Vec<usize> = Vec::with_capacity(chosen.len() * xs.len());
+    for &r in chosen {
+        for x in xs {
+            pick.push(rows[r].1[x]);
+        }
+    }
+    pick
+}
+
+/// Drop columns from `xs` until every move in `chosen × xs` has its
+/// outstanding chain dependencies inside the rectangle.
+///
+/// A chain dependency can only be met by another cell of the same operation,
+/// so a move whose vacating partner falls outside the rectangle cannot ride in
+/// it — and dropping that move means dropping its whole column, since the AOD
+/// drives a complete Cartesian product and rectangularity is the one thing it
+/// cannot compromise on. Dropping a column can strand further moves, hence the
+/// loop; each pass removes at least one column, so it terminates.
+///
+/// The rows are left alone: every choice of rows is enumerated separately by
+/// [`largest_rectangle`], so a stranding that another row set would fix is
+/// already covered there.
+fn close_rectangle(
+    rows: &[(u64, HashMap<u64, usize>)],
+    chosen: &[usize],
+    xs: &mut Vec<u64>,
+    needs: &HashMap<usize, Vec<usize>>,
+) {
+    if needs.is_empty() {
+        return;
+    }
+    while !xs.is_empty() {
+        let picked: HashSet<usize> = cells(rows, chosen, xs).into_iter().collect();
+        let mut stranded: HashSet<u64> = HashSet::new();
+        for &r in chosen {
+            for x in xs.iter() {
+                let i = rows[r].1[x];
+                if needs
+                    .get(&i)
+                    .is_some_and(|req| req.iter().any(|j| !picked.contains(j)))
+                {
+                    stranded.insert(*x);
+                }
+            }
+        }
+        if stranded.is_empty() {
+            return;
+        }
+        xs.retain(|x| !stranded.contains(x));
+    }
 }
 
 /// The lane realising the edge `from -> to`.
@@ -290,4 +518,222 @@ fn lane_between(
                 .is_some_and(|(_, d)| d.encode() == dst_enc)
         })
         .copied()
+}
+
+#[cfg(test)]
+mod tests {
+    //! Batching on an **overlapping-bus** spec, where a bus's source and
+    //! destination sets intersect and conveyor chains are therefore reachable.
+    //!
+    //! [`chain_arch_json`] rewires site bus 0 of the example arch into the
+    //! chain `0→1→2→3→4`, in both of its words. Words 0 and 1 sit on different
+    //! grid rows, so one bus group offers a two-row rectangle — enough to
+    //! exercise the interaction between chain dependencies and the AOD's
+    //! Cartesian-product constraint, which is where batching a chain is harder
+    //! than merely permitting it.
+    //!
+    //! Move lists are written by hand rather than planned: the point is what
+    //! the condenser does with a given dependency structure, and a fabricated
+    //! list pins that structure exactly.
+
+    use super::*;
+    use crate::search::result::SolveStatus;
+    use crate::test_utils::{chain_arch_json, loc};
+    use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+
+    struct Fixture {
+        index: LaneIndex,
+        graph: LaneGraph,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let spec: ArchSpec = serde_json::from_str(&chain_arch_json()).expect("fixture parses");
+            let index = LaneIndex::new(spec);
+            let graph = LaneGraph::build(&index, &Default::default());
+            Self { index, graph }
+        }
+
+        /// The vertex holding `(word, site)`.
+        fn at(&self, word: u32, site: u32) -> VertexId {
+            self.graph
+                .vertex_of(loc(word, site).encode())
+                .expect("site is on the graph")
+        }
+
+        /// One hop `site → site + 1` in `word`, carried by `agent`.
+        fn hop(&self, agent: u32, word: u32, site: u32) -> Move {
+            Move {
+                agent,
+                from: self.at(word, site),
+                to: self.at(word, site + 1),
+            }
+        }
+
+        fn schedule(&self, moves: &[Move]) -> Vec<Batch> {
+            schedule(&self.index, &self.graph, moves).expect("the fixture schedules")
+        }
+    }
+
+    /// Batch sizes in emission order — the shape assertions below are about
+    /// how much rode together, not which lane landed where.
+    fn sizes(batches: &[Batch]) -> Vec<usize> {
+        batches.iter().map(|b| b.lanes.len()).collect()
+    }
+
+    /// The regression this module exists for (issue #892): three hops of one
+    /// conveyor chain are one AOD operation, not three.
+    ///
+    /// Each hop enters the site the next one leaves, so under strict
+    /// precedence every pair was forced apart and the chain serialised.
+    #[test]
+    fn chain_hops_ride_one_operation() {
+        let fx = Fixture::new();
+        // Leader first, as the planner emits it: pushing atom 0 to site 3
+        // clears site 2 for atom 1, and so on.
+        let moves = [fx.hop(0, 0, 2), fx.hop(1, 0, 1), fx.hop(2, 0, 0)];
+        let batches = fx.schedule(&moves);
+
+        assert_eq!(sizes(&batches), vec![3], "the chain must ride in one shot");
+        assert_eq!(batches[0].moves.len(), 3);
+    }
+
+    /// Chains in two words share the operation when their columns line up: a
+    /// 2×2 rectangle whose every row is a chain.
+    #[test]
+    fn aligned_chains_in_two_words_share_one_operation() {
+        let fx = Fixture::new();
+        let moves = [
+            fx.hop(0, 0, 1),
+            fx.hop(1, 1, 1),
+            fx.hop(2, 0, 0),
+            fx.hop(3, 1, 0),
+        ];
+        let batches = fx.schedule(&moves);
+
+        assert_eq!(sizes(&batches), vec![4], "both rows batch together");
+    }
+
+    /// A chain dependency is "same operation or later" — never earlier.
+    ///
+    /// Here the vacating hop is itself held back by a strict edge (its agent
+    /// has to arrive first), so the follower must wait for it rather than
+    /// slide into a site that is still occupied.
+    #[test]
+    fn a_chain_hop_never_precedes_the_move_it_waits_on() {
+        let fx = Fixture::new();
+        // Agent 1 walks site 2 → 1 → 2; agent 0 follows it into site 1.
+        let arrive = Move {
+            agent: 1,
+            from: fx.at(0, 2),
+            to: fx.at(0, 1),
+        };
+        let moves = [arrive, fx.hop(1, 0, 1), fx.hop(0, 0, 0)];
+        let batches = fx.schedule(&moves);
+
+        assert_eq!(sizes(&batches), vec![1, 2]);
+        assert_eq!(
+            batches[0].moves,
+            vec![arrive],
+            "the follower must not overtake the hop that clears its way"
+        );
+    }
+
+    /// A rectangle that would strand a chain leader is shrunk, not broken.
+    ///
+    /// Word 0 carries a three-hop chain and word 1 a two-hop chain, so the
+    /// widest *geometric* rectangle is the 2×2 over their shared columns — and
+    /// it is illegal, because word 0's middle hop needs the leader that sits in
+    /// the column the intersection drops. Trimming has to give up a column (the
+    /// AOD cannot drive a partial row), which leaves word 0's full chain as the
+    /// best legal operation.
+    #[test]
+    fn a_rectangle_that_would_strand_a_chain_leader_is_trimmed() {
+        let fx = Fixture::new();
+        let moves = [
+            fx.hop(0, 0, 2),
+            fx.hop(1, 1, 1),
+            fx.hop(2, 0, 1),
+            fx.hop(3, 1, 0),
+            fx.hop(4, 0, 0),
+        ];
+        let batches = fx.schedule(&moves);
+
+        assert_eq!(
+            sizes(&batches),
+            vec![3, 2],
+            "word 0's chain goes whole, then word 1's — never a stranded 2x2"
+        );
+        assert!(
+            batches[0]
+                .moves
+                .iter()
+                .all(|m| m.agent != 1 && m.agent != 3),
+            "the first operation is word 0's chain: {:?}",
+            batches[0].moves
+        );
+    }
+
+    /// Every emitted operation executes against the placement the previous ones
+    /// produced, checked with the canonical model rather than with this
+    /// module's own reasoning about it.
+    #[test]
+    fn every_emitted_operation_is_executable() {
+        let fx = Fixture::new();
+        let moves = [
+            fx.hop(0, 0, 2),
+            fx.hop(1, 1, 1),
+            fx.hop(2, 0, 1),
+            fx.hop(3, 1, 0),
+            fx.hop(4, 0, 0),
+        ];
+        let batches = fx.schedule(&moves);
+
+        let mut state = mover_state(&fx.graph, &moves);
+        for (i, b) in batches.iter().enumerate() {
+            let validated = state
+                .validate_moves(&b.lanes, fx.index.arch_spec())
+                .unwrap_or_else(|e| panic!("operation {i} does not execute: {e:?}"));
+            state = state.apply_validated(&validated).expect("token is fresh");
+        }
+        assert!(state.collision.is_empty());
+        for m in &moves {
+            assert_eq!(
+                state.qubit_to_locations.get(&m.agent),
+                Some(&LocationAddr::decode(fx.graph.location_of(m.to))),
+                "agent {} did not land on its destination",
+                m.agent
+            );
+        }
+    }
+
+    /// The whole router, not just the condenser: asking three atoms to shift
+    /// one site along the chain comes back as a single AOD operation.
+    ///
+    /// `solve_push_rotate` replays what it packages through the canonical
+    /// execution model before returning (`search::verify`), from the *full*
+    /// root placement rather than this module's mover-only state — so a chain
+    /// batch that only looked legal to the scheduler would panic there.
+    #[test]
+    fn the_router_batches_a_chain_into_one_operation() {
+        let fx = Fixture::new();
+        let initial: Vec<(u32, LocationAddr)> = (0..3u32).map(|q| (q, loc(0, q))).collect();
+        let target: Vec<(u32, LocationAddr)> = (0..3u32).map(|q| (q, loc(0, q + 1))).collect();
+
+        let result =
+            crate::push_rotate::solve_push_rotate(&fx.index, &initial, &target, &[], 10_000)
+                .expect("valid config");
+
+        assert_eq!(result.status, SolveStatus::Solved);
+        let lanes_per_layer: Vec<usize> = result
+            .move_layers
+            .iter()
+            .map(|l| l.decode().len())
+            .collect();
+        assert_eq!(
+            lanes_per_layer,
+            vec![3],
+            "the shift is one conveyor operation, not one per hop"
+        );
+    }
 }

--- a/crates/bloqade-lanes-search/src/push_rotate/schedule.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/schedule.rs
@@ -40,7 +40,13 @@
 //! with it. Every emitted batch is then re-validated with
 //! `AtomStateData::validate_moves` against the replayed placement — the
 //! canonical executability check, `ArchSpec::check_lanes` geometry *plus* the
-//! occupancy rules — and a group it rejects degrades to a single move.
+//! occupancy rules.
+//!
+//! That check is an assertion, not a fallback: the batches built here are legal
+//! by construction, so a rejection is a defect in this module and **panics**
+//! naming the batch, exactly as [`crate::search::verify`] does for a packaged
+//! plan. Emitting a smaller operation instead would keep the plan valid and
+//! leave the defect invisible.
 
 use std::collections::{HashMap, HashSet};
 
@@ -147,8 +153,8 @@ pub fn schedule_with(
         // move has no unscheduled predecessor of either kind: the ready set is
         // never empty, and always holds at least one move with nothing
         // outstanding. Such a move is legal on its own — the plan put it after
-        // whatever vacated its destination — which makes it the fallback when
-        // no batch survives.
+        // whatever vacated its destination — which is what makes `solo` a safe
+        // pick when every group's rectangle is stranded.
         debug_assert!(!ready.is_empty(), "dependency graph had a cycle");
         let needs = outstanding_chain_preds(&ready, &scheduled, &chain_preds);
         let solo = ready.iter().copied().find(|i| !needs.contains_key(i))?;
@@ -185,24 +191,36 @@ pub fn schedule_with(
         }
 
         // Authoritative check: lane-group geometry *and* the occupancy rules,
-        // against the replayed placement. If the execution model rejects the
-        // group, fall back to emitting one move, which is always legal.
-        let mut batch = best;
-        let mut batch_lanes: Vec<LaneAddr> = batch.iter().map(|&i| lanes[i]).collect();
-        let mut validated = state.validate_moves(&batch_lanes, arch).ok();
-        if validated.is_none() && batch.len() > 1 {
-            let one = batch
-                .iter()
-                .copied()
-                .find(|i| !needs.contains_key(i))
-                .unwrap_or(solo);
-            batch = vec![one];
-            batch_lanes = vec![lanes[one]];
-            validated = state.validate_moves(&batch_lanes, arch).ok();
-        }
-        // A single move the execution model refuses means the plan itself does
-        // not execute — a planner bug, not something to schedule around.
-        state = state.apply_validated(&validated?).ok()?;
+        // against the replayed placement.
+        //
+        // Every batch this loop builds is legal by construction — the pick is a
+        // complete rectangle on one bus group, and chain closure leaves each
+        // destination either free or vacated by a move in the same operation —
+        // so a rejection here is a defect in the condenser, not a situation to
+        // schedule around. It fails loudly for the same reason
+        // [`crate::search::verify`] does: degrading to a smaller operation
+        // would hide the defect behind a slower-but-valid plan, and the batch
+        // that provoked it is only in scope right here.
+        let batch = best;
+        let batch_lanes: Vec<LaneAddr> = batch.iter().map(|&i| lanes[i]).collect();
+        let validated = state
+            .validate_moves(&batch_lanes, arch)
+            .unwrap_or_else(|errors| {
+                panic!(
+                    "the condenser built an operation the execution model \
+                     rejects (this is a bug in the scheduler, not in the \
+                     request): {} of {n} moves, {} lanes{}",
+                    batch.len(),
+                    batch_lanes.len(),
+                    errors
+                        .iter()
+                        .map(|e| format!("\n  - {e}"))
+                        .collect::<String>(),
+                )
+            });
+        state = state
+            .apply_validated(&validated)
+            .expect("the token was just validated against this state");
 
         for &i in &batch {
             scheduled[i] = true;

--- a/crates/bloqade-lanes-search/src/push_rotate/schedule.rs
+++ b/crates/bloqade-lanes-search/src/push_rotate/schedule.rs
@@ -47,6 +47,13 @@
 //! naming the batch, exactly as [`crate::search::verify`] does for a packaged
 //! plan. Emitting a smaller operation instead would keep the plan valid and
 //! leave the defect invisible.
+//!
+//! It replays occupancy one operation at a time, so it costs O(operations ×
+//! atoms) and runs in every build — about a quarter of condensing, which is
+//! itself a fraction of planning (0.17 ms of a 2.4 ms plan-and-condense for a
+//! 64-atom physical instance), and this router only runs at all once a search
+//! has already failed. Same trade as `search::verify`: the invariant is a
+//! correctness property, not a debugging aid.
 
 use std::collections::{HashMap, HashSet};
 
@@ -104,11 +111,30 @@ fn group_key(l: &LaneAddr) -> GroupKey {
 ///
 /// Returns `None` if any move has no lane realising it, which would mean the
 /// plan and the architecture disagree.
+///
+/// # Panics
+///
+/// See [`schedule_with`]: `moves` must be a sequential plan that executes as
+/// written.
 pub fn schedule(index: &LaneIndex, graph: &LaneGraph, moves: &[Move]) -> Option<Vec<Batch>> {
     schedule_with(index, graph, moves, &LargestBatch)
 }
 
 /// Schedule with an explicit batch policy.
+///
+/// # Panics
+///
+/// `moves` must be a **sequential plan that executes as written** — each move's
+/// destination unoccupied at the point the list reaches it, as everything
+/// [`PlanState`](crate::push_rotate::state::PlanState) produces is. Given that,
+/// every batch built here is legal and the checks below are assertions about
+/// this module.
+///
+/// A hand-built list that violates it — one move stepping onto a vertex another
+/// still occupies — is not a schedulable input, and aborts rather than being
+/// quietly condensed into a plan that would corrupt atom state downstream. A
+/// [`BatchPolicy`] cannot cause this: it ranks candidates and never proposes
+/// them.
 pub fn schedule_with(
     index: &LaneIndex,
     graph: &LaneGraph,
@@ -150,14 +176,24 @@ pub fn schedule_with(
     while done < n {
         let ready = ready_set(&scheduled, &indeg, &chain_preds);
         // Every edge runs forward through the plan, so the lowest unscheduled
-        // move has no unscheduled predecessor of either kind: the ready set is
-        // never empty, and always holds at least one move with nothing
-        // outstanding. Such a move is legal on its own — the plan put it after
-        // whatever vacated its destination — which is what makes `solo` a safe
-        // pick when every group's rectangle is stranded.
-        debug_assert!(!ready.is_empty(), "dependency graph had a cycle");
+        // move has no unscheduled predecessor of either kind: it is always
+        // ready and always has nothing outstanding. Such a move is legal on its
+        // own — the plan put it after whatever vacated its destination — which
+        // is what makes `solo` a safe pick when every group's rectangle is
+        // stranded.
+        //
+        // Failing to find one means the dependency graph is not the forward DAG
+        // it is built to be, which is a defect here rather than a schedulable
+        // situation — so it aborts, like the batch check below.
         let needs = outstanding_chain_preds(&ready, &scheduled, &chain_preds);
-        let solo = ready.iter().copied().find(|i| !needs.contains_key(i))?;
+        let solo = ready
+            .iter()
+            .copied()
+            .find(|i| !needs.contains_key(i))
+            .expect(
+                "the lowest unscheduled move is always ready with no \
+                 outstanding chain dependency",
+            );
 
         // Partition the ready set by bus group and take the biggest legal
         // rectangle across all groups.
@@ -431,17 +467,24 @@ fn largest_rectangle(
     rows.sort_by_key(|(y, _)| *y);
 
     if rows.len() > MAX_ROWS_EXHAUSTIVE {
-        // Degrade to the single best row rather than enumerate 2^n.
-        let best = rows
-            .iter()
-            .enumerate()
-            .max_by_key(|(_, (_, m))| m.len())
-            .expect("rows is non-empty")
-            .0;
-        let mut xs: Vec<u64> = rows[best].1.keys().copied().collect();
-        xs.sort_unstable();
-        close_rectangle(&rows, &[best], &mut xs, needs);
-        return cells(&rows, &[best], &xs);
+        // Degrade to a single row rather than enumerate 2^n. Every row is
+        // trimmed and the widest survivor wins, rather than trimming the widest
+        // row and taking whatever is left: a chain leader one row over can
+        // strand every column of the widest row, and returning nothing there
+        // would serialise a chain that a narrower row could have carried whole.
+        //
+        // Unreachable on the shipped Gemini specs, whose grids have five y
+        // positions in total.
+        let mut best: Vec<usize> = Vec::new();
+        for r in 0..rows.len() {
+            let mut xs: Vec<u64> = rows[r].1.keys().copied().collect();
+            xs.sort_unstable();
+            close_rectangle(&rows, &[r], &mut xs, needs);
+            if xs.len() > best.len() {
+                best = cells(&rows, &[r], &xs);
+            }
+        }
+        return best;
     }
 
     let mut best: Vec<usize> = Vec::new();
@@ -485,9 +528,11 @@ fn cells(rows: &[(u64, HashMap<u64, usize>)], chosen: &[usize], xs: &[u64]) -> V
 /// cannot compromise on. Dropping a column can strand further moves, hence the
 /// loop; each pass removes at least one column, so it terminates.
 ///
-/// The rows are left alone: every choice of rows is enumerated separately by
-/// [`largest_rectangle`], so a stranding that another row set would fix is
-/// already covered there.
+/// The rows are left alone: on the exhaustive path every choice of rows is
+/// enumerated separately by [`largest_rectangle`], so a stranding that another
+/// row set would fix is already covered there. Past the row cap that no longer
+/// holds, which is why the degrade path trims each row and compares, instead of
+/// trimming one chosen up front.
 fn close_rectangle(
     rows: &[(u64, HashMap<u64, usize>)],
     chosen: &[usize],

--- a/crates/bloqade-lanes-search/tests/push_rotate.rs
+++ b/crates/bloqade-lanes-search/tests/push_rotate.rs
@@ -104,14 +104,13 @@ fn check_end_to_end(
     let batches = schedule(&fx.index, &fx.graph, &p.moves)
         .unwrap_or_else(|| panic!("{label}: scheduling failed"));
 
-    // ── Property 1: every operation executes ───────────────────────
     let start: Vec<(u32, LocationAddr)> = initial
         .iter()
         .map(|&(q, loc)| (q, LocationAddr::decode(loc)))
         .collect();
     let mut state = AtomStateData::from_locations(&start);
 
-    // ── Property 2: the atoms end up where they were asked to ──────
+    // ── Property 1: every operation executes ───────────────────────
     let mut lanes_issued = 0usize;
     for (bi, b) in batches.iter().enumerate() {
         lanes_issued += b.lanes.len();
@@ -132,6 +131,7 @@ fn check_end_to_end(
         "{label}: {lanes_issued} lanes issued but only {moved} atom moves took effect"
     );
 
+    // ── Property 2: the atoms end up where they were asked to ──────
     let want: HashMap<u32, LocationAddr> = target
         .iter()
         .map(|&(q, loc)| (q, LocationAddr::decode(loc)))

--- a/crates/bloqade-lanes-search/tests/push_rotate.rs
+++ b/crates/bloqade-lanes-search/tests/push_rotate.rs
@@ -1,26 +1,39 @@
 //! End-to-end validation of the Push and Rotate router.
 //!
-//! Two properties, checked with [`AtomStateData`] — the same simulator the IR
-//! analysis pipeline uses — rather than a reimplementation of it, since a bug
-//! in a hand-rolled replay could mask exactly the bug it exists to catch:
+//! Two properties, checked with [`AtomStateData`] — the same execution model
+//! the IR analysis pipeline and the bytecode validator use — rather than a
+//! reimplementation of it, since a bug in a hand-rolled replay could mask
+//! exactly the bug it exists to catch:
 //!
-//! 1. **The plan rearranges the atoms correctly.** Feed each scheduled AOD
-//!    operation to [`AtomStateData::apply_moves`] and compare the resulting
-//!    `qubit_to_locations` against the requested target.
-//! 2. **Every operation is a valid AOD move.** Each batch's lane group is
-//!    checked with `ArchSpec::check_lanes`, the same authority the open
-//!    solver's generators are held to.
+//! 1. **Every operation is executable.** Each batch goes through
+//!    [`AtomStateData::validate_moves`] against the placement its predecessors
+//!    produced. That is the canonical check, and it covers both halves: the
+//!    static lane-group rules (`ArchSpec::check_lanes` — address validity, bus
+//!    group consistency, the AOD's complete-rectangle geometry) and the
+//!    occupancy rules, of which the one that bites here is the uniform
+//!    destination rule: an occupied destination is legal exactly when its
+//!    occupant vacates in the same operation.
+//! 2. **The plan rearranges the atoms correctly.** Apply each validated
+//!    operation in turn and compare the resulting `qubit_to_locations` against
+//!    the requested target.
+//!
+//! Note what property 1 deliberately does *not* assert: that an operation's
+//! destinations avoid its own sources. Simultaneity does not require that — a
+//! vertex which is both is a conveyor chain, legal since #866 and reachable on
+//! any spec whose buses overlap (#874, #892). It used to be asserted here, and
+//! it only ever held because these two fixtures keep their bus endpoints
+//! disjoint. `validate_moves` is the actual rule.
 //!
 //! `AtomStateData` earns its place here by failing in ways a naive replay
 //! would not notice:
 //!
-//! * A move onto an occupied site is recorded in `collision`, and **both**
-//!   qubits are dropped from the location maps. Asserting `collision` is
-//!   empty catches any operation that would crash two atoms together.
-//! * `apply_moves` *silently skips* a lane whose source holds no qubit. A
-//!   scheduler that emitted a lane for an atom that is not there would look
-//!   fine on the final placement in some cases, so the total `move_count` is
-//!   asserted against the number of lanes issued.
+//! * A group that would crash two atoms together cannot reach
+//!   `apply_validated` at all — `validate_moves` rejects it first and names
+//!   the offending lane, where a hand-rolled replay would have to notice the
+//!   damage after the fact.
+//! * What validation permits but a caller may not expect is a lane carrying no
+//!   atom (a legal AOD filler, which this scheduler has no reason to emit), so
+//!   the total `move_count` is asserted against the number of lanes issued.
 
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -91,47 +104,28 @@ fn check_end_to_end(
     let batches = schedule(&fx.index, &fx.graph, &p.moves)
         .unwrap_or_else(|| panic!("{label}: scheduling failed"));
 
-    // ── Property 2: every operation is a legal AOD move ────────────
-    for (bi, b) in batches.iter().enumerate() {
-        let errors = fx.spec.check_lanes(&b.lanes);
-        assert!(
-            errors.is_empty(),
-            "{label}: operation {bi} is not a valid AOD move: {errors:?}"
-        );
-        // A bus maps disjoint source and destination sets, so simultaneous
-        // execution is only meaningful if no destination is also a source.
-        let srcs: HashSet<VertexId> = b.moves.iter().map(|m| m.from).collect();
-        for m in &b.moves {
-            assert!(
-                !srcs.contains(&m.to),
-                "{label}: operation {bi} moves into {} while another move leaves it",
-                m.to
-            );
-        }
-    }
-
-    // ── Property 1: the atoms end up where they were asked to ──────
+    // ── Property 1: every operation executes ───────────────────────
     let start: Vec<(u32, LocationAddr)> = initial
         .iter()
         .map(|&(q, loc)| (q, LocationAddr::decode(loc)))
         .collect();
     let mut state = AtomStateData::from_locations(&start);
 
+    // ── Property 2: the atoms end up where they were asked to ──────
     let mut lanes_issued = 0usize;
     for (bi, b) in batches.iter().enumerate() {
         lanes_issued += b.lanes.len();
+        let validated = state
+            .validate_moves(&b.lanes, &fx.spec)
+            .unwrap_or_else(|e| panic!("{label}: operation {bi} cannot execute: {e:?}"));
         state = state
-            .apply_moves(&b.lanes, &fx.spec)
-            .unwrap_or_else(|| panic!("{label}: operation {bi} has an unresolvable lane"));
-        assert!(
-            state.collision.is_empty(),
-            "{label}: operation {bi} collided atoms: {:?}",
-            state.collision
-        );
+            .apply_validated(&validated)
+            .unwrap_or_else(|e| panic!("{label}: operation {bi} was validated stale: {e:?}"));
     }
 
-    // Every lane must have actually moved an atom. `apply_moves` skips a lane
-    // whose source is empty, which would otherwise pass unnoticed.
+    // Every lane must have actually moved an atom. A filler lane — one whose
+    // source is empty — validates and applies as a legal no-op, which would
+    // otherwise pass unnoticed.
     let moved: u32 = state.move_count.values().sum();
     assert_eq!(
         moved as usize, lanes_issued,
@@ -174,35 +168,23 @@ fn assert_solved_result_rearranges(
         let lanes = layer.decode();
         lanes_issued += lanes.len();
 
-        let errors = fx.spec.check_lanes(&lanes);
-        assert!(
-            errors.is_empty(),
-            "{label}: operation {bi} is not a valid AOD move: {errors:?}"
-        );
-        let srcs: HashSet<u64> = lanes
-            .iter()
-            .map(|l| fx.index.endpoints(l).expect("lane resolves").0.encode())
-            .collect();
+        // The blocked set is this harness's own obligation — `validate_moves`
+        // knows about atoms, not about which locations the caller declared
+        // off-limits.
         for lane in &lanes {
             let (src, dst) = fx.index.endpoints(lane).expect("lane resolves");
             assert!(
                 !blocked.contains(&src.encode()) && !blocked.contains(&dst.encode()),
                 "{label}: operation {bi} touches a blocked location"
             );
-            assert!(
-                !srcs.contains(&dst.encode()),
-                "{label}: operation {bi} moves into a location another move leaves"
-            );
         }
 
+        let validated = state
+            .validate_moves(&lanes, &fx.spec)
+            .unwrap_or_else(|e| panic!("{label}: operation {bi} cannot execute: {e:?}"));
         state = state
-            .apply_moves(&lanes, &fx.spec)
-            .unwrap_or_else(|| panic!("{label}: operation {bi} has an unresolvable lane"));
-        assert!(
-            state.collision.is_empty(),
-            "{label}: operation {bi} collided atoms: {:?}",
-            state.collision
-        );
+            .apply_validated(&validated)
+            .unwrap_or_else(|e| panic!("{label}: operation {bi} was validated stale: {e:?}"));
     }
 
     let moved: u32 = state.move_count.values().sum();
@@ -768,13 +750,11 @@ fn a_custom_heuristic_changes_the_plan_but_not_its_validity() {
             .map(|&(q, loc)| (q, LocationAddr::decode(loc)))
             .collect();
         let mut state = AtomStateData::from_locations(&start);
-        for b in &batches {
-            assert!(
-                fx.spec.check_lanes(&b.lanes).is_empty(),
-                "{label}: bad batch"
-            );
-            state = state.apply_moves(&b.lanes, &fx.spec).expect("applies");
-            assert!(state.collision.is_empty(), "{label}: collision");
+        for (bi, b) in batches.iter().enumerate() {
+            let validated = state
+                .validate_moves(&b.lanes, &fx.spec)
+                .unwrap_or_else(|e| panic!("{label}: operation {bi} cannot execute: {e:?}"));
+            state = state.apply_validated(&validated).expect("token is fresh");
         }
         let want: HashMap<u32, LocationAddr> = target
             .iter()
@@ -833,10 +813,13 @@ fn alignment_heuristics_produce_valid_plans() {
                 .map(|&(q, loc)| (q, LocationAddr::decode(loc)))
                 .collect();
             let mut state = AtomStateData::from_locations(&start);
-            for b in &batches {
-                assert!(fx.spec.check_lanes(&b.lanes).is_empty(), "k={k}: bad batch");
-                state = state.apply_moves(&b.lanes, &fx.spec).expect("applies");
-                assert!(state.collision.is_empty(), "k={k}: collision");
+            for (bi, b) in batches.iter().enumerate() {
+                let validated = state
+                    .validate_moves(&b.lanes, &fx.spec)
+                    .unwrap_or_else(|e| {
+                        panic!("k={k} seed={seed}: operation {bi} cannot execute: {e:?}")
+                    });
+                state = state.apply_validated(&validated).expect("token is fresh");
             }
             let want: HashMap<u32, LocationAddr> = target
                 .iter()


### PR DESCRIPTION
Closes #892.

`push_rotate::schedule` built **strict** precedence edges everywhere, justified by a comment asserting that "every bus has disjoint source and destination sets". That is no longer true — #874 made per-bus *acyclicity* the load-bearing invariant, #866 established the uniform destination rule, and the `validate_bus_disjointness` check the comment pointed at has itself been removed. On an overlapping-bus spec the strict edges forbade exactly the batching that makes conveyor chains worthwhile, serialising them into one operation per hop. Same class of stale assumption as #887, one layer down.

## What changed

**Relaxed the precedence edges.** A vertex edge is now classified strict or **chain** — chain when the predecessor *vacates* the vertex the successor *enters*, both lanes share a bus group, and they are different agents (one atom cannot ride two lanes at once). A chain dependency means "the same operation or a later one, never an earlier one": a batch may include such a move only if every outstanding chain dependency rides with it. A strict edge between the same pair always wins.

**Rectangles carry their chain dependencies.** A chain dependency can only be met by another cell of the same operation, so a rectangle that would strand a chain leader is trimmed a column at a time — the AOD drives a complete Cartesian product and cannot compromise on rectangularity. Rows are left alone, since every row set is enumerated separately anyway.

**Batches are gated by the execution model, not geometry alone.** `ArchSpec::check_lanes` is replaced by `AtomStateData::validate_moves` + `apply_validated` against a replayed placement — the canonical rule from #866, both halves. Mover-only occupancy is sufficient: the planner only steps onto a vertex it has established is empty, so a stationary atom can never sit on a move's destination. The argument is written up on `mover_state`.

**Docs corrected.** The disjointness claim and its dead reference in `schedule.rs`, plus `push_rotate/mod.rs`, which asserted a legal AOD move is "vertex-disjoint single moves into empty destinations".

## Tests

Six new unit tests on `test_utils::chain_arch_json()`, the overlapping-bus fixture. Four fail on the old strict edges — `[1, 1, 1]` operations where the fix gives `[3]` — and `a_rectangle_that_would_strand_a_chain_leader_is_trimmed` fails with the trim disabled (`[1, 3, 1]`: the illegal 2×2 gets picked, validation rejects it, the fallback degrades), which pins both the trim and the safety net. `the_router_batches_a_chain_into_one_operation` goes through `solve_push_rotate`, so it also clears `assert_move_layers_executable` replaying from the *full* root placement.

`tests/push_rotate.rs:101-111` and `:186-190` asserted the router's own output was endpoint-disjoint. Chains legitimately violate that, and it only ever held because both fixtures are disjoint specs — removed, with the module doc now stating why `validate_moves` is the actual rule.

## The shipped specs are provably unaffected

Both Gemini specs have zero src/dst overlap on every bus, so no vertex can be both a source and a destination of one bus group, no chain edge can form, `needs` stays empty and the trim early-returns. Verified empirically too: `examples/headroom` output is byte-identical to `main` — `scheduler_ops` 49 / 94 / 163 at k=4 / 8 / 16. Push and Rotate is not in the benchmark registry, so **no baselines move**.

## Verification

- `cargo test -p bloqade-lanes-search` — 390 lib tests, 22 push-rotate integration tests, green
- `cargo test --workspace` — green
- `cargo clippy -p bloqade-lanes-search --all-targets -- -D warnings` — clean
- `uv run pytest python/tests` — 1831 passed, 9 skipped, 1 xpassed

## Note for follow-up

While here I prototyped and measured **filler lanes** (admitting empty-source cells so a rectangle can span columns a mover is missing from) and did *not* ship it. On the shipped specs the binding constraint is bus-group mismatch, not rectangle geometry: physical k=16 has ~6.95 moves ready per step but the largest same-bus-group cohort averages **1.36**, because 44 bus groups outnumber ready moves ~6:1. Fillers measured −1% to −6.7% operations on physical and **0.0% on logical**, for +9% atom-free lanes and a signature change to `schedule`. The upstream lever is `PlanHeuristics::score_step` alignment — `headroom` puts DAG depth at 32 against 163 operations. Worth revisiting only once a wide-bus spec exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)