### PR TITLE
refactor!: made task() take in num_shots instead of run_async()

### DIFF
--- a/demo/cudaq_demo.py
+++ b/demo/cudaq_demo.py
@@ -20,7 +20,7 @@ def main_cuda():
 
 prepared_squin = cudaq_to_squin(main_cuda)
 append_measurements_and_annotations(prepared_squin, m2dets, m2obs)
-task = GeminiLogicalSimulator().task(prepared_squin)
+task = GeminiLogicalSimulator().task(prepared_squin, num_shots=10)
 
-result = task.run(10)
+result = task.run()
 print(result.detectors)

--- a/demo/logical_dialect_demo.py
+++ b/demo/logical_dialect_demo.py
@@ -373,7 +373,7 @@ def main():
     return logical.default_post_processing(reg)  # Return the physical measurements
 
 
-task = GeminiLogicalSimulator().task(main)
+task = GeminiLogicalSimulator().task(main, num_shots=1)
 
 # %% [markdown]
 # The `task` has several attributes. The key attributes are:
@@ -404,13 +404,15 @@ task.tsim_circuit.diagram(height=task.tsim_circuit.num_qubits * 25)
 # The `task.run` attribute compiles the task to tsim and then samples from it. Note that the majority of the time is spent compiling the task; the sampler is very fast.
 
 # %%
-result = task.run(1, with_noise=True)
-result_wo_noise = task.run(1, with_noise=False)
+result = task.run(with_noise=True)
+result_wo_noise = task.run(with_noise=False)
 
 # %%
-# After recompilation, the task runs very quickly.
-result = task.run(10000, with_noise=True)
-result_wo_noise = task.run(10000, with_noise=False)
+# A task's shot count is fixed at creation. Create a separate task for a
+# larger sample.
+large_sample_task = GeminiLogicalSimulator().task(main, num_shots=10000)
+result = large_sample_task.run(with_noise=True)
+result_wo_noise = large_sample_task.run(with_noise=False)
 
 # %% [markdown]
 # The `result` object has several meaningful attributes that are useful for analysis:

--- a/demo/msd_postselection_experiment.py
+++ b/demo/msd_postselection_experiment.py
@@ -79,8 +79,8 @@ msd_mld_exp.kernels(num_logical_qubits=5)
 msd_mld_exp.dem_circuits()
 msd_mld_exp.dems()
 msd_mld_exp.initialize_decoders()
-msd_mld_exp.make_tasks(device=tsim_simulator)
-msd_mld_exp.get_samples(num_shots=100)
+msd_mld_exp.make_tasks(device=tsim_simulator, num_shots=100)
+msd_mld_exp.get_samples()
 msd_mld_exp.decode_and_postselect(np.array([[1, 0, 1, 1]]))
 
 # %%
@@ -89,8 +89,8 @@ msd_mle_exp.kernels(num_logical_qubits=5)
 msd_mle_exp.dem_circuits()
 msd_mle_exp.dems()
 msd_mle_exp.initialize_decoders()
-msd_mle_exp.make_tasks(device=tsim_simulator)
-msd_mle_exp.get_samples(num_shots=100)
+msd_mle_exp.make_tasks(device=tsim_simulator, num_shots=100)
+msd_mle_exp.get_samples()
 msd_mle_exp.decode_and_postselect(np.array([[1, 0, 1, 1]]))
 
 # %%
@@ -100,8 +100,8 @@ injected_mld_exp.kernels(num_logical_qubits=1)
 injected_mld_exp.dem_circuits()
 injected_mld_exp.dems()
 injected_mld_exp.initialize_decoders()
-injected_mld_exp.make_tasks(device=tsim_simulator)
-injected_mld_exp.get_samples(num_shots=100)
+injected_mld_exp.make_tasks(device=tsim_simulator, num_shots=100)
+injected_mld_exp.get_samples()
 injected_mld_exp.decode_and_postselect(np.array([[]]))
 
 # %% [markdown]

--- a/demo/physical_arch_customization.py
+++ b/demo/physical_arch_customization.py
@@ -608,7 +608,7 @@ placement_strategy = make_physical_placement_strategy(
 physical_msd_task = PhysicalSimulator(
     place_opt_type=ASAPPlacePass,
     placement_strategy=placement_strategy,
-).task(allocate_five_qubits)
+).task(allocate_five_qubits, num_shots=1000)
 
 # %%
 # physical_msd_task.visualize()
@@ -618,7 +618,7 @@ physical_msd_task = PhysicalSimulator(
 # Similar to the simulator task for the logical simulator, we can also run the tasks for the physical simulator using "task.run()".
 
 # %%
-physical_msd_task_res = physical_msd_task.run(shots=1000)
+physical_msd_task_res = physical_msd_task.run()
 
 # %%
 print(np.array(physical_msd_task_res.measurements).shape)

--- a/demo/simulator_device_demo.py
+++ b/demo/simulator_device_demo.py
@@ -49,13 +49,13 @@ def main():
     return default_post_processing(reg)
 
 
-task = GeminiLogicalSimulator().task(main)
+task = GeminiLogicalSimulator().task(main, num_shots=1000)
 
 # run simulation with and without noise
 print("Running simulation with noise...")
-future = task.run_async(1000)
+future = task.run_async()
 print("Running simulation without noise...")
-future_wo_noise = task.run_async(1000, with_noise=False)
+future_wo_noise = task.run_async(with_noise=False)
 
 result_wo_noise = future_wo_noise.result()
 result = future.result()

--- a/demo/simulators_demo.py
+++ b/demo/simulators_demo.py
@@ -63,10 +63,10 @@ def test_logical_program():
 
 # %%
 # Compile the logical program to a task
-logical_task = logical_sim.task(test_logical_program)
+logical_task = logical_sim.task(test_logical_program, num_shots=1000)
 
 # %%
-logical_result = logical_task.run(shots=1000)
+logical_result = logical_task.run()
 
 # %%
 print(np.asarray(logical_result.measurements).shape)
@@ -82,10 +82,10 @@ logical_sim_clifft = GeminiLogicalSimulator(backend=CliffTSimulatorBackend())
 
 # %%
 # Compile the program to a task and use CliffT to sample the results.
-logical_task_clifft = logical_sim_clifft.task(test_logical_program)
+logical_task_clifft = logical_sim_clifft.task(test_logical_program, num_shots=1000)
 
 # %%
-logical_result_clifft = logical_task_clifft.run(shots=1000)
+logical_result_clifft = logical_task_clifft.run()
 
 # %%
 print(np.asarray(logical_result_clifft.measurements).shape)
@@ -109,10 +109,10 @@ def test_physical_program():
 
 
 # %%
-physical_task = physical_sim.task(test_physical_program)
+physical_task = physical_sim.task(test_physical_program, num_shots=1000)
 
 # %%
-physical_result = physical_task.run(shots=1000)
+physical_result = physical_task.run()
 
 # %%
 print(np.asarray(physical_result.measurements).shape)
@@ -122,10 +122,10 @@ print(np.asarray(physical_result.measurements).shape)
 physical_sim_clifft = GeminiPhysicalSimulator(backend=CliffTSimulatorBackend())
 
 # %%
-physical_task_clifft = physical_sim_clifft.task(test_physical_program)
+physical_task_clifft = physical_sim_clifft.task(test_physical_program, num_shots=1000)
 
 # %%
-physical_result_clifft = physical_task_clifft.run(shots=1000)
+physical_result_clifft = physical_task_clifft.run()
 
 # %%
 print(np.asarray(physical_result_clifft.measurements).shape)

--- a/demo/star_logical_demo.py
+++ b/demo/star_logical_demo.py
@@ -121,13 +121,19 @@ def postselected_observable_bits(result):
 
 
 # Compile kernels down to tsim circuits to do simulation
-x_task = GeminiLogicalSimulator().task(logical_kernel=star_on_plus_kernel_x)
-y_task = GeminiLogicalSimulator().task(logical_kernel=star_on_plus_kernel_y)
-z_task = GeminiLogicalSimulator().task(logical_kernel=star_on_plus_kernel_z)
+x_task = GeminiLogicalSimulator().task(
+    logical_kernel=star_on_plus_kernel_x, num_shots=SHOTS
+)
+y_task = GeminiLogicalSimulator().task(
+    logical_kernel=star_on_plus_kernel_y, num_shots=SHOTS
+)
+z_task = GeminiLogicalSimulator().task(
+    logical_kernel=star_on_plus_kernel_z, num_shots=SHOTS
+)
 
-x_shots = x_task.run(shots=SHOTS, with_noise=False)
-y_shots = y_task.run(shots=SHOTS, with_noise=False)
-z_shots = z_task.run(shots=SHOTS, with_noise=False)
+x_shots = x_task.run(with_noise=False)
+y_shots = y_task.run(with_noise=False)
+z_shots = z_task.run(with_noise=False)
 
 # Postselect on ancilla detectors being all 0
 x_shots_arr, x_accepted = postselected_observable_bits(x_shots)

--- a/python/bloqade/gemini/decoding/experiments.py
+++ b/python/bloqade/gemini/decoding/experiments.py
@@ -324,18 +324,25 @@ class PostSelectionExperiment:
         # the hardware). However, because GeminiLogicalSimulator currently doesn't obey any interface/inheritance for a generic hardware object,
         # we can't really replace this with a more specific type without changing the design of GeminiLogicalSimulator.
         device: GeminiLogicalSimulator,
+        num_shots: int = 1,
         # TODO: the return type of make_tasks of what we want to run on hardware should not be GeminiLogicalSimulatorTask. It should be
         # TaskABC[GeminiLogicalFuture]. However, currently, GeminiLogicalSimulatorTask does not inherit from the abstract "task" types in
         # bloqade-core.
     ) -> dict[str, GeminiLogicalSimulatorTask[_LogicalTomographyReturn]]:
-        """Prepares tasks for submission to the hardware device."""
+        """Prepares tasks for submission to the hardware device.
+
+        Args:
+            device: Simulator or device used to create the tasks.
+            num_shots: Number of shots assigned to each tomography task.
+                Defaults to 1.
+        """
         dem_kernels = self._postselection_exp_cache.dem_kernels
         if dem_kernels is None:
             raise RuntimeError("kernels must be called before make_tasks.")
         actual_tasks: dict[
             str, GeminiLogicalSimulatorTask[_LogicalTomographyReturn]
         ] = {
-            basis: device.task(kernel.similar())
+            basis: device.task(kernel.similar(), num_shots=num_shots)
             for basis, kernel in dem_kernels.items()
         }
         self._postselection_exp_cache.hardware_tasks = actual_tasks
@@ -346,19 +353,14 @@ class PostSelectionExperiment:
     # ^ We might want a way to reuse hardware samples across different "experiments".
     # NOTE: In the future, we may want to define a "get_samples_async" method that allows
     # the user to get futures and later request to actually get the samples on their own time (a "non-blocking" implementation).
-    def get_samples(
-        self,
-        num_shots: int,
-    ) -> dict[str, _BasisDataset]:
-        """For each basis, samples num_shots from the hardware. Returns the detector and observable information for each task."""
+    def get_samples(self) -> dict[str, _BasisDataset]:
+        """Samples each prepared task and returns detector and observable data."""
         actual_tasks = self._postselection_exp_cache.hardware_tasks
         if actual_tasks is None:
             raise RuntimeError("make_tasks must be called before get_samples.")
         # In this implementation, we request samples for each basis in parallel, and then iteratively block
         # on X, Y, and then Z being finished.
-        futures = {
-            basis: task.run_async(num_shots) for basis, task in actual_tasks.items()
-        }
+        futures = {basis: task.run_async() for basis, task in actual_tasks.items()}
         actual_data = {
             basis: _basis_dataset_from_task_result(future.result())
             for basis, future in futures.items()

--- a/python/bloqade/gemini/device/_task_runtime.py
+++ b/python/bloqade/gemini/device/_task_runtime.py
@@ -208,6 +208,7 @@ class _SimulatorTaskBase(Generic[RetType]):
     physical_arch_spec: ArchSpec
     physical_move_kernel: ir.Method[[], RetType]
     _post_processing: atom.PostProcessing[RetType]
+    num_shots: int
 
     @property
     def _backend(self) -> AbstractSimulatorBackend:
@@ -316,13 +317,11 @@ class _SimulatorTaskBase(Generic[RetType]):
 
     def run(
         self,
-        shots: int = 1,
         with_noise: bool = True,
     ) -> SimulatorResult[RetType]:
         """Run the kernel and get simulation results.
 
         Args:
-            shots (int): Number of shots to run. Defaults to 1.
             with_noise (bool): Whether to include noise in the simulation. Defaults to True.
 
         Returns:
@@ -331,6 +330,7 @@ class _SimulatorTaskBase(Generic[RetType]):
         """
         # Build the guaranteed DEM before beginning a potentially expensive
         # sampling request. This also fails early when Tsim is unavailable.
+        shots = self.num_shots
         detector_error_model = self.detector_error_model
         physical_kernel = (
             self._physical_kernel if with_noise else self._noiseless_physical_kernel
@@ -378,13 +378,11 @@ class _SimulatorTaskBase(Generic[RetType]):
 
     def run_async(
         self,
-        shots: int = 1,
         with_noise: bool = True,
     ) -> Future[SimulatorResult[RetType]]:
         """Run the kernel asynchronously and get simulation results.
 
         Args:
-            shots (int): Number of shots to run. Defaults to 1.
             with_noise (bool): Whether to include noise in the simulation. Defaults to True.
 
         Returns:
@@ -393,5 +391,5 @@ class _SimulatorTaskBase(Generic[RetType]):
         """
         return cast(
             Future[SimulatorResult[RetType]],
-            self._thread_pool_executor.submit(self.run, shots, with_noise),
+            self._thread_pool_executor.submit(self.run, with_noise=with_noise),
         )

--- a/python/bloqade/gemini/device/physical_simulator.py
+++ b/python/bloqade/gemini/device/physical_simulator.py
@@ -167,6 +167,8 @@ class PhysicalSimulatorTask(_SimulatorTaskBase[RetType], Generic[RetType]):
     """The physical move kernel compiled from the source SQuIn kernel."""
     _post_processing: atom.PostProcessing[RetType] = field(repr=False)
     """The post-processing object for extracting detectors, observables, and return values."""
+    num_shots: int
+    """The number of shots to execute the task with."""
     _simulator_backend: AbstractSimulatorBackend = field(
         default_factory=TsimSimulatorBackend, repr=False
     )
@@ -235,11 +237,18 @@ class GeminiPhysicalSimulator:
     def task(
         self,
         physical_kernel: ir.Method[[], RetType],
+        num_shots: int = 1,
     ) -> PhysicalSimulatorTask[RetType]:
         """Compile a physical-pipeline-compatible ``ir.Method`` into a task.
 
         The method must already contain terminal physical measurement and any
         desired annotations; no conversion or insertion is performed.
+
+        Args:
+            physical_kernel (ir.Method[[], RetType]): The physical SQuIN kernel
+                to compile and run.
+            num_shots (int): Number of shots to execute when the returned task
+                is run. Defaults to 1.
         """
         if not isinstance(physical_kernel, ir.Method):
             raise TypeError("GeminiPhysicalSimulator.task() requires a Squin ir.Method")
@@ -272,6 +281,7 @@ class GeminiPhysicalSimulator:
             self.arch_spec,
             physical_move_kernel,
             post_processing,
+            num_shots,
             self.backend,
         )
 

--- a/python/bloqade/gemini/device/simulator.py
+++ b/python/bloqade/gemini/device/simulator.py
@@ -53,9 +53,12 @@ class GeminiLogicalSimulatorTask(_SimulatorTaskBase[RetType], Generic[RetType]):
     """The physical move kernel that executes the logical squin kernel on the physical architecture."""
     _post_processing: atom.PostProcessing[RetType] = field(repr=False)
     """The post-processing object for extracting detectors, observables, and return values."""
+    num_shots: int
+    """The number of shots to execute the task with."""
     _simulator_backend: AbstractSimulatorBackend = field(
         default_factory=TsimSimulatorBackend
     )
+    """Sampling and detector-model backend used to perform sampling."""
 
     @cached_property
     def physical_squin_kernel(self) -> ir.Method[[], RetType]:
@@ -119,6 +122,7 @@ class GeminiLogicalSimulator:
     def task(
         self,
         logical_kernel: ir.Method[[], RetType],
+        num_shots: int = 1,
     ) -> GeminiLogicalSimulatorTask[RetType]:
         """Create a simulation task for the given kernel.
 
@@ -132,6 +136,8 @@ class GeminiLogicalSimulator:
         Args:
             logical_kernel (ir.Method[[], RetType]): The logical
                 squin kernel to compile and run.
+            num_shots (int): Number of shots to execute when the returned task
+                is run. Defaults to 1.
 
         Returns:
             GeminiLogicalSimulatorTask[RetType]: The compiled simulation task.
@@ -153,5 +159,6 @@ class GeminiLogicalSimulator:
             physical_arch_spec,
             physical_move_kernel,
             post_processing,
+            num_shots,
             self.backend,
         )

--- a/python/tests/gemini/decoding/test_experiment.py
+++ b/python/tests/gemini/decoding/test_experiment.py
@@ -115,8 +115,8 @@ def msd_mld_decoders(msd_mld_exp, msd_mld_dems):
 @pytest.fixture(scope="module")
 def msd_mld_samples(msd_mld_exp, msd_mld_kernels):
     _ = msd_mld_kernels
-    msd_mld_exp.make_tasks(GeminiLogicalSimulator())
-    return msd_mld_exp.get_samples(num_shots=100)
+    msd_mld_exp.make_tasks(GeminiLogicalSimulator(), num_shots=100)
+    return msd_mld_exp.get_samples()
 
 
 @pytest.fixture(scope="module")
@@ -249,7 +249,7 @@ def test_postselection_experiment_get_samples_requires_make_tasks(
     with pytest.raises(
         RuntimeError, match="make_tasks must be called before get_samples"
     ):
-        exp.get_samples(num_shots=10)
+        exp.get_samples()
 
 
 def test_postselection_experiment_decode_requires_samples(
@@ -417,9 +417,10 @@ def test_postselection_experiment_initialize_mle_decoders_validate_width(
 
 def test_postselection_experiment_make_tasks_sets_cache(msd_mld_exp, msd_mld_kernels):
     _ = msd_mld_kernels
-    tasks = msd_mld_exp.make_tasks(GeminiLogicalSimulator())
+    tasks = msd_mld_exp.make_tasks(GeminiLogicalSimulator(), num_shots=7)
 
     assert msd_mld_exp._postselection_exp_cache.hardware_tasks is tasks
+    assert all(task.num_shots == 7 for task in tasks.values())
 
 
 @dataclass
@@ -469,10 +470,10 @@ def test_postselection_experiment_get_samples_calls_run_async_once_per_basis():
         tasks[basis] = _FakeTask(run_async=Mock(return_value=future))
     cast(Any, exp._postselection_exp_cache).hardware_tasks = tasks
 
-    exp.get_samples(num_shots=100)
+    exp.get_samples()
 
     for task in tasks.values():
-        task.run_async.assert_called_once_with(100)
+        task.run_async.assert_called_once_with()
 
 
 def test_postselection_experiment_get_samples_shapes(msd_mld_samples):

--- a/python/tests/gemini/decoding/test_msd_postselection_integration.py
+++ b/python/tests/gemini/decoding/test_msd_postselection_integration.py
@@ -30,9 +30,9 @@ def _sample_tasks_sequentially(
     begins sampling, so that path is scheduling-dependent. This test exercises
     the same compiled tasks and post-processing synchronously instead.
     """
-    tasks = experiment.make_tasks(simulator)
+    tasks = experiment.make_tasks(simulator, num_shots=_SIMULATION_SHOTS)
     experiment._postselection_exp_cache.raw_results = {
-        basis: _basis_dataset_from_task_result(tasks[basis].run(_SIMULATION_SHOTS))
+        basis: _basis_dataset_from_task_result(tasks[basis].run())
         for basis in ("X", "Y", "Z")
     }
 

--- a/python/tests/gemini/decoding/test_msd_postselection_numerical_regression.py
+++ b/python/tests/gemini/decoding/test_msd_postselection_numerical_regression.py
@@ -35,9 +35,9 @@ def _sample_tasks_sequentially(
     simulator: GeminiLogicalSimulator,
 ) -> None:
     """Sample tomography bases in a deterministic child-seed order."""
-    tasks = experiment.make_tasks(simulator)
+    tasks = experiment.make_tasks(simulator, num_shots=_SIMULATION_SHOTS)
     experiment._postselection_exp_cache.raw_results = {
-        basis: _basis_dataset_from_task_result(tasks[basis].run(_SIMULATION_SHOTS))
+        basis: _basis_dataset_from_task_result(tasks[basis].run())
         for basis in ("X", "Y", "Z")
     }
 

--- a/python/tests/gemini/test_measurement_permutation_regression.py
+++ b/python/tests/gemini/test_measurement_permutation_regression.py
@@ -40,7 +40,7 @@ def _assert_postprocessed_matches_native(task) -> tuple[list, list]:
     Returns the (detectors, observables) post-processed rows for any
     further value assertions.
     """
-    postprocessed = task.run(shots=SHOTS, with_noise=False)
+    postprocessed = task.run(with_noise=False)
     native = TsimSimulatorBackend(run_detectors=True).sample(
         task.noiseless_physical_squin_kernel,
         shots=SHOTS,
@@ -101,7 +101,7 @@ def _phys_arbitrary_order():
     ids=["allocation", "reversed", "arbitrary"],
 )
 def test_physical_permutation(kernel, expected_return, expected_m0):
-    task = PhysicalSimulator().task(kernel)
+    task = PhysicalSimulator().task(kernel, num_shots=SHOTS)
     dets, obs = _assert_postprocessed_matches_native(task)
 
     # Detector/observable on m[0] reflect the first measured qubit.
@@ -109,7 +109,7 @@ def test_physical_permutation(kernel, expected_return, expected_m0):
     assert all(row == [expected_m0] for row in obs)
 
     # Return values reconstruct the measured bits in the order listed.
-    result = task.run(shots=SHOTS, with_noise=False)
+    result = task.run(with_noise=False)
     for ret in result.return_values:
         assert [bool(x) for x in ret] == expected_return
 
@@ -166,7 +166,7 @@ def _logical_arbitrary_order():
     ids=["allocation", "reversed", "arbitrary"],
 )
 def test_logical_permutation(kernel, expected_m0):
-    task = GeminiLogicalSimulator().task(kernel)
+    task = GeminiLogicalSimulator().task(kernel, num_shots=SHOTS)
     dets, obs = _assert_postprocessed_matches_native(task)
 
     assert all(row == [expected_m0] for row in dets)

--- a/python/tests/gemini/test_optional_tsim_import.py
+++ b/python/tests/gemini/test_optional_tsim_import.py
@@ -130,8 +130,9 @@ def test_composed_backends_fail_before_sampling_with_specific_tsim_guidance():
             task = object.__new__(GeminiLogicalSimulatorTask)
             object.__setattr__(task, "physical_squin_kernel", "kernel")
             object.__setattr__(task, "_simulator_backend", backend)
+            object.__setattr__(task, "num_shots", 1)
             try:
-                task.run(shots=1)
+                task.run()
             except ImportError as exc:
                 message = str(exc)
                 assert label in message

--- a/python/tests/gemini/test_physical_simulator.py
+++ b/python/tests/gemini/test_physical_simulator.py
@@ -79,7 +79,7 @@ def test_physical_result_uses_post_processing():
     post_processing.emit_observables.assert_called_once_with(raw_measurements)
 
 
-def _mock_physical_task() -> Any:
+def _mock_physical_task(num_shots: int = 1) -> Any:
     task = object.__new__(PhysicalSimulatorTask)
     backend = MagicMock()
     backend._detector_error_model.return_value = "dem"
@@ -88,6 +88,7 @@ def _mock_physical_task() -> Any:
     object.__setattr__(task, "_simulator_backend", backend)
     object.__setattr__(task, "fidelity_bounds", MagicMock(return_value=(0.5, 0.9)))
     object.__setattr__(task, "_post_processing", MagicMock())
+    object.__setattr__(task, "num_shots", num_shots)
     return task
 
 
@@ -97,7 +98,7 @@ def test_physical_task_run_routes_through_backend():
         measurements=np.array([[True, False]])
     )
 
-    result = PhysicalSimulatorTask.run(task, shots=1, with_noise=True)
+    result = PhysicalSimulatorTask.run(task, with_noise=True)
 
     task._backend._detector_error_model.assert_called_once_with("noisy-kernel")
     task._backend.sample.assert_called_once_with("noisy-kernel", shots=1)
@@ -311,8 +312,8 @@ def test_builtin_backends_run_physical_workflow_with_guaranteed_dem(
 ):
     result = (
         PhysicalSimulator(backend=backend)
-        .task(small_physical_kernel)
-        .run(shots=2, with_noise=with_noise)
+        .task(small_physical_kernel, num_shots=2)
+        .run(with_noise=with_noise)
     )
 
     assert isinstance(result, Result)
@@ -332,7 +333,7 @@ def test_tsim_physical_detector_backend_returns_detector_result():
     )
     simulator = PhysicalSimulator(backend=TsimSimulatorBackend(run_detectors=True))
 
-    result = simulator.task(prepared_kernel).run(shots=2, with_noise=False)
+    result = simulator.task(prepared_kernel, num_shots=2).run(with_noise=False)
 
     assert isinstance(result, DetectorResult)
     assert len(result.detectors) == 2
@@ -351,7 +352,7 @@ def test_pyqrack_physical_returns_measurement_backed_result():
     )
     simulator = PhysicalSimulator(backend=_PyQrackSimulatorBackend(seed=30))
 
-    result = simulator.task(prepared_kernel).run(shots=2, with_noise=False)
+    result = simulator.task(prepared_kernel, num_shots=2).run(with_noise=False)
 
     assert isinstance(result, Result)
     assert result.detectors == [[True], [True]]
@@ -368,6 +369,7 @@ def test_pyqrack_physical_returns_measurement_backed_result():
 )
 def test_physical_task_run_methods_do_not_expose_runtime_configuration(method):
     assert "run_detectors" not in inspect.signature(method).parameters
+    assert "shots" not in inspect.signature(method).parameters
     assert "seed" not in inspect.signature(method).parameters
 
 

--- a/python/tests/gemini/test_steane_transversal_x_flip_regression.py
+++ b/python/tests/gemini/test_steane_transversal_x_flip_regression.py
@@ -60,7 +60,7 @@ def _steane_p0(steane_kernel, n_anc: int) -> float:
     return P(obs[0] = 0) on the shots where all ``n_anc`` ancilla
     observables are 0."""
     sim = GeminiLogicalSimulator()
-    result = sim.task(steane_kernel).run(shots=STEANE_SHOTS, with_noise=False)
+    result = sim.task(steane_kernel, num_shots=STEANE_SHOTS).run(with_noise=False)
     obs = np.asarray(result.observables)
     successful = np.all(obs[:, 1 : 1 + n_anc] == 0, axis=1)
     assert successful.sum() > 20, (

--- a/python/tests/test_device.py
+++ b/python/tests/test_device.py
@@ -117,7 +117,7 @@ def test_physical_compilation(size: int):
 
         return ilist.map(set_observable, ilist.range(len(reg)))
 
-    result = GeminiLogicalSimulator().task(main).run(1000, with_noise=False)
+    result = GeminiLogicalSimulator().task(main, num_shots=1000).run(with_noise=False)
     # checks to make sure logical GHZ state is created.
     assert all(len(set(rv)) == 1 for rv in result.observables)
 
@@ -126,7 +126,7 @@ def test_physical_compilation(size: int):
 def test_run_default():
     """Test that default measurement sampling returns a Result."""
     sim = GeminiLogicalSimulator()
-    result = sim.task(main).run(shots=5, with_noise=False)
+    result = sim.task(main, num_shots=5).run(with_noise=False)
 
     assert isinstance(result, Result)
     assert result.fidelity_bounds() is not None
@@ -137,7 +137,7 @@ def test_run_default():
 def test_run_with_detector_backend():
     """Test that a detector-configured backend returns a DetectorResult."""
     sim = GeminiLogicalSimulator(backend=TsimSimulatorBackend(run_detectors=True))
-    result = sim.task(main).run(shots=10, with_noise=False)
+    result = sim.task(main, num_shots=10).run(with_noise=False)
 
     assert isinstance(result, DetectorResult)
     assert len(result.detectors) == 10
@@ -150,7 +150,7 @@ def test_run_with_detector_backend():
 def test_detector_backend_with_noise():
     """Test a detector-configured backend samples the noisy circuit."""
     sim = GeminiLogicalSimulator(backend=TsimSimulatorBackend(run_detectors=True))
-    result = sim.task(main).run(shots=10, with_noise=True)
+    result = sim.task(main, num_shots=10).run(with_noise=True)
 
     assert isinstance(result, DetectorResult)
     assert len(result.detectors) == 10
@@ -162,7 +162,7 @@ def test_detector_backend_with_noise():
 def test_run_async_with_detector_backend():
     """Test a detector-configured backend returns a Future[DetectorResult]."""
     sim = GeminiLogicalSimulator(backend=TsimSimulatorBackend(run_detectors=True))
-    future = sim.task(main).run_async(shots=5, with_noise=False)
+    future = sim.task(main, num_shots=5).run_async(with_noise=False)
     result = future.result()
 
     assert isinstance(result, DetectorResult)
@@ -174,8 +174,8 @@ def test_run_async_with_detector_backend():
 def test_detector_backend_via_task():
     """Test a detector-configured backend when running a task directly."""
     sim = GeminiLogicalSimulator(backend=TsimSimulatorBackend(run_detectors=True))
-    task = sim.task(main)
-    result = task.run(shots=5, with_noise=False)
+    task = sim.task(main, num_shots=5)
+    result = task.run(with_noise=False)
 
     assert isinstance(result, DetectorResult)
     assert len(result.detectors) == 5
@@ -189,8 +189,8 @@ def test_detector_backend_task_directly():
         noise_model=generate_logical_noise_model(),
         backend=TsimSimulatorBackend(run_detectors=True),
     )
-    task = sim.task(main)
-    result = task.run(shots=5, with_noise=False)
+    task = sim.task(main, num_shots=5)
+    result = task.run(with_noise=False)
     assert isinstance(result, DetectorResult)
     assert len(result.detectors) == 5
     assert len(result.observables) == 5
@@ -203,8 +203,8 @@ def test_detector_backend_task_async():
         noise_model=generate_logical_noise_model(),
         backend=TsimSimulatorBackend(run_detectors=True),
     )
-    task = sim.task(main)
-    future = task.run_async(shots=5, with_noise=False)
+    task = sim.task(main, num_shots=5)
+    future = task.run_async(with_noise=False)
     result = future.result()
     assert isinstance(result, DetectorResult)
     assert len(result.detectors) == 5
@@ -229,7 +229,7 @@ def test_result_property_caching():
         return ilist.map(set_observable, ilist.range(len(reg)))
 
     sim = GeminiLogicalSimulator()
-    result = sim.task(returning_kernel).run(shots=5, with_noise=False)
+    result = sim.task(returning_kernel, num_shots=5).run(with_noise=False)
 
     # Access each property twice to exercise the caching path
     detectors_first = result.detectors
@@ -305,8 +305,8 @@ def test_noiseless_tsim_circuit_compiles_samplers():
 def test_builtin_backends_run_logical_workflow_with_guaranteed_dem(backend):
     result = (
         GeminiLogicalSimulator(backend=backend)
-        .task(small_backend_kernel)
-        .run(shots=2, with_noise=False)
+        .task(small_backend_kernel, num_shots=2)
+        .run(with_noise=False)
     )
 
     assert isinstance(result, Result)
@@ -319,8 +319,8 @@ def test_builtin_backends_run_logical_workflow_with_guaranteed_dem(backend):
 def test_pyqrack_logical_returns_measurement_backed_result():
     result = (
         GeminiLogicalSimulator(backend=_PyQrackSimulatorBackend(seed=18))
-        .task(small_backend_kernel)
-        .run(shots=2, with_noise=False)
+        .task(small_backend_kernel, num_shots=2)
+        .run(with_noise=False)
     )
 
     assert isinstance(result, Result)
@@ -338,6 +338,7 @@ def test_pyqrack_logical_returns_measurement_backed_result():
 )
 def test_logical_task_run_methods_do_not_expose_runtime_configuration(method):
     assert "run_detectors" not in inspect.signature(method).parameters
+    assert "shots" not in inspect.signature(method).parameters
     assert "seed" not in inspect.signature(method).parameters
 
 
@@ -404,8 +405,8 @@ def test_logical_x_observable_is_one(backend: TsimSimulatorBackend):
         gemini_logical.terminal_measure(reg)
 
     append_measurements_and_annotations(logical_x, m2dets, m2obs)
-    task = GeminiLogicalSimulator(backend=backend).task(logical_x)
-    result = task.run(10, with_noise=False)
+    task = GeminiLogicalSimulator(backend=backend).task(logical_x, num_shots=10)
+    result = task.run(with_noise=False)
 
     expected_observable_width = len(m2obs[0])
     assert expected_observable_width > 0
@@ -442,8 +443,8 @@ def test_explicit_annotations_on_kernel_with_terminal_measure(
     append_measurements_and_annotations(
         kernel_with_measure, selected_m2dets, selected_m2obs
     )
-    task = GeminiLogicalSimulator().task(kernel_with_measure)
-    result = task.run(10, with_noise=False)
+    task = GeminiLogicalSimulator().task(kernel_with_measure, num_shots=10)
+    result = task.run(with_noise=False)
 
     expected_detector_width = len(m2dets[0]) if use_dets else 0
     expected_observable_width = len(m2obs[0]) if use_obs else 0
@@ -480,8 +481,8 @@ def test_cudaq_kernel_explicit_conversion_and_annotation(use_dets: bool, use_obs
     selected_m2dets = m2dets if use_dets else None
     selected_m2obs = m2obs if use_obs else None
     append_measurements_and_annotations(squin_kernel, selected_m2dets, selected_m2obs)
-    task = GeminiLogicalSimulator().task(squin_kernel)
-    result = task.run(10, with_noise=False)
+    task = GeminiLogicalSimulator().task(squin_kernel, num_shots=10)
+    result = task.run(with_noise=False)
 
     expected_detector_width = len(m2dets[0]) if use_dets else 0
     expected_observable_width = len(m2obs[0]) if use_obs else 0
@@ -497,7 +498,7 @@ def test_cudaq_kernel_explicit_conversion_and_annotation(use_dets: bool, use_obs
         assert all(isinstance(b, bool) for obs in result.observables for b in obs)
 
 
-def _mock_task() -> Any:
+def _mock_task(num_shots: int = 1) -> Any:
     task = object.__new__(GeminiLogicalSimulatorTask)
     backend = MagicMock()
     backend._detector_error_model.return_value = "dem"
@@ -506,6 +507,7 @@ def _mock_task() -> Any:
     object.__setattr__(task, "_simulator_backend", backend)
     object.__setattr__(task, "fidelity_bounds", MagicMock(return_value=(0.5, 0.9)))
     object.__setattr__(task, "_post_processing", MagicMock())
+    object.__setattr__(task, "num_shots", num_shots)
     return task
 
 
@@ -514,7 +516,7 @@ def test_run_samples_noisy_kernel_through_backend_after_dem_generation():
     samples = np.array([[True, False]])
     task._backend.sample.return_value = BackendSample(measurements=samples)
 
-    result = GeminiLogicalSimulatorTask.run(task, shots=1, with_noise=True)
+    result = GeminiLogicalSimulatorTask.run(task, with_noise=True)
 
     task._backend._detector_error_model.assert_called_once_with("noisy-kernel")
     task._backend.sample.assert_called_once_with("noisy-kernel", shots=1)
@@ -527,7 +529,7 @@ def test_run_samples_noiseless_kernel_through_backend():
     task = _mock_task()
     task._backend.sample.return_value = BackendSample(measurements=np.array([[True]]))
 
-    GeminiLogicalSimulatorTask.run(task, shots=1, with_noise=False)
+    GeminiLogicalSimulatorTask.run(task, with_noise=False)
 
     task._backend.sample.assert_called_once_with("noiseless-kernel", shots=1)
 
@@ -539,7 +541,7 @@ def test_run_uses_native_backend_detector_and_observable_samples():
         detectors=detectors, observables=observables
     )
 
-    result = GeminiLogicalSimulatorTask.run(task, shots=1, with_noise=True)
+    result = GeminiLogicalSimulatorTask.run(task, with_noise=True)
 
     task._backend.sample.assert_called_once_with("noisy-kernel", shots=1)
     assert isinstance(result, DetectorResult)
@@ -559,7 +561,7 @@ def test_run_rejects_invalid_backend_measurement_payloads(sample, message):
     task._backend.sample.return_value = sample
 
     with pytest.raises(ValueError, match=message):
-        GeminiLogicalSimulatorTask.run(task, shots=1)
+        GeminiLogicalSimulatorTask.run(task)
 
 
 @pytest.mark.parametrize(
@@ -584,7 +586,7 @@ def test_run_rejects_nonexclusive_backend_payload_shapes(sample):
     with pytest.raises(
         ValueError, match="measurement-only or detector\\+observable-only"
     ):
-        GeminiLogicalSimulatorTask.run(task, shots=1)
+        GeminiLogicalSimulatorTask.run(task)
 
 
 @pytest.mark.parametrize(
@@ -619,7 +621,7 @@ def test_run_rejects_invalid_backend_detector_payloads(sample, message):
     task._backend.sample.return_value = sample
 
     with pytest.raises(ValueError, match=message):
-        GeminiLogicalSimulatorTask.run(task, shots=1)
+        GeminiLogicalSimulatorTask.run(task)
 
 
 def test_run_fails_on_dem_before_sampling():
@@ -627,13 +629,13 @@ def test_run_fails_on_dem_before_sampling():
     task._backend._detector_error_model.side_effect = ImportError("no tsim")
 
     with pytest.raises(ImportError, match="no tsim"):
-        GeminiLogicalSimulatorTask.run(task, shots=1)
+        GeminiLogicalSimulatorTask.run(task)
 
     task._backend.sample.assert_not_called()
 
 
 def test_task_run_async_submits_run_without_runtime_configuration():
-    task = _mock_task()
+    task = _mock_task(num_shots=3)
     executor = MagicMock()
     future = Future()
     future.set_result(object())
@@ -642,10 +644,10 @@ def test_task_run_async_submits_run_without_runtime_configuration():
     object.__setattr__(task, "_thread_pool_executor", executor)
     object.__setattr__(task, "run", run)
 
-    result = GeminiLogicalSimulatorTask.run_async(task, shots=3, with_noise=False)
+    result = GeminiLogicalSimulatorTask.run_async(task, with_noise=False)
 
     assert result is future
-    executor.submit.assert_called_once_with(run, 3, False)
+    executor.submit.assert_called_once_with(run, with_noise=False)
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
closes https://github.com/QuEraComputing/bloqade-internal/issues/398

- removed "num_shots" from "run" and "run_async" on task classes
- added "num_shots" as a field in task classes
- added "num_shots" as an argument to "task" on simulator classes
- added docstrings and updated tests

## Summary

Moves simulator shot-count configuration from task execution to task creation so
the local Gemini simulators follow the same ownership model as
`bloqade-core`'s `Device.task()` API.

## Breaking change

`num_shots` has been removed from `GeminiLogicalSimulatorTask.run()` and
`run_async()`, and from the corresponding physical simulator task methods.
Configure it when creating the task instead.

```python
# Before
task = GeminiLogicalSimulator().task(kernel)
result = task.run(shots=1_000, with_noise=False)

# After
task = GeminiLogicalSimulator().task(kernel, num_shots=1_000)
result = task.run(with_noise=False)
```

The same migration applies to `run_async()` and `GeminiPhysicalSimulator`.

## What changed

- Added `num_shots` to logical and physical simulator task objects.
- Added `num_shots: int = 1` to `GeminiLogicalSimulator.task()` and
  `GeminiPhysicalSimulator.task()`.
- Updated task execution to use the shot count stored on the task.
- Updated `PostSelectionExperiment` so `make_tasks(..., num_shots=...)`
  configures tomography tasks and `get_samples()` executes those prepared
  tasks without a shot-count argument.
- Migrated affected tests and demos to the new API.
- Added API-shape and task-owned-shot-count coverage for synchronous and
  asynchronous execution.

## Validation

- Updated logical and physical simulator tests.
- Updated decoding regression tests and simulator demos.
- Formatted and type-checked the affected code.