### PR TITLE
feat: added integration for PPVM simulator backend (backport of #838)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ msd-reprod = [
 clifft = [
     "clifft; python_version >= '3.12'"
 ]
+ppvm = [
+    "ppvm"
+]
 
 [tool.maturin]
 manifest-path = "crates/bloqade-lanes-bytecode-python/Cargo.toml"
@@ -187,3 +190,6 @@ testpaths = "python/tests/"
 markers = [
     "msd_numerical_regression: optional long-running, environment-specific MSD numerical regression",
 ]
+
+[tool.uv.sources]
+ppvm = { git = "https://github.com/QuEraComputing/ppvm.git", subdirectory = "ppvm-python" }

--- a/python/bloqade/gemini/__init__.py
+++ b/python/bloqade/gemini/__init__.py
@@ -18,6 +18,7 @@ from .device import (
     PhysicalResult as PhysicalResult,
     PhysicalSimulator as PhysicalSimulator,
     PhysicalSimulatorTask as PhysicalSimulatorTask,
+    PPVMSimulatorBackend as PPVMSimulatorBackend,
     Result as Result,
     SimulatorResult as SimulatorResult,
     TsimSimulatorBackend as TsimSimulatorBackend,

--- a/python/bloqade/gemini/device/__init__.py
+++ b/python/bloqade/gemini/device/__init__.py
@@ -22,5 +22,6 @@ from .simulator_backend import (
     AbstractSimulatorBackend as AbstractSimulatorBackend,
     BackendSample as BackendSample,
     CliffTSimulatorBackend as CliffTSimulatorBackend,
+    PPVMSimulatorBackend as PPVMSimulatorBackend,
     TsimSimulatorBackend as TsimSimulatorBackend,
 )

--- a/python/bloqade/gemini/device/_task_runtime.py
+++ b/python/bloqade/gemini/device/_task_runtime.py
@@ -281,17 +281,37 @@ class _SimulatorTaskBase(Generic[RetType]):
         return min_fidelity, max_fidelity
 
     @staticmethod
-    def _normalize_matrix(payload: Any, *, name: str, shots: int) -> list[list[bool]]:
+    def _normalize_matrix(
+        payload: Any,
+        *,
+        name: str,
+        shots: int,
+        loss_replace: Any = None,
+        loss: Any = None,
+    ) -> list[list[bool]]:
+        """
+        Checks that the shape of the returned measurements is valid, and
+        adds configuration options for converting values of `loss` (representing atom loss values) to `loss_replace`.
+
+        By default, loss and loss_replace are no-ops (converts None to None).
+        """
         try:
-            array = np.asarray(payload, dtype=bool)
+            array = np.asarray(payload, dtype=object)
+
+            # NOTE: this is to model a lack of loss-resolved readout; atom loss is indistinguishable from measuring the |1> state
+            array[array == loss] = loss_replace
+            array = array.astype(bool)
         except (TypeError, ValueError) as exc:
             raise ValueError(f"Backend returned invalid {name} samples") from exc
+
         if array.ndim != 2:
             raise ValueError(f"Backend {name} samples must be a two-dimensional array")
+
         if array.shape[0] != shots:
             raise ValueError(
                 f"Backend returned {array.shape[0]} {name} rows for {shots} shots"
             )
+
         return array.tolist()
 
     def run(

--- a/python/bloqade/gemini/device/physical_simulator.py
+++ b/python/bloqade/gemini/device/physical_simulator.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from functools import cache, cached_property
 from typing import (
     TYPE_CHECKING,
+    Any,
     Generic,
     TypeVar,
 )
@@ -189,6 +190,27 @@ class PhysicalSimulatorTask(_SimulatorTaskBase[RetType], Generic[RetType]):
         return MoveToSquinPhysical(
             arch_spec=self.physical_arch_spec,
         ).emit(self.physical_move_kernel)
+
+    @staticmethod
+    def _normalize_matrix(
+        payload: Any,
+        *,
+        name: str,
+        shots: int,
+        loss_replace: Any = True,
+        loss: Any = None,
+    ) -> list[list[bool]]:
+        """
+        Overrides _normalize_matrix to convert the None values in the measurement output to True (to model a lack of loss-resolved readout
+        on Gemini)
+        """
+        return _SimulatorTaskBase._normalize_matrix(
+            payload=payload,
+            name=name,
+            shots=shots,
+            loss_replace=loss_replace,
+            loss=loss,
+        )
 
 
 @dataclass

--- a/python/bloqade/gemini/device/simulator.py
+++ b/python/bloqade/gemini/device/simulator.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from typing import (
     TYPE_CHECKING,
+    Any,
     Generic,
     TypeVar,
 )
@@ -77,6 +78,27 @@ class GeminiLogicalSimulatorTask(_SimulatorTaskBase[RetType], Generic[RetType]):
             noise_model=self.noise_model,
             add_noise=False,
         ).emit(self.physical_move_kernel)
+
+    @staticmethod
+    def _normalize_matrix(
+        payload: Any,
+        *,
+        name: str,
+        shots: int,
+        loss_replace: Any = True,
+        loss: Any = None,
+    ) -> list[list[bool]]:
+        """
+        Overrides _normalize_matrix to convert the None values in the measurement output to True (to model a lack of loss-resolved readout
+        on Gemini)
+        """
+        return _SimulatorTaskBase._normalize_matrix(
+            payload=payload,
+            name=name,
+            shots=shots,
+            loss_replace=loss_replace,
+            loss=loss,
+        )
 
 
 @dataclass

--- a/python/bloqade/gemini/device/simulator_backend.py
+++ b/python/bloqade/gemini/device/simulator_backend.py
@@ -13,7 +13,7 @@ from kirin import ir, rewrite
 from kirin.rewrite.abc import RewriteResult, RewriteRule
 
 if TYPE_CHECKING:
-    from stim import DetectorErrorModel
+    from stim import Circuit as StimCircuit, DetectorErrorModel
     from tsim import Circuit as TsimCircuit  # type: ignore[reportMissingImports]
 
 
@@ -191,6 +191,43 @@ def _clifft_compatible_stim_text(circuit: Any) -> str:
     )
 
 
+_PPVM_CORRELATED_LOSS_EVENT = re.compile(
+    r"^(?P<instruction>\s*I_ERROR)"
+    r"\[correlated_loss:(?P<event_id>\d+)\]"
+    r"(?P<arguments>\([^)\n]*\))"
+    r"(?P<targets>\s+[^#\n]+)"
+    r"(?P<comment>#.*)?$"
+)
+
+
+def _ppvm_compatible_stim_text(circuit: str | StimCircuit) -> str:
+    """Convert paired Bloqade correlated-loss tags to PPVM syntax."""
+
+    converted_lines: list[str] = []
+    for line in str(circuit).splitlines():
+        match = _PPVM_CORRELATED_LOSS_EVENT.match(line)
+        if match is None:
+            converted_lines.append(line)
+            continue
+
+        targets = match.group("targets").split()
+        if len(targets) != 2:
+            event_id = match.group("event_id")
+            raise ValueError(
+                "PPVM requires each Bloqade correlated-loss event to target "
+                f"exactly two qubits, but correlated_loss:{event_id} targets "
+                f"{len(targets)}."
+            )
+
+        converted_lines.append(
+            f"{match.group('instruction')}[correlated_loss]"
+            f"{match.group('arguments')}{match.group('targets')}"
+            f"{match.group('comment') or ''}"
+        )
+
+    return "\n".join(converted_lines)
+
+
 def _clifft() -> Any:
     try:
         import clifft  # type: ignore[reportMissingImports]
@@ -204,9 +241,29 @@ def _clifft() -> Any:
     return clifft
 
 
+def _ppvm() -> Any:
+    try:
+        import ppvm  # type: ignore[reportMissingImports]
+    except ImportError as exc:
+        raise ImportError(
+            "PPVM simulation requires the optional `ppvm` dependency. "
+            "Install it with `bloqade-lanes[ppvm,sim]`."
+        ) from exc
+
+    return ppvm
+
+
 def _clifft_tsim_import_error(exc: ImportError) -> ImportError:
     return ImportError(
         "CliffT simulation also requires `bloqade-lanes[sim]`: Tsim performs "
+        "physical SQuIn conversion and detector error model generation even "
+        "when CliffT is selected for sampling."
+    )
+
+
+def _ppvm_tsim_import_error(exc: ImportError) -> ImportError:
+    return ImportError(
+        "PPVM simulation also requires `bloqade-lanes[sim]`: Tsim performs "
         "physical SQuIn conversion and detector error model generation even "
         "when CliffT is selected for sampling."
     )
@@ -287,6 +344,89 @@ def _pyqrack_tsim_import_error(exc: ImportError) -> ImportError:
         "the guaranteed detector error model even when PyQrack is selected "
         "for sampling."
     )
+
+
+@dataclass
+class PPVMSimulatorBackend(AbstractSimulatorBackend):
+    """
+    Backend using Tsim for conversion/DEM generation and PPVM for sampling.
+
+    ``seed`` is a construction-time root seed. Each seeded sampling request
+    receives the next derived child seed from this backend's private stream.
+    """
+
+    seed: int | None = None
+    _tsim_backend: TsimSimulatorBackend = field(
+        default_factory=TsimSimulatorBackend, repr=False
+    )
+    _programs: WeakKeyDictionary[ir.Method, Any] = field(
+        default_factory=WeakKeyDictionary, init=False, repr=False
+    )
+    _rng_state: np.random.Generator | None = field(init=False, repr=False)
+    _rng_lock: LockType = field(default_factory=Lock, init=False, repr=False)
+
+    def __post_init__(self):
+        _validate_seed(self.seed)
+        self._rng_state = (
+            np.random.default_rng(self.seed) if self.seed is not None else None
+        )
+
+    def _tsim_circuit(self, physical_squin_kernel: ir.Method) -> TsimCircuit:
+        try:
+            return self._tsim_backend._tsim_circuit(physical_squin_kernel)
+        except ImportError as exc:
+            raise _ppvm_tsim_import_error(exc) from exc
+
+    def _ppvm_program(self, physical_squin_kernel: ir.Method) -> Any:
+        try:
+            return self._programs[physical_squin_kernel]
+        except KeyError:
+            pass
+
+        ppvm = _ppvm()
+        tsim_circuit = self._tsim_circuit(physical_squin_kernel)
+        stim_text = _ppvm_compatible_stim_text(tsim_circuit.stim_circuit)
+
+        program = ppvm.StimProgram.parse(
+            stim_text
+        )  # parses and validates compatibility
+        self._programs[physical_squin_kernel] = program
+        return program
+
+    def sample(
+        self,
+        physical_squin_kernel: ir.Method,
+        *,
+        shots: int,
+    ) -> BackendSample:
+        effective_seed = _next_child_seed(self._rng_state, self._rng_lock)
+
+        program = self._ppvm_program(physical_squin_kernel)
+
+        ppvm = _ppvm()
+        samples = ppvm.sample_stim(
+            program,
+            n_qubits=program.num_qubits,
+            num_shots=int(shots),
+            seed=effective_seed,
+        )
+
+        raw_measurements = np.asarray(samples)
+
+        measurements = np.empty(raw_measurements.shape, dtype=object)
+        measurements[raw_measurements == ppvm.MeasurementResult.ZERO] = False
+        measurements[raw_measurements == ppvm.MeasurementResult.ONE] = True
+        measurements[raw_measurements == ppvm.MeasurementResult.LOST] = None
+
+        return BackendSample(measurements=measurements)
+
+    def _detector_error_model(
+        self, physical_squin_kernel: ir.Method
+    ) -> DetectorErrorModel:
+        try:
+            return self._tsim_backend._detector_error_model(physical_squin_kernel)
+        except ImportError as exc:
+            raise _ppvm_tsim_import_error(exc) from exc
 
 
 class _RemovePyQrackAnnotations(RewriteRule):

--- a/python/tests/gemini/test_physical_simulator.py
+++ b/python/tests/gemini/test_physical_simulator.py
@@ -125,6 +125,28 @@ def test_logical_and_physical_tasks_share_non_dataclass_runtime():
     assert issubclass(PhysicalSimulatorTask, _SimulatorTaskBase)
 
 
+@pytest.mark.parametrize(
+    "task_type", [GeminiLogicalSimulatorTask, PhysicalSimulatorTask]
+)
+def test_simulator_tasks_normalize_lost_measurements_as_true(task_type):
+    assert task_type._normalize_matrix(
+        [[False, None], [None, True]], name="measurement", shots=2
+    ) == [[False, True], [True, True]]
+
+
+@pytest.mark.parametrize(
+    "task_type", [GeminiLogicalSimulatorTask, PhysicalSimulatorTask]
+)
+def test_simulator_tasks_forward_loss_normalization_options(task_type):
+    assert task_type._normalize_matrix(
+        [[True, "lost"]],
+        name="measurement",
+        shots=1,
+        loss_replace=False,
+        loss="lost",
+    ) == [[True, False]]
+
+
 @pytest.mark.parametrize("simulator_type", [GeminiLogicalSimulator, PhysicalSimulator])
 @pytest.mark.parametrize(
     "method",

--- a/python/tests/gemini/test_simulator_backend.py
+++ b/python/tests/gemini/test_simulator_backend.py
@@ -18,11 +18,14 @@ from bloqade.gemini.device import (
     AbstractSimulatorBackend,
     BackendSample,
     CliffTSimulatorBackend,
+    PPVMSimulatorBackend,
     TsimSimulatorBackend,
 )
 from bloqade.gemini.device.simulator_backend import (
     _clifft_compatible_stim_text,
     _get_tsim_circuit,
+    _ppvm,
+    _ppvm_compatible_stim_text,
     _PyQrackSimulatorBackend,
 )
 
@@ -67,6 +70,7 @@ def test_backend_contract_has_exactly_two_abstract_operations():
         AbstractSimulatorBackend,
         TsimSimulatorBackend,
         CliffTSimulatorBackend,
+        PPVMSimulatorBackend,
         _PyQrackSimulatorBackend,
     ],
 )
@@ -77,7 +81,12 @@ def test_backend_sample_does_not_expose_detector_mode(backend_type):
 
 @pytest.mark.parametrize(
     "backend_type",
-    [TsimSimulatorBackend, CliffTSimulatorBackend, _PyQrackSimulatorBackend],
+    [
+        TsimSimulatorBackend,
+        CliffTSimulatorBackend,
+        PPVMSimulatorBackend,
+        _PyQrackSimulatorBackend,
+    ],
 )
 def test_backends_expose_only_private_detector_error_model(backend_type):
     backend = backend_type()
@@ -100,7 +109,8 @@ def test_tsim_backend_accepts_detector_mode_configuration():
 
 
 @pytest.mark.parametrize(
-    "backend_type", [CliffTSimulatorBackend, _PyQrackSimulatorBackend]
+    "backend_type",
+    [CliffTSimulatorBackend, PPVMSimulatorBackend, _PyQrackSimulatorBackend],
 )
 def test_composite_backend_exposes_only_private_tsim_backend(backend_type):
     backend = backend_type()
@@ -110,7 +120,12 @@ def test_composite_backend_exposes_only_private_tsim_backend(backend_type):
 
 @pytest.mark.parametrize(
     "backend_type",
-    [TsimSimulatorBackend, CliffTSimulatorBackend, _PyQrackSimulatorBackend],
+    [
+        TsimSimulatorBackend,
+        CliffTSimulatorBackend,
+        PPVMSimulatorBackend,
+        _PyQrackSimulatorBackend,
+    ],
 )
 @pytest.mark.parametrize("seed", [True, -1, 2**63, 1.5, "1"])
 def test_backends_reject_invalid_public_seed(backend_type, seed):
@@ -353,6 +368,112 @@ def test_clifft_compatible_stim_text_strips_instruction_tags_only():
         )
         == "I_ERROR(0)\nDETECTOR(1)\n# [comment]"
     )
+
+
+def test_ppvm_compatible_stim_text_converts_paired_correlated_loss_events():
+    stim_text = (
+        "I_ERROR[correlated_loss:7](0.1) 0 1\n"
+        "  I_ERROR[correlated_loss:8](0.2, 0.03, 0.04) 2 3 # paired loss\n"
+        "I_ERROR[loss](0.05) 4"
+    )
+
+    assert _ppvm_compatible_stim_text(stim_text) == (
+        "I_ERROR[correlated_loss](0.1) 0 1\n"
+        "  I_ERROR[correlated_loss](0.2, 0.03, 0.04) 2 3 # paired loss\n"
+        "I_ERROR[loss](0.05) 4"
+    )
+
+
+@pytest.mark.parametrize("targets", ["0", "0 1 2", "0 1 2 3"])
+def test_ppvm_compatible_stim_text_rejects_non_pair_events(targets):
+    stim_text = f"I_ERROR[correlated_loss:4](0.1) {targets}"
+
+    with pytest.raises(ValueError, match="exactly two qubits"):
+        _ppvm_compatible_stim_text(stim_text)
+
+
+def _fake_ppvm(monkeypatch, *, samples):
+    ppvm = ModuleType("ppvm")
+    ppvm.StimProgram = SimpleNamespace(  # type: ignore[attr-defined]
+        parse=MagicMock(return_value=SimpleNamespace(num_qubits=5))
+    )
+    ppvm.MeasurementResult = SimpleNamespace(  # type: ignore[attr-defined]
+        ZERO=0,
+        ONE=1,
+        LOST=2,
+    )
+    ppvm.sample_stim = MagicMock(return_value=samples)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "ppvm", ppvm)
+    return ppvm
+
+
+def test_ppvm_missing_dependency_has_installation_guidance(monkeypatch):
+    monkeypatch.setitem(sys.modules, "ppvm", None)
+
+    with pytest.raises(ImportError, match=r"bloqade-lanes\[ppvm,sim\]"):
+        _ppvm()
+
+
+def test_ppvm_backend_caches_program_maps_losses_and_derives_child_seed(monkeypatch):
+    ppvm = _fake_ppvm(monkeypatch, samples=[[0, 1, 2], [2, 0, 1]])
+    tsim_backend = MagicMock(spec=TsimSimulatorBackend)
+    tsim_backend._tsim_circuit.return_value = SimpleNamespace(
+        stim_circuit="I_ERROR[correlated_loss:9](0.1) 0 1\nM 0 1 2"
+    )
+    backend = PPVMSimulatorBackend(seed=123, _tsim_backend=tsim_backend)
+
+    first = backend.sample(_physical_kernel, shots=2)
+    second = backend.sample(_physical_kernel, shots=2)
+
+    assert first.measurements is not None
+    assert first.measurements.dtype == object
+    assert first.measurements.tolist() == [[False, True, None], [None, False, True]]
+    assert second.measurements is not None
+    ppvm.StimProgram.parse.assert_called_once_with(  # type: ignore[attr-defined]
+        "I_ERROR[correlated_loss](0.1) 0 1\nM 0 1 2"
+    )
+    assert ppvm.sample_stim.call_args_list == [  # type: ignore[attr-defined]
+        call(
+            ppvm.StimProgram.parse.return_value,  # type: ignore[attr-defined]
+            n_qubits=5,
+            num_shots=2,
+            seed=child_seed,
+        )
+        for child_seed in _derived_seeds(123, 2)
+    ]
+    assert tsim_backend._tsim_circuit.call_count == 1
+
+
+def test_ppvm_backend_omits_unconfigured_seed_and_returns_measurements(monkeypatch):
+    ppvm = _fake_ppvm(monkeypatch, samples=[[1]])
+    tsim_backend = MagicMock(spec=TsimSimulatorBackend)
+    tsim_backend._tsim_circuit.return_value = SimpleNamespace(stim_circuit="M 0")
+    backend = PPVMSimulatorBackend(_tsim_backend=tsim_backend)
+
+    sample = backend.sample(_physical_kernel, shots=1)
+
+    assert sample.measurements is not None
+    assert sample.measurements.tolist() == [[True]]
+    ppvm.sample_stim.assert_called_once_with(  # type: ignore[attr-defined]
+        ppvm.StimProgram.parse.return_value,  # type: ignore[attr-defined]
+        n_qubits=5,
+        num_shots=1,
+        seed=None,
+    )
+    assert sample.detectors is None
+    assert sample.observables is None
+
+
+def test_ppvm_backend_delegates_tsim_circuit_and_dem_to_injected_backend():
+    tsim_backend = MagicMock(spec=TsimSimulatorBackend)
+    tsim_backend._tsim_circuit.return_value = "circuit"
+    tsim_backend._detector_error_model.return_value = "dem"
+    backend = PPVMSimulatorBackend(_tsim_backend=tsim_backend)
+
+    assert _get_tsim_circuit(backend, _physical_kernel) == "circuit"
+    assert backend._detector_error_model(_physical_kernel) == "dem"
+    tsim_backend._tsim_circuit.assert_called_once_with(_physical_kernel)
+    tsim_backend._detector_error_model.assert_called_once_with(_physical_kernel)
 
 
 def test_clifft_backend_compiles_once_normalizes_measurements_and_derives_child_seed(

--- a/uv.lock
+++ b/uv.lock
@@ -369,6 +369,9 @@ msd-reprod = [
     { name = "clifft", marker = "python_full_version >= '3.12'" },
     { name = "ipywidgets" },
 ]
+ppvm = [
+    { name = "ppvm" },
+]
 sim = [
     { name = "bloqade-circuit", extra = ["cirq", "tsim"] },
     { name = "bloqade-tsim" },
@@ -436,6 +439,7 @@ requires-dist = [
     { name = "kirin-toolchain", specifier = "~=0.22.6" },
     { name = "matplotlib", marker = "extra == 'visualization'", specifier = ">=3.9.4" },
     { name = "numpy", specifier = ">=2.2.6" },
+    { name = "ppvm", marker = "extra == 'ppvm'", git = "https://github.com/QuEraComputing/ppvm.git?subdirectory=ppvm-python" },
     { name = "pyqt5", marker = "sys_platform == 'darwin' and extra == 'visualization'", specifier = ">=5.15.11" },
     { name = "pyqt5", marker = "sys_platform == 'linux' and extra == 'visualization'", specifier = ">=5.15.11" },
     { name = "qbraid-qir", extras = ["squin"], marker = "sys_platform != 'win32' and extra == 'cudaq'", specifier = ">=0.5.1" },
@@ -443,7 +447,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "scipy", marker = "extra == 'visualization'", specifier = ">=1.15.3" },
 ]
-provides-extras = ["cudaq", "sim", "decoding", "visualization", "msd-reprod", "clifft"]
+provides-extras = ["cudaq", "sim", "decoding", "visualization", "msd-reprod", "clifft", "ppvm"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4032,6 +4036,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/43/2e/12e987b0f311f20e41f904acc452824af3009579d60c878a5435ae1e9f0a/polars_runtime_32-1.43.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:977b4620d837f3ca0d131f858ac1bd72e2ae10a5e85a6cc27fddc71fbdb5005d", size = 55189721, upload-time = "2026-07-27T12:06:54.68Z" },
     { url = "https://files.pythonhosted.org/packages/3a/f6/5bfba6f40a08b2b1bbe0507e9cc638ebada2dceaece45f9d87a905c57de5/polars_runtime_32-1.43.1-cp310-abi3-win_amd64.whl", hash = "sha256:fa557938e9113c12d59c56df8d7f7e1a411cc1954df0dafbb05900136c6329e7", size = 52566672, upload-time = "2026-07-27T12:06:57.725Z" },
     { url = "https://files.pythonhosted.org/packages/f9/5e/41df901e2684e8857bdffd458c8157d237c701df9f3f922d101075f97724/polars_runtime_32-1.43.1-cp310-abi3-win_arm64.whl", hash = "sha256:cc186bad9f33b71f66ee6cc3ba2146d64315a120b0e988814d6fb1a37f0cc9e9", size = 46575356, upload-time = "2026-07-27T12:07:00.856Z" },
+]
+
+[[package]]
+name = "ppvm"
+version = "0.1.0"
+source = { git = "https://github.com/QuEraComputing/ppvm.git?subdirectory=ppvm-python#661fc66fffe1826dad5ee14b514f151b8703a69e" }
+dependencies = [
+    { name = "bloqade-circuit" },
+    { name = "kirin-toolchain" },
 ]
 
 [[package]]


### PR DESCRIPTION
Manual backport of #838 to \`release-0-11\`. The automated backport failed with a cherry-pick conflict in \`uv.lock\` (#904).

## Conflict resolution

\`uv.lock\` was the only conflicted file — every source file merged cleanly. Rather than hand-merging the lock, it was regenerated with \`uv lock\` on top of \`release-0-11\`'s existing lock, so the only change is the new \`ppvm\` entry (14 insertions). Release-branch pins are otherwise untouched.

## Verification

- \`uv lock --check\` — lock consistent with \`pyproject.toml\`
- \`uv sync --dev --all-extras --index-strategy=unsafe-best-match\` — resolves and installs cleanly
- \`uv run pytest python/tests/gemini/test_simulator_backend.py python/tests/gemini/test_physical_simulator.py\` — 122 passed, 1 xpassed

Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)