### PR TITLE
docs: add logical.qalloc_at demo (backport of #897)

### DIFF
--- a/demo/logical_qalloc_at_demo.py
+++ b/demo/logical_qalloc_at_demo.py
@@ -1,0 +1,71 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.19.5
+#   kernelspec:
+#     display_name: bloqade-lanes (3.12.13)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Demo for using qalloc_at for Gemini Logical dialect
+#
+# In this notebook, we give a short demo for using the `logical.qalloc_at` statement in the Gemini Logical dialect to allocate qubits at particular positions.
+
+# %% [markdown]
+# Here, we show the slot ID's for the different locations that logical qubits can be allocated on the processor, indexed from 0-9.
+#
+# <img src="./demo_imgs/logical_slot_ids.png" height=200>
+
+
+# %%
+# Define dialects to program in
+from kirin.dialects import ilist
+
+from bloqade.gemini import logical
+
+# Define Gemini simulator device
+from bloqade.gemini.device import GeminiLogicalSimulator
+
+# %% [markdown]
+# We now go through an example of allocating logical qubits at specific "positions".
+
+
+# %%
+@logical.kernel(aggressive_unroll=True)
+def logical_qubit_allocation():
+    qubits = logical.qalloc_at(ilist.IList([1, 2, 3, 4]))
+
+    return logical.terminal_measure(qubits)
+
+
+# %%
+allocated_task = GeminiLogicalSimulator().task(logical_qubit_allocation)
+
+# %%
+# %matplotlib qt
+
+# %%
+# We see that the four qubits are allocated at positions 1-4, skipping position 0.
+# allocated_task.visualize()
+
+
+# %%
+# We can alternative allocate logical qubits in different orders, at different "positions".
+@logical.kernel(aggressive_unroll=True)
+def logical_qubit_allocation_alt():
+    qubits = logical.qalloc_at(ilist.IList([3, 1, 2, 4]))
+
+    return logical.terminal_measure(qubits)
+
+
+# %%
+allocated_task_alt = GeminiLogicalSimulator().task(logical_qubit_allocation_alt)
+
+# %%
+# allocated_task_alt.visualize()

--- a/justfile
+++ b/justfile
@@ -76,7 +76,10 @@ demo-star-logical-demo:
 demo-simulators:
     python demo/simulators_demo.py
 
-demo: demo-msd demo-pipeline pipeline-details simulator-device-demo demo-explicit-allocation demo-logical-dialect demo-logical-new-at demo-msd-postselection-experiment demo-phys-arch-customization demo-star-logical-demo
+demo-qalloc-at:
+    python demo/logical_qalloc_at_demo.py
+
+demo: demo-msd demo-pipeline pipeline-details simulator-device-demo demo-explicit-allocation demo-logical-dialect demo-logical-new-at demo-msd-postselection-experiment demo-phys-arch-customization demo-star-logical-demo demo-qalloc-at
 
 # Install mdBook at the pinned version
 install-mdbook:


### PR DESCRIPTION
Automated backport of PR #897 (b42c3d6052d928c31f37ab1f3594d75c80504d77) to `release-0-11`.

Recreated manually after the automated backport failed — see #913. The original run raced with the backport of #897's prerequisite: the `justfile` hunk carries the `demo-simulators` recipe (added by #893) as context, and the #893 backport (#912) had not merged yet at the time. With #912 in, `git cherry-pick b42c3d60` applies cleanly with no conflict resolution.

Fixes #913