### PR TITLE
fix(search): stop returning unsolvable on solvable instances

### DIFF
--- a/crates/bloqade-lanes-bytecode-python/src/search_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/search_python.rs
@@ -255,7 +255,13 @@ impl PySolveResult {
         self.inner.cost
     }
 
-    /// Number of deadlocks encountered during search.
+    /// Number of nodes at which the generator had nothing useful to offer.
+    ///
+    /// Counts both "nothing scored an improvement" and "nothing was executable"
+    /// (every rectangle rejected). **Not** a count of escape moves taken: the
+    /// counter is incremented before ``deadlock_policy`` is consulted, so under
+    /// the default ``SKIP`` it records nodes where nothing was generated in
+    /// response. Read it as "how often the search got stuck".
     #[getter]
     fn deadlocks(&self) -> u32 {
         self.inner.deadlocks

--- a/crates/bloqade-lanes-bytecode-python/src/search_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/search_python.rs
@@ -205,6 +205,11 @@ pub struct PySolveResult {
 #[pymethods]
 impl PySolveResult {
     /// Status of the solve: "solved", "unsolvable", or "budget_exceeded".
+    ///
+    /// ``"unsolvable"`` is a *proof* only from the ``push_rotate`` strategy. From
+    /// a search strategy it means the search exhausted the moves its generator
+    /// offered, which is less than the architecture allows — see
+    /// ``SolveStatus::Unsolvable`` in the Rust docs for why (issue #910).
     #[getter]
     fn status(&self) -> &'static str {
         self.inner.status.as_label()

--- a/crates/bloqade-lanes-search/src/drivers/entropy.rs
+++ b/crates/bloqade-lanes-search/src/drivers/entropy.rs
@@ -482,6 +482,7 @@ fn build_deadlock_breaker_candidate(
         for entry in chain_scored_entries(&close_chain_entries(
             &mut entries,
             &seed_lanes,
+            occupied,
             config,
             ctx.index,
         )) {
@@ -1455,6 +1456,7 @@ pub(crate) fn generate_candidates(
         for entry in chain_scored_entries(&close_chain_entries(
             &mut entries,
             &seed_lanes,
+            &occupied,
             config,
             ctx.index,
         )) {

--- a/crates/bloqade-lanes-search/src/drivers/entropy.rs
+++ b/crates/bloqade-lanes-search/src/drivers/entropy.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use crate::drivers::result::SearchResult;
 use crate::feasibility::graph::LaneGraph;
 use crate::observer::{SearchEvent, SearchObserver};
-use crate::ops::aod_grid::BusGridContext;
+use crate::ops::aod_grid::{BusGridContext, ChainLink, close_chain_entries};
 use crate::primitives::config::Config;
 use crate::primitives::context::SearchContext;
 use crate::primitives::distance::DistanceTable;
@@ -388,6 +388,25 @@ fn cmp_group_entries(a: &ScoredEntry, b: &ScoredEntry) -> Ordering {
     })
 }
 
+/// Turn the conveyor followers [`close_chain_entries`] pulled in into scored
+/// entries, so their moves get recorded in the candidate's config.
+///
+/// The score is `0.0` deliberately. A follower is not a chosen move — it is
+/// what the chosen move costs — and these entry scores only order candidates
+/// *within* a bus group before the `max_movesets_per_group` truncation. The
+/// authoritative ranking is [`score_moveset`], which reads the whole
+/// old-config → new-config delta and therefore already prices every follower's
+/// displacement, arrival, and mobility change. Synthesizing an entry score here
+/// would double-count it.
+fn chain_scored_entries(links: &[ChainLink]) -> impl Iterator<Item = ScoredEntry> + '_ {
+    links.iter().map(|link| ScoredEntry {
+        qubit_id: link.qubit_id,
+        score: 0.0,
+        lane_encoded: link.lane_encoded,
+        dst_encoded: link.dst_encoded,
+    })
+}
+
 fn build_deadlock_breaker_candidate(
     config: &Config,
     occupied: &HashSet<u64>,
@@ -427,6 +446,7 @@ fn build_deadlock_breaker_candidate(
 
         let mut entries: HashMap<u64, u64> = HashMap::new();
         let mut entry_by_lane: HashMap<u64, ScoredEntry> = HashMap::new();
+        let mut seed_lanes: Vec<u64> = Vec::new();
         let mut seen_qubits: HashSet<u32> = HashSet::new();
         let mut selected_unresolved = 0usize;
         for t in &qubits {
@@ -444,6 +464,7 @@ fn build_deadlock_breaker_candidate(
                 }
                 entries.insert(src_enc, t.lane_encoded);
                 entry_by_lane.insert(t.lane_encoded, *t);
+                seed_lanes.push(t.lane_encoded);
                 if unresolved.contains(&t.qubit_id) {
                     selected_unresolved += 1;
                 }
@@ -452,6 +473,19 @@ fn build_deadlock_breaker_candidate(
 
         if entries.is_empty() {
             continue;
+        }
+
+        // Conveyor followers ride along (#910). They are exempt from the
+        // `target_movers` cap on purpose: the cap limits how many atoms this
+        // breaker *chooses* to move, and a follower is not a choice — without
+        // it the mover ahead has nowhere to go and the group emits nothing.
+        for entry in chain_scored_entries(&close_chain_entries(
+            &mut entries,
+            &seed_lanes,
+            config,
+            ctx.index,
+        )) {
+            entry_by_lane.insert(entry.lane_encoded, entry);
         }
 
         for grid_lanes in grid_ctx.build_aod_grids(&entries) {
@@ -1403,14 +1437,28 @@ pub(crate) fn generate_candidates(
         let grid_ctx = BusGridContext::new(ctx.index, mt, bus_id, None, dir, &occupied);
 
         let mut entries: HashMap<u64, u64> = HashMap::new();
-        let mut entry_by_lane: HashMap<u64, &ScoredEntry> = HashMap::new();
+        let mut entry_by_lane: HashMap<u64, ScoredEntry> = HashMap::new();
+        let mut seed_lanes: Vec<u64> = Vec::with_capacity(qubits.len());
         for t in &qubits {
             let lane = LaneAddr::decode_u64(t.lane_encoded);
             if let Some((src, _)) = ctx.index.endpoints(&lane) {
                 let src_enc = src.encode();
                 entries.insert(src_enc, t.lane_encoded);
-                entry_by_lane.insert(t.lane_encoded, t);
+                entry_by_lane.insert(t.lane_encoded, *t);
+                seed_lanes.push(t.lane_encoded);
             }
+        }
+
+        // Co-select the conveyor followers a selected mover has to displace, to
+        // the end of the chain (#910). Without them the leader's rectangle is
+        // unexecutable and a packed block yields no candidate at all.
+        for entry in chain_scored_entries(&close_chain_entries(
+            &mut entries,
+            &seed_lanes,
+            config,
+            ctx.index,
+        )) {
+            entry_by_lane.insert(entry.lane_encoded, entry);
         }
 
         // Grids may include empty filler lanes so the emitted MoveSet remains

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -632,7 +632,8 @@ impl MoveGenerator for HeuristicGenerator {
             // scored `<= 0` and was pruned — leaves the rectangle unexecutable
             // and the group emits nothing. Co-select those followers, to the end
             // of the chain, so the whole shift rides in one AOD shot.
-            let chain_links = close_chain_entries(&mut entries, &seed_lanes, config, ctx.index);
+            let chain_links =
+                close_chain_entries(&mut entries, &seed_lanes, &occupied, config, ctx.index);
             let chain_triples: Vec<ScoredTriple> = if chain_links.is_empty() {
                 Vec::new()
             } else {

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -333,6 +333,12 @@ impl MoveGenerator for HeuristicGenerator {
         _state: &mut SearchState,
         out: &mut Vec<MoveCandidate>,
     ) {
+        // Candidates already in `out` belong to the caller, not to this call:
+        // `MoveGenerator::generate` appends. Step 7 needs to know whether *this*
+        // call produced anything, so record the mark rather than testing
+        // `out.is_empty()` and silently depending on every caller to clear first.
+        let out_mark = out.len();
+
         // Select the CZ-coordination policy ONCE. `cz_pairs.is_some()`
         // (entangling: loose-goal/no-home/RH) vs `None` (legacy fixed-target)
         // formerly gated three inline branches; the policy makes that explicit.
@@ -717,12 +723,13 @@ impl MoveGenerator for HeuristicGenerator {
         // scored positive. A positive score is a claim about distance, made in
         // step 2 before any AOD geometry is known; whether a candidate can
         // actually execute is decided two steps later by `build_aod_grids`. If
-        // every positive candidate's rectangle turns out unexecutable, `out` is
-        // empty and the node is a dead end — and gating on `has_positive` alone
+        // every positive candidate's rectangle turns out unexecutable this call
+        // emits nothing and the node is a dead end — and gating on `has_positive`
+        // alone
         // meant the escape hatch stayed shut in exactly that case, so the search
         // drained its open list and reported `unsolvable` on solvable instances
         // (#910).
-        if out.is_empty() || !has_positive {
+        if out.len() == out_mark || !has_positive {
             self.deadlock_count.set(self.deadlock_count.get() + 1);
             match self.deadlock_policy {
                 DeadlockPolicy::Skip => {}
@@ -928,6 +935,97 @@ mod tests {
             snapshot(&out)
         );
     }
+
+    fn make_siding_index() -> LaneIndex {
+        let spec: ArchSpec =
+            serde_json::from_str(crate::test_utils::chain_with_siding_arch_json()).unwrap();
+        assert!(
+            spec.validate().is_ok(),
+            "siding fixture must be a legal spec"
+        );
+        LaneIndex::new(spec)
+    }
+
+    /// The **actual** cause of the `unsolvable` verdicts in issue #910: a node
+    /// whose every candidate scored positive but whose every rectangle turned
+    /// out unexecutable, leaving it with no successors at all.
+    ///
+    /// `q0`-`q2` fill the three-site chain of word 0 and `q0` wants the far end.
+    /// Its first hop is admitted — the atom ahead is a chain source, so it can
+    /// vacate — and scores `+1`, so `has_positive` is true. But the chain's head
+    /// sits on site 2, which is a chain *destination* and not a chain source, so
+    /// it cannot vacate on that group; the closure stops there and
+    /// `build_aod_grids` rightly rejects every rectangle. The word-bus
+    /// alternative scores `-1` and is pruned by `retain(score > 0)`.
+    ///
+    /// So the grid path legitimately yields nothing, and the escape hatch used to
+    /// stay shut because something had scored positive — a step-2 claim about
+    /// distance, decided before any geometry existed. The node died silently,
+    /// with the deadlock counter reading zero.
+    #[test]
+    fn a_node_whose_rectangles_all_fail_still_gets_escape_moves() {
+        let index = make_siding_index();
+        let config = Config::new([(0, loc(0, 0)), (1, loc(0, 1)), (2, loc(0, 2))]).unwrap();
+        let targets = [(0u32, loc(0, 2))];
+        let table = make_table(&targets, &index);
+        let targets_enc: Vec<(u32, u64)> = targets.iter().map(|&(q, l)| (q, l.encode())).collect();
+        let blocked = HashSet::new();
+        let ctx = make_ctx(&index, &table, &targets_enc, &blocked);
+
+        // With escapes disabled, the node really does produce nothing: this pins
+        // that the grid path is empty, so the assertion below is about the escape
+        // hatch rather than about some rectangle happening to work.
+        let mut grid_only = Vec::new();
+        HeuristicGenerator::new()
+            .with_deadlock_policy(DeadlockPolicy::Skip)
+            .generate(
+                &config,
+                NodeId(0),
+                &ctx,
+                &mut SearchState::default(),
+                &mut grid_only,
+            );
+        assert!(
+            grid_only.is_empty(),
+            "expected no executable rectangle at this node; got {:?}",
+            snapshot(&grid_only)
+        );
+
+        let generator = HeuristicGenerator::new().with_deadlock_policy(DeadlockPolicy::AllMoves);
+        let mut out = Vec::new();
+        generator.generate(
+            &config,
+            NodeId(0),
+            &ctx,
+            &mut SearchState::default(),
+            &mut out,
+        );
+        assert!(
+            !out.is_empty(),
+            "a node with no executable rectangle must still get escape moves, \
+             otherwise the search reports `unsolvable` on a solvable instance"
+        );
+        assert_eq!(
+            generator.deadlock_count(),
+            1,
+            "the node is a dead end and must be counted as one, so the metric \
+             stops hiding this failure mode"
+        );
+    }
+
+    // No end-to-end companion to the test above, deliberately. Reaching a *goal*
+    // through this fixture runs into a different and untouched limit: with
+    // `retain(score > 0)` pruning every non-improving move whenever an improving
+    // one exists, the reachable subgraph of a three-site siding is a handful of
+    // forced moves that closes on itself, so the solve still exhausts. That is
+    // the generator's move vocabulary, not the escape gate, and a test asserting
+    // `Solved` here would be asserting the wrong thing.
+    //
+    // The end-to-end evidence for this fix is the instance in #910 itself — a
+    // 98-atom, 49-pair stage phase on a gate+memory 5x16 spec, which went from
+    // `unsolvable` to solved in 16 layers (ids) and 15 (astar). That arch is not
+    // in this repo, so it cannot be a committed test; the numbers are recorded in
+    // the commit message.
 
     fn make_ctx<'a>(
         index: &'a LaneIndex,

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -18,6 +18,7 @@ use rand::{Rng, SeedableRng};
 use crate::generators::cz_coordination::{
     CzCoordination, EntanglingCoordination, FixedTargetCoordination,
 };
+use crate::ops::aod_grid::{ChainLink, close_chain_entries, vacating_lane};
 use crate::primitives::config::Config;
 use crate::primitives::context::{MoveCandidate, SearchContext, SearchState};
 use crate::primitives::distance::DistanceTable;
@@ -258,45 +259,46 @@ impl HeuristicGenerator {
 }
 
 /// Whether the atom occupying `dst` could vacate in the same AOD shot as
-/// `lane`: it has an outgoing lane on the same
-/// `(zone_id, move_type, bus_id, direction)` group — the four fields
-/// `ArchSpec::check_lane_group_consistency` requires a group to share, so a
-/// candidate admitted here is one the validator will accept.
-///
-/// The `zone_id` term only bites for `ZoneBus` lanes: site and word buses are
-/// intra-zone, so a lane and its destination share a zone automatically. A
-/// single `zone_bus` may serve several zones across its pairs, and for such a
-/// lane `zone_id` is the *source's* zone, so a chain through it
-/// (`z0w0 → z1w0`, then `z1w0 → z2w0`) carries a different `zone_id` per hop.
-///
-/// Consequence, stated honestly: those hops get **serialized** into one
-/// operation each. Serialization is permitted by the architecture — but so is
-/// batching them, since one zone bus may carry transfers among more than two
-/// zones in a single shot. This predicate is therefore deliberately *stricter
-/// than the architecture*, matching today's group-consistency rule rather than
-/// the hardware's capability. The reason to keep it that way for now is that
-/// `check_lane_group_consistency` rejects a mixed-`zone_id` group, so
-/// generating such candidates would produce plans that fail the
-/// solver-boundary replay outright. Unlocking the batching means relaxing that
-/// rule for zone buses first, then relaxing this in step.
+/// `lane` — see [`vacating_lane`] for which lanes qualify and why the rule is
+/// deliberately stricter than the architecture for zone buses.
 ///
 /// This is the selection-time half of the uniform destination rule (#866).
 /// [`crate::ops::aod_grid::destination_is_available`] states the rule against a
 /// known mover set; at scoring time that set does not exist yet, so this
-/// admits a conveyor chain as a *candidate* and
-/// `BusGridContext::is_valid_rect` adjudicates once the rectangle's actual
-/// movers are known.
+/// admits a conveyor chain as a *candidate*, [`close_chain_entries`] co-selects
+/// the atoms that make it executable, and `BusGridContext::is_valid_rect`
+/// adjudicates once the rectangle's actual movers are known.
 ///
 /// Necessarily `false` on endpoint-disjoint buses — a destination there is
 /// never a source of the same bus — so the shipped Gemini specs produce
 /// exactly the same candidates as the previous unconditional occupancy filter.
 fn occupant_can_vacate(dst: LocationAddr, lane: &LaneAddr, index: &LaneIndex) -> bool {
-    index.outgoing_lanes(dst).iter().any(|l| {
-        l.zone_id == lane.zone_id
-            && l.move_type == lane.move_type
-            && l.bus_id == lane.bus_id
-            && l.direction == lane.direction
-    })
+    vacating_lane(dst, lane, index).is_some()
+}
+
+/// Distance improvement for a co-selected conveyor follower, on the same
+/// `d_now - d_after` scale the scoring loop uses for chosen movers.
+///
+/// A follower is not a chosen move — it is what the chosen move costs — and
+/// that cost is real: shifting an atom off its target scores `-1`, so a chain
+/// that derails a packed block ranks below one that runs into free space. A
+/// follower with no target of its own, or an unreachable one, contributes `0`
+/// rather than a fabricated preference.
+fn chain_link_score(
+    link: &ChainLink,
+    targets: &HashMap<u32, u64>,
+    dist_table: &DistanceTable,
+) -> i32 {
+    let Some(&target_enc) = targets.get(&link.qubit_id) else {
+        return 0;
+    };
+    let (Some(d_now), Some(d_after)) = (
+        dist_table.distance(link.src_encoded, target_enc),
+        dist_table.distance(link.dst_encoded, target_enc),
+    ) else {
+        return 0;
+    };
+    d_now as i32 - d_after as i32
 }
 
 /// Yield `(lane, destination)` pairs for every outgoing lane from `loc`
@@ -590,6 +592,10 @@ impl MoveGenerator for HeuristicGenerator {
         // Side-index of movesets already emitted, for O(1) dedup. Order of
         // `candidates` is irrelevant — Step 6 re-sorts by score.
         let mut seen_movesets: HashSet<MoveSet> = HashSet::new();
+        // Target lookup for scoring co-selected conveyor followers. Built on
+        // first use so the endpoint-disjoint specs — where no chain can ever
+        // form — pay nothing for it.
+        let mut target_by_qubit: Option<HashMap<u32, u64>> = None;
 
         for (
             TripletKey {
@@ -605,19 +611,51 @@ impl MoveGenerator for HeuristicGenerator {
                 ctx.index, mt, bus_id, None, dir, &occupied,
             );
 
-            // Build entries (src_encoded -> lane_encoded) and a lane -> triple lookup.
-            // Each source location has at most one atom, so no overwrites occur.
+            // Build entries (src_encoded -> lane_encoded) and the seed order for
+            // the chain closure. Each source location has at most one atom, so
+            // no overwrites occur.
             let mut entries: HashMap<u64, u64> = HashMap::new();
-            let mut triple_by_lane: HashMap<u64, &ScoredTriple> = HashMap::new();
+            let mut seed_lanes: Vec<u64> = Vec::with_capacity(qubits.len());
 
             for t in &qubits {
                 let lane = LaneAddr::decode_u64(t.lane_encoded);
                 if let Some((src, _)) = ctx.index.endpoints(&lane) {
                     let src_enc = src.encode();
                     entries.insert(src_enc, t.lane_encoded);
-                    triple_by_lane.insert(t.lane_encoded, t);
+                    seed_lanes.push(t.lane_encoded);
                 }
             }
+
+            // Step 5a: chain closure (#910). Scoring picks movers one qubit at a
+            // time, so a mover whose destination is held by an atom that must
+            // vacate with it — one already on its target, or one whose own move
+            // scored `<= 0` and was pruned — leaves the rectangle unexecutable
+            // and the group emits nothing. Co-select those followers, to the end
+            // of the chain, so the whole shift rides in one AOD shot.
+            let chain_links = close_chain_entries(&mut entries, &seed_lanes, config, ctx.index);
+            let chain_triples: Vec<ScoredTriple> = if chain_links.is_empty() {
+                Vec::new()
+            } else {
+                let targets = target_by_qubit
+                    .get_or_insert_with(|| ctx.targets.iter().copied().collect::<HashMap<_, _>>());
+                chain_links
+                    .iter()
+                    .map(|link| ScoredTriple {
+                        qubit_id: link.qubit_id,
+                        score: chain_link_score(link, targets, ctx.dist_table),
+                        lane_encoded: link.lane_encoded,
+                        dst_encoded: link.dst_encoded,
+                    })
+                    .collect()
+            };
+
+            // Lane -> triple lookup over both the selected movers and the
+            // followers pulled in behind them.
+            let triple_by_lane: HashMap<u64, &ScoredTriple> = qubits
+                .iter()
+                .chain(chain_triples.iter())
+                .map(|t| (t.lane_encoded, t))
+                .collect();
 
             // Build rectangular grids via two-phase algorithm. Grids may include
             // empty filler lanes to keep complete AOD geometry; only lanes that
@@ -748,13 +786,16 @@ mod tests {
         );
     }
 
-    /// Chains now assemble into a single AOD shot (issue #887).
+    /// Chains assemble into a single AOD shot (issue #887).
     ///
-    /// Selection still picks movers independently — nothing here co-selects
-    /// the atom ahead. What changed is one layer down: rectangle growth
-    /// repairs a chain by pulling in the follower's cell, so both hops ride in
-    /// one move set. Previously only the follower's move was emitted, leaving
-    /// the leader to wait a step.
+    /// Both atoms are nominated by scoring here, so this case is carried by the
+    /// grid layer alone: rectangle growth repairs the chain by pulling in the
+    /// follower's cell, and both hops ride in one move set. Previously only the
+    /// follower's move was emitted, leaving the leader to wait a step.
+    ///
+    /// [`packed_chain_shifts_the_whole_row_in_one_shot`] covers what growth
+    /// cannot reach — a follower that scoring never nominated, which needs the
+    /// selection-time closure.
     #[test]
     fn heuristic_selection_assembles_chains() {
         let index = make_chain_index();
@@ -781,6 +822,99 @@ mod tests {
             out.iter()
                 .map(|c| (c.new_config.location_of(0), c.new_config.location_of(1)))
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// The packed conveyor of issue #910, as small as it gets: atoms on sites
+    /// 0-3, only site 4 free, and `q0` has to travel to the far end.
+    ///
+    /// `q1..q3` already sit on their targets, so nothing scores them and they
+    /// never became movers — which used to make `q0`'s rectangle unexecutable
+    /// and left the node with **zero** successors. Under grid-complete
+    /// activation there is no chain-free alternative in a packed block, so the
+    /// search reported `unsolvable` on an instance a whole-row shift solves.
+    fn packed_chain_setup() -> (LaneIndex, Config, [(u32, LocationAddr); 4]) {
+        let index = make_chain_index();
+        let config = Config::new([
+            (0, loc(0, 0)),
+            (1, loc(0, 1)),
+            (2, loc(0, 2)),
+            (3, loc(0, 3)),
+        ])
+        .unwrap();
+        let targets = [
+            (0u32, loc(0, 4)),
+            (1, loc(0, 1)),
+            (2, loc(0, 2)),
+            (3, loc(0, 3)),
+        ];
+        (index, config, targets)
+    }
+
+    #[test]
+    fn packed_chain_shifts_the_whole_row_in_one_shot() {
+        let (index, config, targets) = packed_chain_setup();
+        let dist_table = make_table(&targets, &index);
+        let targets_raw: Vec<(u32, u64)> = targets.iter().map(|&(q, l)| (q, l.encode())).collect();
+        let blocked = HashSet::new();
+        let ctx = make_ctx(&index, &dist_table, &targets_raw, &blocked);
+
+        let mut out = Vec::new();
+        HeuristicGenerator::new().generate(
+            &config,
+            NodeId(0),
+            &ctx,
+            &mut SearchState::default(),
+            &mut out,
+        );
+
+        assert!(
+            !out.is_empty(),
+            "a packed conveyor with a free head must still have successors"
+        );
+        let shifts_all = out
+            .iter()
+            .any(|c| (0..4).all(|q| c.new_config.location_of(q) == Some(loc(0, q + 1))));
+        assert!(
+            shifts_all,
+            "expected one candidate shifting all four atoms; got {:?}",
+            snapshot(&out)
+        );
+    }
+
+    /// Same witness through the entropy generator: its candidate path derives
+    /// movers from the same selected-entry set, so it deadlocked here too.
+    #[test]
+    fn packed_chain_shifts_the_whole_row_under_entropy() {
+        use crate::drivers::entropy::EntropyParams;
+        use crate::generators::entropy::EntropyGenerator;
+
+        let (index, config, targets) = packed_chain_setup();
+        let dist_table = make_table(&targets, &index);
+        let targets_raw: Vec<(u32, u64)> = targets.iter().map(|&(q, l)| (q, l.encode())).collect();
+        let blocked = HashSet::new();
+        let ctx = make_ctx(&index, &dist_table, &targets_raw, &blocked);
+
+        let mut out = Vec::new();
+        EntropyGenerator::new(EntropyParams::default(), 0).generate(
+            &config,
+            NodeId(0),
+            &ctx,
+            &mut SearchState::default(),
+            &mut out,
+        );
+
+        assert!(
+            !out.is_empty(),
+            "entropy generator must have successors on a packed conveyor"
+        );
+        let shifts_all = out
+            .iter()
+            .any(|c| (0..4).all(|q| c.new_config.location_of(q) == Some(loc(0, q + 1))));
+        assert!(
+            shifts_all,
+            "expected one candidate shifting all four atoms; got {:?}",
+            snapshot(&out)
         );
     }
 

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -712,7 +712,17 @@ impl MoveGenerator for HeuristicGenerator {
         }
 
         // Step 7: deadlock escape.
-        if !has_positive {
+        //
+        // Fires when the node has **no successors**, not merely when nothing
+        // scored positive. A positive score is a claim about distance, made in
+        // step 2 before any AOD geometry is known; whether a candidate can
+        // actually execute is decided two steps later by `build_aod_grids`. If
+        // every positive candidate's rectangle turns out unexecutable, `out` is
+        // empty and the node is a dead end — and gating on `has_positive` alone
+        // meant the escape hatch stayed shut in exactly that case, so the search
+        // drained its open list and reported `unsolvable` on solvable instances
+        // (#910).
+        if out.is_empty() || !has_positive {
             self.deadlock_count.set(self.deadlock_count.get() + 1);
             match self.deadlock_policy {
                 DeadlockPolicy::Skip => {}

--- a/crates/bloqade-lanes-search/src/generators/heuristic.rs
+++ b/crates/bloqade-lanes-search/src/generators/heuristic.rs
@@ -281,24 +281,37 @@ fn occupant_can_vacate(dst: LocationAddr, lane: &LaneAddr, index: &LaneIndex) ->
 ///
 /// A follower is not a chosen move — it is what the chosen move costs — and
 /// that cost is real: shifting an atom off its target scores `-1`, so a chain
-/// that derails a packed block ranks below one that runs into free space. A
-/// follower with no target of its own, or an unreachable one, contributes `0`
-/// rather than a fabricated preference.
+/// that derails a packed block ranks below one that runs into free space.
+///
+/// The three ways a delta is unavailable are *not* equivalent, so they do not
+/// share a score:
+///
+/// * **No target of its own** — a spectator, genuinely neutral, `0`.
+/// * **Already unreachable** before this hop — the chain did not cause it, so
+///   also `0`.
+/// * **Reachable now, unreachable after** — the chain would strand the atom.
+///   That is the worst outcome available and must not tie with "no change", so
+///   it is penalized: `STRANDS_FOLLOWER`.
 fn chain_link_score(
     link: &ChainLink,
     targets: &HashMap<u32, u64>,
     dist_table: &DistanceTable,
 ) -> i32 {
+    /// Penalty for a hop that leaves a follower unable to reach its target at
+    /// all. Worse than any finite regression a single hop can produce (a lane
+    /// moves one hop, so `d_now - d_after >= -1` whenever both are finite).
+    const STRANDS_FOLLOWER: i32 = -2;
+
     let Some(&target_enc) = targets.get(&link.qubit_id) else {
         return 0;
     };
-    let (Some(d_now), Some(d_after)) = (
-        dist_table.distance(link.src_encoded, target_enc),
-        dist_table.distance(link.dst_encoded, target_enc),
-    ) else {
+    let Some(d_now) = dist_table.distance(link.src_encoded, target_enc) else {
         return 0;
     };
-    d_now as i32 - d_after as i32
+    match dist_table.distance(link.dst_encoded, target_enc) {
+        Some(d_after) => d_now as i32 - d_after as i32,
+        None => STRANDS_FOLLOWER,
+    }
 }
 
 /// Yield `(lane, destination)` pairs for every outgoing lane from `loc`
@@ -719,16 +732,22 @@ impl MoveGenerator for HeuristicGenerator {
 
         // Step 7: deadlock escape.
         //
-        // Fires when the node has **no successors**, not merely when nothing
-        // scored positive. A positive score is a claim about distance, made in
-        // step 2 before any AOD geometry is known; whether a candidate can
-        // actually execute is decided two steps later by `build_aod_grids`. If
-        // every positive candidate's rectangle turns out unexecutable this call
-        // emits nothing and the node is a dead end — and gating on `has_positive`
-        // alone
-        // meant the escape hatch stayed shut in exactly that case, so the search
-        // drained its open list and reported `unsolvable` on solvable instances
-        // (#910).
+        // Two independent triggers, either of which opens the hatch:
+        //
+        // 1. `!has_positive` — nothing scored an improvement. Pre-existing, and
+        //    deliberately *not* conditional on the output being empty: the
+        //    step-3 fallback keeps a narrow set of non-improving entries that
+        //    may well have produced candidates, and escapes are appended
+        //    alongside those rather than replacing them.
+        // 2. This call emitted nothing at all. Added for #910.
+        //
+        // The second exists because a positive score is a claim about
+        // *distance*, made in step 2 before any AOD geometry is known, whereas
+        // whether a candidate can actually execute is settled two steps later by
+        // `build_aod_grids`. When every positive-scoring candidate's rectangle
+        // turns out unexecutable, trigger 1 stays silent, and with it alone the
+        // node was a dead end with no escape — the search drained its open list
+        // and reported `unsolvable` on a solvable instance.
         if out.len() == out_mark || !has_positive {
             self.deadlock_count.set(self.deadlock_count.get() + 1);
             match self.deadlock_policy {
@@ -972,23 +991,36 @@ mod tests {
         let blocked = HashSet::new();
         let ctx = make_ctx(&index, &table, &targets_enc, &blocked);
 
-        // With escapes disabled, the node really does produce nothing: this pins
-        // that the grid path is empty, so the assertion below is about the escape
-        // hatch rather than about some rectangle happening to work.
+        // `Skip` is `SolveOptions::default()`, so this half is what a caller who
+        // never touches `deadlock_policy` actually gets: the gate opens (the node
+        // *is* recognised as a dead end) but the policy declines to generate
+        // anything, so the node still has no successors and the search still
+        // reports `unsolvable`. Pinning both halves means a future change to the
+        // default cannot silently switch #910's fix on or off for every default
+        // caller without a test moving.
+        //
+        // It doubles as the control for the assertion below: the grid path really
+        // is empty here, so what follows is about the escape hatch and not about
+        // some rectangle happening to work.
+        let skipped = HeuristicGenerator::new().with_deadlock_policy(DeadlockPolicy::Skip);
         let mut grid_only = Vec::new();
-        HeuristicGenerator::new()
-            .with_deadlock_policy(DeadlockPolicy::Skip)
-            .generate(
-                &config,
-                NodeId(0),
-                &ctx,
-                &mut SearchState::default(),
-                &mut grid_only,
-            );
+        skipped.generate(
+            &config,
+            NodeId(0),
+            &ctx,
+            &mut SearchState::default(),
+            &mut grid_only,
+        );
         assert!(
             grid_only.is_empty(),
-            "expected no executable rectangle at this node; got {:?}",
+            "on the default policy this node has no successors; got {:?}",
             snapshot(&grid_only)
+        );
+        assert_eq!(
+            skipped.deadlock_count(),
+            1,
+            "the gate must still fire under `Skip` — the node is a dead end \
+             whatever the policy then decides to do about it"
         );
 
         let generator = HeuristicGenerator::new().with_deadlock_policy(DeadlockPolicy::AllMoves);

--- a/crates/bloqade-lanes-search/src/ops/aod_grid.rs
+++ b/crates/bloqade-lanes-search/src/ops/aod_grid.rs
@@ -11,7 +11,7 @@
 
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use bloqade_lanes_bytecode_core::arch::addr::{Direction, LaneAddr, LocationAddr, MoveType};
 
@@ -75,9 +75,17 @@ pub(crate) fn destination_is_available(
 ///
 /// The `zone_id` term only bites for `ZoneBus` lanes: site and word buses are
 /// intra-zone, so a lane and its destination share a zone automatically. A
-/// single `zone_bus` may serve several zones across its pairs, and for such a
-/// lane `zone_id` is the *source's* zone, so a chain through it
-/// (`z0w0 → z1w0`, then `z1w0 → z2w0`) carries a different `zone_id` per hop.
+/// single `zone_bus` may serve several zones across its pairs, and each hop of a
+/// chain through it (`z0w0 → z1w0`, then `z1w0 → z2w0`) carries a different
+/// `zone_id`, so no two hops can share a group.
+///
+/// This matches on the raw [`LaneAddr`] fields rather than on resolved
+/// endpoints, deliberately: `check_lane_group_consistency` groups on those same
+/// raw fields. Note they are not always the *source's* zone — a backward
+/// `ZoneBus` lane's true source is the forward destination (see
+/// [`BusGridMaps`](crate::primitives::bus_grid_maps::BusGridMaps)) — which is
+/// another reason to compare the addresses the validator compares instead of
+/// reasoning about which end is which.
 ///
 /// Consequence, stated honestly: those hops get **serialized** into one
 /// operation each. Serialization is permitted by the architecture — but so is
@@ -162,30 +170,60 @@ pub(crate) struct ChainLink {
 /// spinning — though `ArchSpec::validate` rejects cyclic buses outright
 /// (#874), which is what makes a closed chain a shift and not a rotation.
 ///
+/// # Cost
+///
+/// Runs on every expansion of every spec, chain-capable or not, so the walk is
+/// ordered cheapest-test-first: the `occupied` lookup is a hash probe and
+/// rejects the common case (a free destination) before
+/// [`Config::qubit_at`]'s O(atoms) scan is reached. Skipping it would make this
+/// quadratic in the atom count on exactly the specs where it can never do
+/// anything. `occupied` is the caller's config-plus-blocked set, so the probe
+/// and the scan agree: a location holding an atom is always in `occupied`, and a
+/// blocked location has no qubit either way.
+///
+/// The worklist is walked by cursor rather than drained, so the only allocation
+/// is `links` — and `pending` never allocates unless a chain actually forms.
+///
 /// A no-op on endpoint-disjoint buses (see [`vacating_lane`]), so the shipped
 /// Gemini specs get byte-identical entry sets.
 pub(crate) fn close_chain_entries(
     entries: &mut HashMap<u64, u64>,
     seed_lanes: &[u64],
+    occupied: &HashSet<u64>,
     config: &Config,
     index: &LaneIndex,
 ) -> Vec<ChainLink> {
     let mut links: Vec<ChainLink> = Vec::new();
-    let mut queue: VecDeque<u64> = seed_lanes.iter().copied().collect();
+    // Walk the seeds first, then whatever the closure appends behind them.
+    let mut pending: Vec<u64> = Vec::new();
+    let mut cursor = 0usize;
 
-    while let Some(lane_enc) = queue.pop_front() {
+    loop {
+        let lane_enc = match seed_lanes.get(cursor) {
+            Some(&enc) => enc,
+            None => match pending.get(cursor - seed_lanes.len()) {
+                Some(&enc) => enc,
+                None => break,
+            },
+        };
+        cursor += 1;
+
         let lane = LaneAddr::decode_u64(lane_enc);
         let Some((_, dst)) = index.endpoints(&lane) else {
             continue;
         };
         let dst_enc = dst.encode();
+        // Nothing in the way: no atom, or a blocked site, which holds no qubit
+        // and never frees up. Checked first because it is a hash probe and it is
+        // what almost every lane hits.
+        if !occupied.contains(&dst_enc) {
+            continue;
+        }
         // The occupant is already a mover on this group, so the rule is
         // satisfied and there is nothing to add.
         if entries.contains_key(&dst_enc) {
             continue;
         }
-        // No atom to co-select: the destination is free, or it is a blocked
-        // site, which holds no qubit and never frees up.
         let Some(qubit_id) = config.qubit_at(dst) else {
             continue;
         };
@@ -206,7 +244,7 @@ pub(crate) fn close_chain_entries(
             src_encoded: dst_enc,
             dst_encoded: next_dst.encode(),
         });
-        queue.push_back(next_lane_enc);
+        pending.push(next_lane_enc);
     }
 
     links
@@ -404,14 +442,24 @@ impl<'a> BusGridContext<'a> {
     /// whose selection can nominate an atom whose destination is occupied must
     /// therefore run [`close_chain_entries`] first, so the atoms that *have* to
     /// move are in `entries` before the geometry is decided — otherwise the
-    /// group silently emits nothing (#910). The heuristic generator and both
-    /// entropy candidate paths do this.
+    /// group silently emits nothing (#910).
     ///
-    /// [`GreedyGenerator`](crate::generators::greedy::GreedyGenerator) does not,
-    /// and does not need to: `find_path_occupied` treats every atom as a wall, so
-    /// its first-step lanes never point at an occupied site and no chain can
-    /// arise. That also makes it chain-*incapable* — following a chain would take
-    /// multi-agent pathfinding rather than per-atom BFS (#887).
+    /// Where each caller stands:
+    ///
+    /// * The heuristic generator and both entropy candidate paths run the
+    ///   closure.
+    /// * [`GreedyGenerator`](crate::generators::greedy::GreedyGenerator) does
+    ///   not, and does not need to: `find_path_occupied` treats every atom as a
+    ///   wall, so its first-step lanes never point at an occupied site and no
+    ///   chain can arise. That also makes it chain-*incapable* — following a
+    ///   chain would take multi-agent pathfinding rather than per-atom BFS
+    ///   (#887).
+    /// * [`pack_aod_rectangles`](crate::dsl::pipeline) does not, and **does**
+    ///   need to: a Starlark policy enumerates legal lanes itself, with no
+    ///   occupancy prefilter, so a policy that nominates a lane into an occupied
+    ///   site still hits #910 on a chain-capable spec. Latent rather than live —
+    ///   no shipped spec can form a chain — and tracked separately rather than
+    ///   fixed here.
     ///
     /// # What the result is, precisely
     ///
@@ -1550,6 +1598,15 @@ mod tests {
             Config::new(sites.iter().map(|&s| (s, loc(0, s)))).unwrap()
         }
 
+        /// The occupancy set every caller passes: atom locations plus `blocked`.
+        fn occupied_of(config: &Config, blocked: &[u32]) -> HashSet<u64> {
+            config
+                .iter()
+                .map(|(_, l)| l.encode())
+                .chain(blocked.iter().map(|&s| loc(0, s).encode()))
+                .collect()
+        }
+
         /// Seed the closure with the forward site-bus-0 lane out of `site`.
         fn seed(site: u32) -> Vec<u64> {
             vec![lane(0, site, 0).encode_u64()]
@@ -1565,7 +1622,13 @@ mod tests {
                 .into_iter()
                 .collect();
 
-            let links = close_chain_entries(&mut entries, &seed(0), &config, &index);
+            let links = close_chain_entries(
+                &mut entries,
+                &seed(0),
+                &occupied_of(&config, &[]),
+                &config,
+                &index,
+            );
 
             let hops: Vec<(u32, u32, u32)> = links
                 .iter()
@@ -1594,7 +1657,13 @@ mod tests {
                 .into_iter()
                 .collect();
 
-            let links = close_chain_entries(&mut entries, &seed(0), &config, &index);
+            let links = close_chain_entries(
+                &mut entries,
+                &seed(0),
+                &occupied_of(&config, &[]),
+                &config,
+                &index,
+            );
 
             assert_eq!(links.len(), 1, "site 2 is free, so the chain ends at q1");
             assert_eq!(links[0].qubit_id, 1);
@@ -1612,7 +1681,13 @@ mod tests {
             let mut entries: HashMap<u64, u64> =
                 [(loc(0, 3).encode(), seed_lane)].into_iter().collect();
 
-            let links = close_chain_entries(&mut entries, &seed(3), &config, &index);
+            let links = close_chain_entries(
+                &mut entries,
+                &seed(3),
+                &occupied_of(&config, &[]),
+                &config,
+                &index,
+            );
 
             assert!(links.is_empty(), "site 4 cannot vacate: {links:?}");
             assert_eq!(entries.len(), 1, "entries must be left untouched");
@@ -1630,7 +1705,13 @@ mod tests {
                 .into_iter()
                 .collect();
 
-            let links = close_chain_entries(&mut entries, &seed(0), &config, &index);
+            let links = close_chain_entries(
+                &mut entries,
+                &seed(0),
+                &occupied_of(&config, &[1]),
+                &config,
+                &index,
+            );
 
             assert!(links.is_empty(), "a blocked destination has no follower");
             assert_eq!(entries.len(), 1);
@@ -1649,7 +1730,13 @@ mod tests {
                     .into_iter()
                     .collect();
 
-            let links = close_chain_entries(&mut entries, &[lane_0, lane_1], &config, &index);
+            let links = close_chain_entries(
+                &mut entries,
+                &[lane_0, lane_1],
+                &occupied_of(&config, &[]),
+                &config,
+                &index,
+            );
 
             assert!(links.is_empty(), "both hops were already selected");
             assert_eq!(entries.len(), 2);
@@ -1667,7 +1754,13 @@ mod tests {
             let mut entries: HashMap<u64, u64> =
                 [(loc(0, 0).encode(), lane_0)].into_iter().collect();
 
-            let links = close_chain_entries(&mut entries, &[lane_0], &config, &index);
+            let links = close_chain_entries(
+                &mut entries,
+                &[lane_0],
+                &occupied_of(&config, &[]),
+                &config,
+                &index,
+            );
 
             assert!(links.is_empty(), "no chain exists on a disjoint bus");
             assert_eq!(entries.len(), 1);

--- a/crates/bloqade-lanes-search/src/ops/aod_grid.rs
+++ b/crates/bloqade-lanes-search/src/ops/aod_grid.rs
@@ -11,11 +11,12 @@
 
 use std::borrow::Cow;
 use std::cell::RefCell;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 
-use bloqade_lanes_bytecode_core::arch::addr::{Direction, MoveType};
+use bloqade_lanes_bytecode_core::arch::addr::{Direction, LaneAddr, LocationAddr, MoveType};
 
 use crate::primitives::bus_grid_maps::BusGridMaps;
+use crate::primitives::config::Config;
 use crate::primitives::lane_index::LaneIndex;
 
 /// A cluster represented by its X and Y coordinate sets.
@@ -61,6 +62,154 @@ pub(crate) fn destination_is_available(
     group_mover_srcs: &HashSet<u64>,
 ) -> bool {
     !occupied.contains(&dst_enc) || group_mover_srcs.contains(&dst_enc)
+}
+
+/// The lane on which the atom occupying `dst` could vacate in the same AOD shot
+/// as `lane`: an outgoing lane sharing all four of
+/// `(zone_id, move_type, bus_id, direction)` — the fields
+/// `ArchSpec::check_lane_group_consistency` requires a group to share, so a lane
+/// returned here is one the validator will accept alongside `lane`.
+///
+/// A source has at most one lane per bus group (the bus's src→dst relation is a
+/// function), so "the" lane is well defined; `find` returns that one.
+///
+/// The `zone_id` term only bites for `ZoneBus` lanes: site and word buses are
+/// intra-zone, so a lane and its destination share a zone automatically. A
+/// single `zone_bus` may serve several zones across its pairs, and for such a
+/// lane `zone_id` is the *source's* zone, so a chain through it
+/// (`z0w0 → z1w0`, then `z1w0 → z2w0`) carries a different `zone_id` per hop.
+///
+/// Consequence, stated honestly: those hops get **serialized** into one
+/// operation each. Serialization is permitted by the architecture — but so is
+/// batching them, since one zone bus may carry transfers among more than two
+/// zones in a single shot. This predicate is therefore deliberately *stricter
+/// than the architecture*, matching today's group-consistency rule rather than
+/// the hardware's capability. The reason to keep it that way for now is that
+/// `check_lane_group_consistency` rejects a mixed-`zone_id` group, so
+/// generating such candidates would produce plans that fail the
+/// solver-boundary replay outright. Unlocking the batching means relaxing that
+/// rule for zone buses first, then relaxing this in step.
+///
+/// Necessarily `None` on endpoint-disjoint buses — a destination there is never
+/// a source of the same bus — so the shipped Gemini specs never see a chain.
+pub(crate) fn vacating_lane(
+    dst: LocationAddr,
+    lane: &LaneAddr,
+    index: &LaneIndex,
+) -> Option<LaneAddr> {
+    index.outgoing_lanes(dst).iter().copied().find(|l| {
+        l.zone_id == lane.zone_id
+            && l.move_type == lane.move_type
+            && l.bus_id == lane.bus_id
+            && l.direction == lane.direction
+    })
+}
+
+/// One conveyor follower co-selected by [`close_chain_entries`]: the atom that
+/// has to vacate so an already-selected mover's destination is free in the same
+/// shot, plus the lane it vacates on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ChainLink {
+    /// The follower's qubit id, so the caller records its move in the config.
+    pub(crate) qubit_id: u32,
+    /// Encoded lane the follower vacates on.
+    pub(crate) lane_encoded: u64,
+    /// Encoded location the follower is vacating — the blocked destination of
+    /// the hop ahead of it.
+    pub(crate) src_encoded: u64,
+    /// Encoded destination that lane carries it to.
+    pub(crate) dst_encoded: u64,
+}
+
+/// Close a bus group's mover set under the uniform destination rule (#866):
+/// when a selected mover's destination holds an atom that can vacate on this
+/// same group, co-select that atom's lane too — transitively, to the end of the
+/// chain.
+///
+/// # Why selection has to do this, not the grid layer
+///
+/// [`BusGridContext::build_aod_grids`] derives its mover set from `entries`, so
+/// [`BusGridContext::rect_outcome`]'s repair closure can only pull in cells
+/// whose source is *already* an entry. It deliberately never promotes a
+/// stationary atom to a mover: that would move an atom the caller never
+/// selected and never recorded in the config, so the plan and the hardware
+/// would disagree. The result is that a chain assembles only when every
+/// follower happens to have been selected on its own merit.
+///
+/// On a packed block that is exactly what does not happen. Followers drop out
+/// of selection for two ordinary reasons — a follower already sitting on its
+/// target is never scored at all, and one whose own move scores `≤ 0` is pruned
+/// — and then the leader's rectangle is rejected, the successor set comes up
+/// empty, and the search reports `unsolvable` on a solvable instance (#910).
+/// Under grid-complete activation semantics a packed region has no chain-free
+/// alternative to fall back on, so this is a correctness bug, not a cost one.
+///
+/// # Contract
+///
+/// `entries` maps `encoded_src → encoded_lane` and is extended in place;
+/// `seed_lanes` lists the already-selected lanes in the caller's deterministic
+/// order. Every returned [`ChainLink`] is a *new* entry the caller must turn
+/// into a recorded qubit move, in the order returned.
+///
+/// A chain that cannot complete is left alone rather than half-selected being
+/// rejected here: the follower's own rectangle is invalid for the same reason
+/// the leader's was, so `build_aod_grids` drops the whole thing. Letting one
+/// layer adjudicate keeps the two from drifting apart.
+///
+/// Terminates because every iteration inserts a source not already in
+/// `entries`, and locations are finite. The `contains_key` guard also means a
+/// hypothetically cyclic bus closes back onto a seed and stops rather than
+/// spinning — though `ArchSpec::validate` rejects cyclic buses outright
+/// (#874), which is what makes a closed chain a shift and not a rotation.
+///
+/// A no-op on endpoint-disjoint buses (see [`vacating_lane`]), so the shipped
+/// Gemini specs get byte-identical entry sets.
+pub(crate) fn close_chain_entries(
+    entries: &mut HashMap<u64, u64>,
+    seed_lanes: &[u64],
+    config: &Config,
+    index: &LaneIndex,
+) -> Vec<ChainLink> {
+    let mut links: Vec<ChainLink> = Vec::new();
+    let mut queue: VecDeque<u64> = seed_lanes.iter().copied().collect();
+
+    while let Some(lane_enc) = queue.pop_front() {
+        let lane = LaneAddr::decode_u64(lane_enc);
+        let Some((_, dst)) = index.endpoints(&lane) else {
+            continue;
+        };
+        let dst_enc = dst.encode();
+        // The occupant is already a mover on this group, so the rule is
+        // satisfied and there is nothing to add.
+        if entries.contains_key(&dst_enc) {
+            continue;
+        }
+        // No atom to co-select: the destination is free, or it is a blocked
+        // site, which holds no qubit and never frees up.
+        let Some(qubit_id) = config.qubit_at(dst) else {
+            continue;
+        };
+        // The atom ahead cannot vacate on this group — the chain is broken
+        // here and `build_aod_grids` will reject the rectangle.
+        let Some(next_lane) = vacating_lane(dst, &lane, index) else {
+            continue;
+        };
+        let Some((_, next_dst)) = index.endpoints(&next_lane) else {
+            continue;
+        };
+
+        let next_lane_enc = next_lane.encode_u64();
+        entries.insert(dst_enc, next_lane_enc);
+        links.push(ChainLink {
+            qubit_id,
+            lane_encoded: next_lane_enc,
+            src_encoded: dst_enc,
+            dst_encoded: next_dst.encode(),
+        });
+        queue.push_back(next_lane_enc);
+    }
+
+    links
 }
 
 /// Context for building AOD-compatible rectangular grids on one bus group.
@@ -248,6 +397,21 @@ impl<'a> BusGridContext<'a> {
     /// selecting a column drives it at *every* selected row. Empty **filler
     /// lanes** are therefore included where needed to complete the product —
     /// they carry no atom but let a rectangle grow to cover more movers.
+    ///
+    /// The mover set is exactly `entries.keys()`: growth may pull a mover's
+    /// *cell* into a rectangle, but it never promotes a stationary atom to a
+    /// mover, because the caller would not record that atom's move. A caller
+    /// whose selection can nominate an atom whose destination is occupied must
+    /// therefore run [`close_chain_entries`] first, so the atoms that *have* to
+    /// move are in `entries` before the geometry is decided — otherwise the
+    /// group silently emits nothing (#910). The heuristic generator and both
+    /// entropy candidate paths do this.
+    ///
+    /// [`GreedyGenerator`](crate::generators::greedy::GreedyGenerator) does not,
+    /// and does not need to: `find_path_occupied` treats every atom as a wall, so
+    /// its first-step lanes never point at an occupied site and no chain can
+    /// arise. That also makes it chain-*incapable* — following a chain would take
+    /// multi-agent pathfinding rather than per-atom BFS (#887).
     ///
     /// # What the result is, precisely
     ///
@@ -1357,5 +1521,185 @@ mod tests {
         let mut sorted = grids[0].clone();
         sorted.sort();
         assert_eq!(sorted, vec![100, 101, 102, 103]);
+    }
+
+    // ── `close_chain_entries` (issue #910) ──
+    //
+    // These need real lane topology rather than the fabricated `BusGridMaps`
+    // above, so they build a `LaneIndex` from the conveyor-chain fixture
+    // (`0→1→2→3→4` along one row of word 0) and its endpoint-disjoint sibling.
+
+    mod chain_closure {
+        use super::*;
+        use crate::primitives::lane_index::LaneIndex;
+        use crate::test_utils::{chain_arch_json, example_arch_json, lane, loc};
+        use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+
+        fn chain_index() -> LaneIndex {
+            let spec: ArchSpec = serde_json::from_str(&chain_arch_json()).unwrap();
+            LaneIndex::new(spec)
+        }
+
+        fn disjoint_index() -> LaneIndex {
+            let spec: ArchSpec = serde_json::from_str(example_arch_json()).unwrap();
+            LaneIndex::new(spec)
+        }
+
+        /// Atoms on the given sites of word 0, keyed by qubit id = site id.
+        fn packed(sites: &[u32]) -> Config {
+            Config::new(sites.iter().map(|&s| (s, loc(0, s)))).unwrap()
+        }
+
+        /// Seed the closure with the forward site-bus-0 lane out of `site`.
+        fn seed(site: u32) -> Vec<u64> {
+            vec![lane(0, site, 0).encode_u64()]
+        }
+
+        /// One selected mover ahead of a packed run pulls in every atom between
+        /// it and the hole — transitively, in chain order.
+        #[test]
+        fn walks_to_the_end_of_the_chain() {
+            let index = chain_index();
+            let config = packed(&[0, 1, 2, 3]);
+            let mut entries: HashMap<u64, u64> = [(loc(0, 0).encode(), lane(0, 0, 0).encode_u64())]
+                .into_iter()
+                .collect();
+
+            let links = close_chain_entries(&mut entries, &seed(0), &config, &index);
+
+            let hops: Vec<(u32, u32, u32)> = links
+                .iter()
+                .map(|l| {
+                    (
+                        l.qubit_id,
+                        LocationAddr::decode(l.src_encoded).site_id,
+                        LocationAddr::decode(l.dst_encoded).site_id,
+                    )
+                })
+                .collect();
+            assert_eq!(
+                hops,
+                vec![(1, 1, 2), (2, 2, 3), (3, 3, 4)],
+                "followers must be co-selected in chain order"
+            );
+            assert_eq!(entries.len(), 4, "every atom in the run becomes a mover");
+        }
+
+        /// The walk stops at the hole rather than running to the bus's end.
+        #[test]
+        fn stops_at_a_free_destination() {
+            let index = chain_index();
+            let config = packed(&[0, 1]);
+            let mut entries: HashMap<u64, u64> = [(loc(0, 0).encode(), lane(0, 0, 0).encode_u64())]
+                .into_iter()
+                .collect();
+
+            let links = close_chain_entries(&mut entries, &seed(0), &config, &index);
+
+            assert_eq!(links.len(), 1, "site 2 is free, so the chain ends at q1");
+            assert_eq!(links[0].qubit_id, 1);
+            assert_eq!(LocationAddr::decode(links[0].dst_encoded), loc(0, 2));
+        }
+
+        /// An atom at the chain's final destination has no lane on this group,
+        /// so nothing is co-selected and `build_aod_grids` rejects the
+        /// rectangle — the same outcome as before the closure existed.
+        #[test]
+        fn leaves_an_unvacatable_occupant_alone() {
+            let index = chain_index();
+            let config = packed(&[3, 4]);
+            let seed_lane = lane(0, 3, 0).encode_u64();
+            let mut entries: HashMap<u64, u64> =
+                [(loc(0, 3).encode(), seed_lane)].into_iter().collect();
+
+            let links = close_chain_entries(&mut entries, &seed(3), &config, &index);
+
+            assert!(links.is_empty(), "site 4 cannot vacate: {links:?}");
+            assert_eq!(entries.len(), 1, "entries must be left untouched");
+        }
+
+        /// A destination held by a *blocked* location carries no qubit to
+        /// co-select, and blocked atoms never move — so the closure must not
+        /// invent a mover for one.
+        #[test]
+        fn never_co_selects_a_blocked_site() {
+            let index = chain_index();
+            // Site 1 is blocked (an external atom), so it is not in the config.
+            let config = packed(&[0]);
+            let mut entries: HashMap<u64, u64> = [(loc(0, 0).encode(), lane(0, 0, 0).encode_u64())]
+                .into_iter()
+                .collect();
+
+            let links = close_chain_entries(&mut entries, &seed(0), &config, &index);
+
+            assert!(links.is_empty(), "a blocked destination has no follower");
+            assert_eq!(entries.len(), 1);
+        }
+
+        /// A follower already selected on its own merit needs no help, and must
+        /// not be added twice.
+        #[test]
+        fn skips_an_occupant_that_is_already_a_mover() {
+            let index = chain_index();
+            let config = packed(&[0, 1]);
+            let lane_0 = lane(0, 0, 0).encode_u64();
+            let lane_1 = lane(0, 1, 0).encode_u64();
+            let mut entries: HashMap<u64, u64> =
+                [(loc(0, 0).encode(), lane_0), (loc(0, 1).encode(), lane_1)]
+                    .into_iter()
+                    .collect();
+
+            let links = close_chain_entries(&mut entries, &[lane_0, lane_1], &config, &index);
+
+            assert!(links.is_empty(), "both hops were already selected");
+            assert_eq!(entries.len(), 2);
+        }
+
+        /// On an endpoint-disjoint bus a destination is never a source of the
+        /// same bus, so the closure cannot fire at all. This is what keeps the
+        /// shipped Gemini specs byte-identical.
+        #[test]
+        fn is_a_no_op_on_endpoint_disjoint_buses() {
+            let index = disjoint_index();
+            // Site bus 0 maps 0-4 → 5-9; park atoms on both ends of one lane.
+            let config = Config::new([(0, loc(0, 0)), (1, loc(0, 5))]).unwrap();
+            let lane_0 = lane(0, 0, 0).encode_u64();
+            let mut entries: HashMap<u64, u64> =
+                [(loc(0, 0).encode(), lane_0)].into_iter().collect();
+
+            let links = close_chain_entries(&mut entries, &[lane_0], &config, &index);
+
+            assert!(links.is_empty(), "no chain exists on a disjoint bus");
+            assert_eq!(entries.len(), 1);
+        }
+
+        /// [`vacating_lane`] is what confines a chain to one lane group: the
+        /// occupant needs an outgoing lane matching all four grouping fields.
+        #[test]
+        fn vacating_lane_requires_the_same_bus_group() {
+            let index = chain_index();
+            let forward_0 = lane(0, 0, 0);
+            assert_eq!(
+                vacating_lane(loc(0, 1), &forward_0, &index).map(|l| l.site_id),
+                Some(1),
+                "site 1 is a source of the same forward chain bus"
+            );
+            assert!(
+                vacating_lane(loc(0, 4), &lane(0, 3, 0), &index).is_none(),
+                "the chain's final destination has no outgoing lane on it"
+            );
+            // Same sites, opposite direction: a backward mover cannot be
+            // cleared by a forward follower, since a lane group shares one
+            // direction.
+            let backward_2 = LaneAddr {
+                direction: Direction::Backward,
+                ..lane(0, 2, 0)
+            };
+            assert_eq!(
+                vacating_lane(loc(0, 1), &backward_2, &index).map(|l| l.direction),
+                Some(Direction::Backward),
+                "a backward mover is cleared by a backward follower, not a forward one"
+            );
+        }
     }
 }

--- a/crates/bloqade-lanes-search/src/search/options.rs
+++ b/crates/bloqade-lanes-search/src/search/options.rs
@@ -73,7 +73,29 @@ pub struct SolveOptions {
     pub weight: f64,
     /// Number of parallel restarts with perturbed scoring (1 = no restarts).
     pub restarts: u32,
-    /// How to handle deadlocks (no improving moves).
+    /// How to handle deadlocks — a node whose candidates all turn out
+    /// unexecutable, or where nothing scores an improvement.
+    ///
+    /// Never *lowered*: an explicit [`DeadlockPolicy::AllMoves`] reaches every
+    /// strategy that routes through
+    /// [`HeuristicGenerator`](crate::generators::HeuristicGenerator). It can be
+    /// *raised*, in two places, neither obvious from here:
+    ///
+    /// * The plain frontier strategies — A*, BFS, greedy, and the cascade's A*
+    ///   refinement — floor [`DeadlockPolicy::Skip`] at
+    ///   [`DeadlockPolicy::MoveBlockers`]. They have no depth-first jump-back to
+    ///   fall back on, so `Skip` would leave them with no successors at all at a
+    ///   node whose candidates are unexecutable. IDS and DFS take the request
+    ///   verbatim.
+    /// * The **entangling entry points** — `solve_loose_goal`, `solve_nohome`
+    ///   and the receding-horizon driver — apply the same floor to *every*
+    ///   strategy via [`Self::upgraded_for_entangling`].
+    ///
+    /// So `Skip` means `Skip` only for IDS and DFS on the fixed-target path.
+    ///
+    /// One strategy is out of reach entirely: [`Strategy::Entropy`] generates its
+    /// candidates itself rather than through that generator, so this never
+    /// affects it — its fallback is the driver's own deadlock breaker.
     pub deadlock_policy: DeadlockPolicy,
     /// Enable 2-step lookahead scoring inside
     /// [`HeuristicGenerator`](crate::generators::HeuristicGenerator).

--- a/crates/bloqade-lanes-search/src/search/restarts.rs
+++ b/crates/bloqade-lanes-search/src/search/restarts.rs
@@ -78,6 +78,28 @@ pub(crate) fn pick_best(results: Vec<SolveResult>) -> Option<SolveResult> {
     })
 }
 
+/// Deadlock policy for the plain frontier strategies — A*, BFS, greedy, and the
+/// cascade's A* refinement.
+///
+/// [`DeadlockPolicy::MoveBlockers`] is a **floor here, not an override**. Those
+/// strategies have no depth-first jump-back to fall back on, so under
+/// [`DeadlockPolicy::Skip`] a node whose candidates all fail leaves them with
+/// nothing at all; the floor keeps them functional on the default options.
+///
+/// What the floor must not do is *lower* the caller's request. Hardcoding
+/// `MoveBlockers` — as this dispatch did — silently discarded an explicit
+/// [`DeadlockPolicy::AllMoves`], and `MoveBlockers` only frees atoms parked on
+/// an unresolved target. When the target is simply *far away* rather than
+/// occupied it emits nothing, so A* got zero successors and reported
+/// `unsolvable` on instances IDS and entropy — which do honour the option —
+/// solved in three nodes.
+fn frontier_deadlock_policy(requested: DeadlockPolicy) -> DeadlockPolicy {
+    match requested {
+        DeadlockPolicy::Skip => DeadlockPolicy::MoveBlockers,
+        stronger => stronger,
+    }
+}
+
 /// Run the trait-based frontier search with the scorer, cost, state, and
 /// observer fixed to the values every call site in this module uses
 /// identically. Removes those four boilerplate arguments from
@@ -254,7 +276,7 @@ where
         }
 
         let max_depth = Some(inner_result.cost.ceil() as u32);
-        let astar_move_gen = make_generator(0, DeadlockPolicy::MoveBlockers);
+        let astar_move_gen = make_generator(0, frontier_deadlock_policy(deadlock_policy));
         let mut astar_f = PriorityFrontier::astar(h_max, weight);
         let astar_result = run_frontier(
             &root,
@@ -287,7 +309,7 @@ where
             Strategy::Ids => run_inner(InnerStrategy::Ids, seed, budget),
             Strategy::HeuristicDfs => run_inner(InnerStrategy::Dfs, seed, budget),
             _ => {
-                let move_gen = make_generator(seed, DeadlockPolicy::MoveBlockers);
+                let move_gen = make_generator(seed, frontier_deadlock_policy(deadlock_policy));
                 let result = run_strategy_v2(
                     strategy,
                     root.clone(),
@@ -358,5 +380,41 @@ where
         _ => {
             unreachable!("IDS/DFS/Cascade/Entropy handled before run_strategy_v2")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The dispatch may *raise* a caller's deadlock policy to keep the plain
+    /// frontier strategies functional on the defaults, but it must never lower
+    /// one. Hardcoding `MoveBlockers` here — which is what it used to do — meant
+    /// A*, BFS and greedy silently ignored an explicit `AllMoves`, so a solve the
+    /// caller had configured to escape deadlocks reported `unsolvable` at a node
+    /// where IDS and entropy, which honour the option, walked straight through.
+    ///
+    /// Observed on a 37-atom staging phase with a single mover whose target was
+    /// *free*: `MoveBlockers` only frees atoms parked on an unresolved target, so
+    /// it emitted nothing and A* died with zero successors at the root, while the
+    /// same instance solved in three nodes under `AllMoves`.
+    #[test]
+    fn an_explicit_deadlock_policy_is_never_downgraded() {
+        assert_eq!(
+            frontier_deadlock_policy(DeadlockPolicy::AllMoves),
+            DeadlockPolicy::AllMoves,
+            "AllMoves asks for *more* escapes than MoveBlockers; honour it"
+        );
+        assert_eq!(
+            frontier_deadlock_policy(DeadlockPolicy::MoveBlockers),
+            DeadlockPolicy::MoveBlockers
+        );
+        // `Skip` is the default and leaves these strategies with no escape hatch
+        // at all, so the floor still applies there — this is the one case the
+        // dispatch is allowed to change.
+        assert_eq!(
+            frontier_deadlock_policy(DeadlockPolicy::Skip),
+            DeadlockPolicy::MoveBlockers
+        );
     }
 }

--- a/crates/bloqade-lanes-search/src/search/result.rs
+++ b/crates/bloqade-lanes-search/src/search/result.rs
@@ -65,7 +65,17 @@ pub struct SolveResult {
     pub nodes_expanded: u32,
     /// Total path cost. 0.0 when `status` is not `Solved`.
     pub cost: f64,
-    /// Number of deadlocks encountered during search.
+    /// Number of nodes at which the generator had nothing useful to offer.
+    ///
+    /// Counts two distinct situations: no candidate scored an improvement, and
+    /// no candidate turned out *executable* (every rectangle rejected) even
+    /// though something did score positive.
+    ///
+    /// **Not a count of escape moves taken.** The counter is incremented before
+    /// the [`DeadlockPolicy`](crate::generators::heuristic::DeadlockPolicy) is
+    /// consulted, so under `Skip` — the default — it records nodes where nothing
+    /// was generated in response. Read it as "how often the search got stuck",
+    /// not "how often it escaped".
     pub deadlocks: u32,
     /// Optional entropy-search trace payload for visualization/debugging.
     pub entropy_trace: Option<EntropyTrace>,

--- a/crates/bloqade-lanes-search/src/search/result.rs
+++ b/crates/bloqade-lanes-search/src/search/result.rs
@@ -12,10 +12,27 @@ use crate::primitives::graph::MoveSet;
 pub enum SolveStatus {
     /// A solution was found.
     Solved,
-    /// The search space was fully explored — no solution exists.
+    /// The search exhausted its space without finding a solution.
+    ///
+    /// **This is a proof only for a complete router.** From
+    /// [`Strategy::PushRotate`](crate::search::options::Strategy::PushRotate) it
+    /// means no solution exists. From every search strategy it means no solution
+    /// exists *within the move vocabulary its generator offered* — and the
+    /// heuristic generators deliberately offer less than the architecture
+    /// allows: non-improving moves are pruned whenever an improving one exists,
+    /// and only nominated atoms enter a bus group's mover set.
+    ///
+    /// Issue #910 is the cautionary case. On a packed block, an atom the
+    /// generator never nominated left the whole group unexecutable, so nodes had
+    /// no successors and the open list drained in seconds — identical verdicts at
+    /// `max_expansions` of 1e5 and 1e8 — on an instance one AOD operation
+    /// solves. Callers that branch on this status (fallback logic, feasibility
+    /// conclusions, optimality baselines) should treat it as "this search found
+    /// nothing" rather than "nothing exists"; for a genuine verdict use the
+    /// feasibility oracle or Push and Rotate.
     Unsolvable,
     /// The expansion budget was exhausted before finding a solution or
-    /// proving unsolvability.
+    /// exhausting the space.
     BudgetExceeded,
 }
 

--- a/crates/bloqade-lanes-search/src/search/target_solver.rs
+++ b/crates/bloqade-lanes-search/src/search/target_solver.rs
@@ -381,6 +381,73 @@ mod tests {
         assert!(!result.move_layers.is_empty());
         assert_eq!(result.goal_config.location_of(0), Some(loc(0, 5)));
     }
+
+    /// End-to-end deadlock witness for issue #910: a packed conveyor block whose
+    /// only free site is at the head of the chain.
+    ///
+    /// Atoms fill sites 0-3 of the `0→1→2→3→4` row, site 4 is the lone hole, and
+    /// only `q0` is targeted — one site forward, into `q1`. The three atoms
+    /// ahead of it are untargeted spectators, so scoring never nominates them
+    /// and they never joined the mover set.
+    ///
+    /// That made the instance a dead end. Under grid-complete activation a
+    /// packed block has no chain-free alternative — firing the bus moves *every*
+    /// atom on the fired tones, so any single-mover selection here implies
+    /// co-moving its neighbours — and with the spectators absent from the mover
+    /// set `q0`'s rectangle was rejected, the root had **zero** successors, and
+    /// the search returned `Unsolvable` at any budget. One whole-row shift
+    /// solves it.
+    ///
+    /// Reaching `Solved` also proves the assembled chain is *executable*:
+    /// `solve_with_engine` replays every returned plan through
+    /// `AtomStateData::validate_moves` + `apply_validated` before handing it
+    /// back, so a simultaneous shift the hardware model rejected would panic
+    /// here rather than pass.
+    #[test]
+    fn packed_conveyor_block_is_solvable_not_unsolvable() {
+        let initial = [
+            (0u32, loc(0, 0)),
+            (1, loc(0, 1)),
+            (2, loc(0, 2)),
+            (3, loc(0, 3)),
+        ];
+        let target = [(0u32, loc(0, 1))];
+
+        for search in [MoveSearch::astar(1.0), MoveSearch::entropy()] {
+            let strategy = search.options.strategy;
+            let solver = TargetSolver::new(make_chain_engine(), search);
+            let result = solver
+                .solve(initial, target, std::iter::empty(), Some(10_000))
+                .unwrap();
+
+            assert_eq!(
+                result.status,
+                SolveStatus::Solved,
+                "{strategy:?} reported {:?} on a solvable packed conveyor",
+                result.status
+            );
+            assert_eq!(
+                result.goal_config.location_of(0),
+                Some(loc(0, 1)),
+                "{strategy:?}: q0 did not reach its target"
+            );
+            // The whole row shifts in a single AOD operation: one layer, four
+            // lanes, every spectator pushed one site along.
+            assert_eq!(
+                result.move_layers.len(),
+                1,
+                "{strategy:?}: expected one whole-row shift, got {:?}",
+                result.move_layers
+            );
+            for (qid, site) in [(1u32, 2u32), (2, 3), (3, 4)] {
+                assert_eq!(
+                    result.goal_config.location_of(qid),
+                    Some(loc(0, site)),
+                    "{strategy:?}: spectator q{qid} did not ride the chain"
+                );
+            }
+        }
+    }
     // ── `SolveOptions::backwards_search` ──
     //
     // The transform under test is "reverse the layer list AND invert each

--- a/crates/bloqade-lanes-search/src/test_utils.rs
+++ b/crates/bloqade-lanes-search/src/test_utils.rs
@@ -59,6 +59,45 @@ pub fn chain_arch_json() -> String {
     serde_json::to_string(&spec).expect("spec serializes")
 }
 
+/// A conveyor chain with a **siding**: two words of three sites each, a chain
+/// site bus (`0→1, 1→2`) in both, and a word bus joining them at every site.
+///
+/// The smallest spec on which a chain can be *admitted* at selection time and
+/// still fail to assemble. Site `2` is a chain destination but not a chain
+/// source, so an atom parked there cannot vacate on that bus group — a run of
+/// three atoms therefore has a blocked head, every rectangle on the chain bus is
+/// rejected, and the group emits nothing even though the leader's move scored
+/// positive. The word bus is what makes the instance solvable anyway, and is the
+/// escape route the generator has to fall back on (#910).
+#[allow(dead_code)]
+pub fn chain_with_siding_arch_json() -> &'static str {
+    r#"{
+        "version": "2.0",
+        "words": [
+            { "sites": [[0, 0], [1, 0], [2, 0]] },
+            { "sites": [[0, 1], [1, 1], [2, 1]] }
+        ],
+        "zones": [
+            {
+                "grid": { "x_start": 0.0, "y_start": 0.0, "x_spacing": [2.0, 2.0], "y_spacing": [2.0] },
+                "site_buses": [
+                    { "src": [0, 1], "dst": [1, 2] }
+                ],
+                "word_buses": [
+                    { "src": [0], "dst": [1] }
+                ],
+                "words_with_site_buses": [0, 1],
+                "sites_with_word_buses": [0, 1, 2],
+                "entangling_pairs": []
+            }
+        ],
+        "zone_buses": [],
+        "modes": [
+            { "name": "default", "zones": [0], "bitstring_order": [] }
+        ]
+    }"#
+}
+
 /// Minimal two-zone architecture with a single inter-zone `zone_bus`.
 ///
 /// Zone 0 ("gate") holds word 0 and zone 1 ("memory") holds word 1, each a

--- a/crates/bloqade-lanes-search/tests/conveyor_1d.rs
+++ b/crates/bloqade-lanes-search/tests/conveyor_1d.rs
@@ -464,7 +464,7 @@ fn fully_packed_line_admits_only_the_identity() {
 
         for (name, search) in searches() {
             // The identity target is already met at the root: solved, no moves.
-            let solver = TargetSolver::new(Arc::clone(&engine), search);
+            let solver = TargetSolver::new(Arc::clone(&engine), search.clone());
             let identity = solver
                 .solve(
                     initial.iter().copied(),
@@ -499,7 +499,7 @@ fn fully_packed_line_admits_only_the_identity() {
                     )
                 })
                 .collect();
-            let solver = TargetSolver::new(Arc::clone(&engine), MoveSearch::astar(1.0));
+            let solver = TargetSolver::new(Arc::clone(&engine), search);
             let moved = solver
                 .solve(
                     initial.iter().copied(),
@@ -699,7 +699,6 @@ fn router_matches_a_brute_force_optimum_on_every_1d_instance() {
 
             for target in &targets {
                 let optimal = optimal_for_target(&distances, target);
-                let budget = SWEEP_BUDGET;
 
                 for (name, search) in searches() {
                     let solver = TargetSolver::new(Arc::clone(&engine), search);
@@ -708,7 +707,7 @@ fn router_matches_a_brute_force_optimum_on_every_1d_instance() {
                             initial.iter().copied(),
                             target.iter().copied(),
                             std::iter::empty(),
-                            Some(budget),
+                            Some(SWEEP_BUDGET),
                         )
                         .expect("instance is well formed");
                     let label = format!(

--- a/crates/bloqade-lanes-search/tests/conveyor_1d.rs
+++ b/crates/bloqade-lanes-search/tests/conveyor_1d.rs
@@ -1,0 +1,765 @@
+//! End-to-end router validation on a **one-dimensional conveyor**, where the
+//! optimal plan length is known in closed form (issue #910).
+//!
+//! The fixture is a single row of sites joined by one site bus `0→1, 1→2, …`.
+//! Its source and destination sets overlap, so it is the smallest architecture
+//! on which conveyor chains are reachable at all — on the shipped Gemini specs
+//! every bus keeps its endpoints disjoint and the chain paths are dead code.
+//!
+//! # Why the optimum is provable here
+//!
+//! Every lane on this bus moves an atom exactly one site, in one direction, and
+//! `UniformCost` charges one unit per layer. So for any instance, the number of
+//! AOD operations is **at least** the largest per-atom hop distance:
+//!
+//! ```text
+//! layers >= max_i | target_i - start_i |
+//! ```
+//!
+//! For a **rigid shift** of a packed block by `d` sites, every atom needs `d`
+//! hops, so `d` is a lower bound — and it is achievable, because one AOD
+//! operation can drive the whole block one site along (the block's cells form a
+//! complete 1 × n rectangle on this bus, and each destination is vacated in the
+//! same shot by the atom ahead). The optimum is therefore exactly `d`, and A*
+//! with weight 1.0 over an admissible heuristic must return exactly `d` layers.
+//!
+//! Reaching that bound is a strictly stronger claim than `Solved`: it says the
+//! chain assembled into **one** operation per shift rather than serializing into
+//! several, which is the whole point of chain assembly.
+//!
+//! The two optimality tests exercise different layers, and it is worth knowing
+//! which is which. When *every* atom in the block is targeted, scoring nominates
+//! them all and the grid layer's repair closure (#887/#896) can assemble the shift
+//! on its own — `rigid_shifts_are_solved_in_exactly_the_optimal_number_of_operations`
+//! passes without any selection-time help. When some are not targeted,
+//! `a_block_pushed_by_one_targeted_atom_is_optimal` is the case that needs
+//! selection to close its own mover set over chains: without it the leader's
+//! rectangle is unexecutable, the root has no successors at all, and the instance
+//! comes back `Unsolvable` at any budget (#910).
+//!
+//! # The soundness half
+//!
+//! A 1D line also pins down what must be *unreachable*. Atoms on a path cannot
+//! pass each other — no legal move sequence changes their left-to-right order —
+//! so a cyclic permutation of atom identities across a fixed set of sites has no
+//! solution. That is the exact shape a *rotation* would take, and a rotation is
+//! the one thing the architecture cannot do (a bus is a set of edge transports,
+//! never a permutation; `ArchSpec::validate` rejects cyclic buses for this
+//! reason, #866/#874). So `router_never_fabricates_a_rotation` is the guard that
+//! chain assembly did not quietly buy us a capability the hardware lacks.
+//!
+//! # The exhaustive half
+//!
+//! The hand-written families above pick particular hole layouts — a packed block
+//! with all the free sites at one end, or a fixed site set being permuted — so on
+//! their own they say nothing about instances with holes *inside* the atom set, or
+//! about mixed compaction-and-shift targets.
+//! [`router_matches_a_brute_force_optimum_on_every_1d_instance`] removes that
+//! gap by enumerating **every** instance at several sizes and checking each
+//! against a brute-force optimum computed by BFS over
+//! [`ExhaustiveGenerator`](bloqade_lanes_search::generators::exhaustive::ExhaustiveGenerator)
+//! — the generator that enumerates every rectangle the architecture admits, and
+//! therefore the reference for what is reachable and in how few operations.
+//! `fully_packed_line_admits_only_the_identity` covers the one regime the sweep
+//! excludes, zero holes.
+//!
+//! Every `Solved` result here is also replayed through
+//! `AtomStateData::validate_moves` + `apply_validated` inside
+//! `solve_with_engine` before it is returned, so a plan the execution model
+//! rejects panics rather than passing.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
+
+use bloqade_lanes_bytecode_core::arch::addr::LocationAddr;
+use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
+use bloqade_lanes_search::generators::exhaustive::ExhaustiveGenerator;
+use bloqade_lanes_search::primitives::config::Config;
+use bloqade_lanes_search::primitives::context::{SearchContext, SearchState};
+use bloqade_lanes_search::primitives::distance::DistanceTable;
+use bloqade_lanes_search::primitives::graph::SearchGraph;
+use bloqade_lanes_search::primitives::lane_index::LaneIndex;
+use bloqade_lanes_search::search::engine::SearchEngine;
+use bloqade_lanes_search::search::move_search::MoveSearch;
+use bloqade_lanes_search::search::result::SolveStatus;
+use bloqade_lanes_search::search::target_solver::TargetSolver;
+use bloqade_lanes_search::traits::MoveGenerator;
+
+/// A one-dimensional architecture: one word of `n_sites` sites in a row, joined
+/// by a single conveyor site bus `0→1, 1→2, …, (n-2)→(n-1)`.
+fn line_arch_json(n_sites: u32) -> String {
+    assert!(n_sites >= 2, "a conveyor needs at least one lane");
+    let sites: Vec<String> = (0..n_sites).map(|i| format!("[{i}, 0]")).collect();
+    let src: Vec<String> = (0..n_sites - 1).map(|i| i.to_string()).collect();
+    let dst: Vec<String> = (1..n_sites).map(|i| i.to_string()).collect();
+    let x_spacing: Vec<String> = (0..n_sites - 1).map(|_| "2.0".to_string()).collect();
+
+    let json = format!(
+        r#"{{
+            "version": "2.0",
+            "words": [ {{ "sites": [{sites}] }} ],
+            "zones": [
+                {{
+                    "grid": {{
+                        "x_start": 0.0,
+                        "y_start": 0.0,
+                        "x_spacing": [{x_spacing}],
+                        "y_spacing": []
+                    }},
+                    "site_buses": [ {{ "src": [{src}], "dst": [{dst}] }} ],
+                    "word_buses": [],
+                    "words_with_site_buses": [0],
+                    "sites_with_word_buses": [],
+                    "entangling_pairs": []
+                }}
+            ],
+            "zone_buses": [],
+            "modes": [ {{ "name": "default", "zones": [0], "bitstring_order": [] }} ]
+        }}"#,
+        sites = sites.join(", "),
+        src = src.join(", "),
+        dst = dst.join(", "),
+        x_spacing = x_spacing.join(", "),
+    );
+
+    let spec: ArchSpec = serde_json::from_str(&json).expect("line arch parses");
+    assert!(
+        spec.validate().is_ok(),
+        "line arch must be a legal spec: {:?}",
+        spec.validate()
+    );
+    json
+}
+
+fn line_engine(n_sites: u32) -> Arc<SearchEngine> {
+    Arc::new(SearchEngine::from_json(&line_arch_json(n_sites)).expect("engine builds"))
+}
+
+fn site(s: u32) -> LocationAddr {
+    LocationAddr {
+        zone_id: 0,
+        word_id: 0,
+        site_id: s,
+    }
+}
+
+/// Expansion budget for the hand-written solvable instances.
+///
+/// Deliberately tight rather than generous. The optimal plan for every case
+/// below is at most six expansions, so anything this side of a hundred is a
+/// 100× margin — and the entropy driver keeps searching for further goal
+/// candidates after its first (`EntropyOptions::max_goal_candidates`), so a
+/// large budget costs seconds per solve to re-derive an answer it already had.
+const SOLVABLE_BUDGET: u32 = 500;
+
+/// Expansion budget for the exhaustive sweep, used for reachable and unreachable
+/// targets alike.
+///
+/// Sized from measurement, not guesswork: across every instance the sweep visits,
+/// the most any strategy needs to reach the optimum is **five** expansions
+/// (entropy; A* and IDS peak at two), so this is a 20× margin. It doubles as the
+/// cap on the unreachable instances, which do wander before draining — hence the
+/// sweep asserts only `!= Solved` there, which `BudgetExceeded` satisfies just as
+/// honestly as `Unsolvable`. Raising it buys nothing and costs real CI time: the
+/// sweep runs thousands of solves, so its runtime scales with this number.
+const SWEEP_BUDGET: u32 = 100;
+
+/// Expansion budget for the unsolvable instances, which have to *exhaust* rather
+/// than succeed. Every one of them actually drains its open list in fewer than
+/// five expansions — the reachable space on a short line is a handful of
+/// configurations — so this is three orders of magnitude of headroom, not a cap
+/// the assertions lean on.
+const UNSOLVABLE_BUDGET: u32 = 2_000;
+
+/// Every search strategy that routes through the heuristic generator, plus the
+/// entropy driver. Push and Rotate is excluded: it is a different router with
+/// its own regime conditions (it needs two or more holes) and its own suite.
+fn searches() -> Vec<(&'static str, MoveSearch)> {
+    vec![
+        ("astar", MoveSearch::astar(1.0)),
+        ("ids", MoveSearch::ids()),
+        ("entropy", MoveSearch::entropy()),
+    ]
+}
+
+/// **Optimality.** A packed block of `n` atoms shifted `d` sites along the
+/// conveyor must be solved in exactly `d` AOD operations — the provable optimum
+/// — with every atom landing on its target.
+///
+/// The instances are packed on purpose: with no gap inside the block, no atom
+/// can move without its neighbour moving in the same shot, so every layer here
+/// *is* an assembled chain. Serializing a shift into per-atom moves would show
+/// up immediately as more than `d` layers.
+#[test]
+fn rigid_shifts_are_solved_in_exactly_the_optimal_number_of_operations() {
+    // (sites, atoms, shift): the block occupies 0..n and must land on d..n+d.
+    let cases = [
+        (4u32, 2u32, 1u32),
+        (5, 3, 1),
+        (5, 3, 2),
+        (6, 4, 2),
+        (8, 5, 3),
+        (8, 2, 6),
+        (10, 8, 2),
+    ];
+
+    for (n_sites, n_atoms, shift) in cases {
+        assert!(n_atoms + shift <= n_sites, "case must fit on the line");
+        let initial: Vec<(u32, LocationAddr)> = (0..n_atoms).map(|q| (q, site(q))).collect();
+        let target: Vec<(u32, LocationAddr)> = (0..n_atoms).map(|q| (q, site(q + shift))).collect();
+        let engine = line_engine(n_sites);
+
+        for (name, search) in searches() {
+            let solver = TargetSolver::new(Arc::clone(&engine), search);
+            let result = solver
+                .solve(
+                    initial.iter().copied(),
+                    target.iter().copied(),
+                    std::iter::empty(),
+                    Some(SOLVABLE_BUDGET),
+                )
+                .expect("instance is well formed");
+
+            let label = format!("{name}: {n_atoms} atoms on {n_sites} sites, shift {shift}");
+            assert_eq!(
+                result.status,
+                SolveStatus::Solved,
+                "{label}: reported {:?} on a solvable rigid shift",
+                result.status
+            );
+            for &(qid, want) in &target {
+                assert_eq!(
+                    result.goal_config.location_of(qid),
+                    Some(want),
+                    "{label}: q{qid} did not reach its target"
+                );
+            }
+            assert_eq!(
+                result.move_layers.len(),
+                shift as usize,
+                "{label}: expected the optimal {shift} operations, got {} \
+                 (expanded {} nodes)",
+                result.move_layers.len(),
+                result.nodes_expanded
+            );
+            // The plan is not just optimal in length but *found* optimally: the
+            // whole-row shift is the top-ranked candidate at every step, so the
+            // walk is straight down with no backtracking.
+            assert_eq!(
+                result.nodes_expanded, shift,
+                "{label}: expected a straight walk of {shift} expansions, got {}",
+                result.nodes_expanded
+            );
+        }
+    }
+}
+
+/// **Optimality where the chain is not nominated.** The same bound, on the
+/// instance shape that used to have no plan at all: one targeted atom at the back
+/// of a packed block, with the atoms ahead of it untargeted spectators.
+///
+/// The bound is unchanged — the goal constrains `q0` alone, `q0` needs `d` hops,
+/// and a layer moves it one site, so `d` operations is optimal — but the route to
+/// it is different. Scoring nominates only `q0`; the spectators have no target, so
+/// nothing scores them and they never entered the bus group's mover set. That
+/// left `q0`'s rectangle unexecutable and the whole instance without a single
+/// successor, at any budget (#910). The fully-targeted shifts above were already
+/// fine, because there the grid layer's repair closure had every follower to work
+/// with; these are the cases that need selection to close its mover set first.
+#[test]
+fn a_block_pushed_by_one_targeted_atom_is_optimal() {
+    // (sites, atoms in the block, hops q0 must travel).
+    let cases = [(5u32, 4u32, 1u32), (8, 5, 3), (10, 4, 6), (10, 9, 1)];
+
+    for (n_sites, n_atoms, shift) in cases {
+        assert!(
+            n_atoms + shift <= n_sites,
+            "the block must have room to shift"
+        );
+        let initial: Vec<(u32, LocationAddr)> = (0..n_atoms).map(|q| (q, site(q))).collect();
+        // Only q0 is targeted; q1.. are spectators that have to get out of the way.
+        let target = [(0u32, site(shift))];
+        let engine = line_engine(n_sites);
+
+        for (name, search) in searches() {
+            let solver = TargetSolver::new(Arc::clone(&engine), search);
+            let result = solver
+                .solve(
+                    initial.iter().copied(),
+                    target,
+                    std::iter::empty(),
+                    Some(SOLVABLE_BUDGET),
+                )
+                .expect("instance is well formed");
+
+            let label = format!("{name}: q0 pushes {} spectators {shift} sites", n_atoms - 1);
+            assert_eq!(
+                result.status,
+                SolveStatus::Solved,
+                "{label}: reported {:?}",
+                result.status
+            );
+            assert_eq!(
+                result.goal_config.location_of(0),
+                Some(site(shift)),
+                "{label}: q0 did not reach its target"
+            );
+            assert_eq!(
+                result.move_layers.len(),
+                shift as usize,
+                "{label}: expected the optimal {shift} operations, got {}",
+                result.move_layers.len()
+            );
+            // Each operation carries the whole block, not just the targeted atom:
+            // the spectators end up exactly `shift` sites along.
+            for q in 1..n_atoms {
+                assert_eq!(
+                    result.goal_config.location_of(q),
+                    Some(site(q + shift)),
+                    "{label}: spectator q{q} did not ride the chain"
+                );
+            }
+        }
+    }
+}
+
+/// **Optimality, both directions.** The same bound holds running backwards along
+/// the conveyor, which uses the reverse lane group. Asserted separately because
+/// a chain is confined to one direction — a lane group shares one — so the
+/// backward shift is a different set of lanes, not a mirror of the same ones.
+#[test]
+fn backward_shifts_are_also_optimal() {
+    let n_sites = 8;
+    let engine = line_engine(n_sites);
+    for shift in 1u32..=3 {
+        let n_atoms = 4u32;
+        // Block starts at the far end and walks back toward site 0.
+        let start = n_sites - n_atoms;
+        let initial: Vec<(u32, LocationAddr)> =
+            (0..n_atoms).map(|q| (q, site(start + q))).collect();
+        let target: Vec<(u32, LocationAddr)> =
+            (0..n_atoms).map(|q| (q, site(start + q - shift))).collect();
+
+        for (name, search) in searches() {
+            let solver = TargetSolver::new(Arc::clone(&engine), search);
+            let result = solver
+                .solve(
+                    initial.iter().copied(),
+                    target.iter().copied(),
+                    std::iter::empty(),
+                    Some(SOLVABLE_BUDGET),
+                )
+                .expect("instance is well formed");
+
+            let label = format!("{name}: backward shift {shift}");
+            assert_eq!(result.status, SolveStatus::Solved, "{label}: not solved");
+            for &(qid, want) in &target {
+                assert_eq!(
+                    result.goal_config.location_of(qid),
+                    Some(want),
+                    "{label}: q{qid} did not reach its target"
+                );
+            }
+            assert_eq!(
+                result.move_layers.len(),
+                shift as usize,
+                "{label}: expected the optimal {shift} operations, got {}",
+                result.move_layers.len()
+            );
+        }
+    }
+}
+
+/// **Soundness.** A cyclic permutation of atom identities across a fixed set of
+/// sites is unreachable on a line: atoms cannot pass each other, so their order
+/// along the row is invariant, and a rotation of identities changes it.
+///
+/// Executing it would need the one operation the architecture does not have — a
+/// rotation, as opposed to a set of edge transports (#866/#874). No strategy may
+/// return `Solved` here. The verdict itself is not asserted: from a search
+/// strategy `Unsolvable` is exhaustion, not proof (see `SolveStatus`), so
+/// `Unsolvable` and `BudgetExceeded` are both honest answers and only `Solved`
+/// is a bug.
+#[test]
+fn router_never_fabricates_a_rotation() {
+    // Every non-identity rotation of 2..=4 atoms packed at the start of the
+    // line, with and without a hole to work in.
+    for n_sites in [4u32, 6, 8] {
+        let engine = line_engine(n_sites);
+        for n_atoms in 2..=4u32.min(n_sites - 1) {
+            for shift in 1..n_atoms {
+                let initial: Vec<(u32, LocationAddr)> =
+                    (0..n_atoms).map(|q| (q, site(q))).collect();
+                // q_i takes the site q_{i+shift mod n} held: a single cycle.
+                let target: Vec<(u32, LocationAddr)> = (0..n_atoms)
+                    .map(|q| (q, site((q + shift) % n_atoms)))
+                    .collect();
+
+                for (name, search) in searches() {
+                    let solver = TargetSolver::new(Arc::clone(&engine), search);
+                    let result = solver
+                        .solve(
+                            initial.iter().copied(),
+                            target.iter().copied(),
+                            std::iter::empty(),
+                            Some(UNSOLVABLE_BUDGET),
+                        )
+                        .expect("instance is well formed");
+
+                    assert_ne!(
+                        result.status,
+                        SolveStatus::Solved,
+                        "{name}: claimed a solution for a rotation of {n_atoms} atoms by \
+                         {shift} on {n_sites} sites, which no sequence of edge transports \
+                         can realize; plan was {:?}",
+                        result.move_layers
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// **Soundness, non-rotation reorderings.** The same order invariant rules out
+/// *any* reordering, not just cyclic ones: a single transposition of two atoms
+/// is unreachable on a line however much free space it is given.
+#[test]
+fn router_never_transposes_two_atoms_on_a_line() {
+    for n_sites in [4u32, 8, 12] {
+        let engine = line_engine(n_sites);
+        // Two atoms with the whole line to themselves, asked to swap.
+        let initial = [(0u32, site(0)), (1, site(1))];
+        let target = [(0u32, site(1)), (1, site(0))];
+
+        for (name, search) in searches() {
+            let solver = TargetSolver::new(Arc::clone(&engine), search);
+            let result = solver
+                .solve(initial, target, std::iter::empty(), Some(UNSOLVABLE_BUDGET))
+                .expect("instance is well formed");
+
+            assert_ne!(
+                result.status,
+                SolveStatus::Solved,
+                "{name}: claimed a swap on a {n_sites}-site line; plan was {:?}",
+                result.move_layers
+            );
+        }
+    }
+}
+
+/// **Zero holes.** A fully packed line cannot move at all: every lane's
+/// destination is held by an atom, and the atom at the far end has no outgoing
+/// lane, so no chain can complete and no rectangle is executable. Only the
+/// identity target is reachable.
+///
+/// This is the regime the exhaustive sweep below deliberately excludes (it needs
+/// at least one hole to have anything to enumerate), and it is the boundary at
+/// which chain assembly must stop helping — a closure that "completed" a chain
+/// here would be manufacturing a rotation.
+#[test]
+fn fully_packed_line_admits_only_the_identity() {
+    for n_sites in [3u32, 5] {
+        let engine = line_engine(n_sites);
+        let initial: Vec<(u32, LocationAddr)> = (0..n_sites).map(|q| (q, site(q))).collect();
+
+        for (name, search) in searches() {
+            // The identity target is already met at the root: solved, no moves.
+            let solver = TargetSolver::new(Arc::clone(&engine), search);
+            let identity = solver
+                .solve(
+                    initial.iter().copied(),
+                    initial.iter().copied(),
+                    std::iter::empty(),
+                    Some(SOLVABLE_BUDGET),
+                )
+                .expect("instance is well formed");
+            assert_eq!(
+                identity.status,
+                SolveStatus::Solved,
+                "{name}: the identity on a packed line is already solved"
+            );
+            assert!(
+                identity.move_layers.is_empty(),
+                "{name}: the identity needs no operations, got {:?}",
+                identity.move_layers
+            );
+
+            // Anything else is unreachable: there is nowhere for any atom to go.
+            let swapped: Vec<(u32, LocationAddr)> = (0..n_sites)
+                .map(|q| {
+                    (
+                        q,
+                        site(if q == 0 {
+                            1
+                        } else if q == 1 {
+                            0
+                        } else {
+                            q
+                        }),
+                    )
+                })
+                .collect();
+            let solver = TargetSolver::new(Arc::clone(&engine), MoveSearch::astar(1.0));
+            let moved = solver
+                .solve(
+                    initial.iter().copied(),
+                    swapped.iter().copied(),
+                    std::iter::empty(),
+                    Some(UNSOLVABLE_BUDGET),
+                )
+                .expect("instance is well formed");
+            assert_ne!(
+                moved.status,
+                SolveStatus::Solved,
+                "{name}: claimed a move on a fully packed line; plan was {:?}",
+                moved.move_layers
+            );
+        }
+    }
+}
+
+// ── Exhaustive sweep against a brute-force optimum ──
+
+/// A configuration as a sorted, comparable key.
+type ConfigKey = Vec<(u32, u64)>;
+
+fn config_key(config: &Config) -> ConfigKey {
+    let mut v: ConfigKey = config.iter().map(|(q, l)| (q, l.encode())).collect();
+    v.sort_unstable();
+    v
+}
+
+/// Optimal operation count from `start` to **every** reachable configuration, by
+/// breadth-first search over
+/// [`ExhaustiveGenerator`](bloqade_lanes_search::generators::exhaustive::ExhaustiveGenerator).
+///
+/// That generator enumerates every valid X × Y rectangle on every bus group, so
+/// its successor relation *is* the architecture's move relation — which makes BFS
+/// over it the ground truth for both questions this file asks: what is reachable,
+/// and in how few AOD operations. It is only tractable because a short line has a
+/// handful of configurations; it is a test oracle, not a router.
+///
+/// One BFS serves every target for this start: the generator reads only
+/// `ctx.index` and `ctx.blocked`, never the targets or the distance table, so the
+/// successor relation is target-independent.
+fn optimal_distances_from(index: &LaneIndex, start: &Config) -> HashMap<ConfigKey, usize> {
+    let no_targets: Vec<(u32, u64)> = Vec::new();
+    let table = DistanceTable::new(&[], index);
+    let blocked = HashSet::new();
+    let ctx = SearchContext {
+        index,
+        dist_table: &table,
+        blocked: &blocked,
+        targets: &no_targets,
+        cz_pairs: None,
+    };
+    let generator = ExhaustiveGenerator::new(None, None);
+    // `NodeId` has no public constructor and the exhaustive generator ignores
+    // the one it is handed, so borrow a root id from a throwaway graph.
+    let scratch = SearchGraph::new(start.clone());
+    let node = scratch.root();
+    let mut state = SearchState::default();
+
+    let mut dist: HashMap<ConfigKey, usize> = HashMap::new();
+    dist.insert(config_key(start), 0);
+    let mut queue: VecDeque<(Config, usize)> = VecDeque::new();
+    queue.push_back((start.clone(), 0));
+
+    while let Some((config, d)) = queue.pop_front() {
+        let mut out = Vec::new();
+        generator.generate(&config, node, &ctx, &mut state, &mut out);
+        for candidate in out {
+            let key = config_key(&candidate.new_config);
+            if dist.contains_key(&key) {
+                continue;
+            }
+            dist.insert(key, d + 1);
+            queue.push_back((candidate.new_config, d + 1));
+        }
+    }
+
+    dist
+}
+
+/// Every injective placement of `k` labelled atoms onto `n` sites, as site lists
+/// indexed by qubit id.
+fn placements(n: u32, k: u32) -> Vec<Vec<u32>> {
+    fn rec(n: u32, k: u32, cur: &mut Vec<u32>, out: &mut Vec<Vec<u32>>) {
+        if cur.len() == k as usize {
+            out.push(cur.clone());
+            return;
+        }
+        for s in 0..n {
+            if !cur.contains(&s) {
+                cur.push(s);
+                rec(n, k, cur, out);
+                cur.pop();
+            }
+        }
+    }
+    let mut out = Vec::new();
+    rec(n, k, &mut Vec::new(), &mut out);
+    out
+}
+
+/// Fewest operations from the BFS map to any reachable configuration satisfying
+/// every `(qubit, encoded site)` constraint in `target`.
+///
+/// A *total* target names every atom, so at most one configuration can match and
+/// this is a lookup. A *partial* target leaves the untargeted atoms free, so the
+/// optimum is the minimum over every reachable configuration that places the named
+/// ones correctly — which is exactly the goal predicate the solver uses
+/// (`AllAtTarget` checks only the qubits it was given).
+fn optimal_for_target(
+    distances: &HashMap<ConfigKey, usize>,
+    target: &[(u32, LocationAddr)],
+) -> Option<usize> {
+    distances
+        .iter()
+        .filter(|(key, _)| {
+            target
+                .iter()
+                .all(|&(qid, loc)| key.contains(&(qid, loc.encode())))
+        })
+        .map(|(_, &d)| d)
+        .min()
+}
+
+/// **Every 1D instance, against ground truth.** For each size, enumerate every
+/// start placement and every target — total and single-atom partial — and check
+/// the router against a brute-force optimum.
+///
+/// This is what closes the coverage gap the hand-written families leave: it
+/// includes holes inside the atom set, holes at either end, compaction, spreading,
+/// mixed compaction-and-shift, and every reordering — not just the packed blocks
+/// with trailing holes that the shift tests use.
+///
+/// Start placements are restricted to *sorted* site lists, which loses nothing:
+/// relabelling atoms is a symmetry of the instance, and sweeping all `k!`
+/// relabellings of each start would only multiply the runtime.
+///
+/// **Both kinds of target are swept, and they are not interchangeable.** With a
+/// total assignment on a line, any solvable instance is order-preserving, so every
+/// atom that has to move wants to move the same way as the atom behind it and
+/// scoring nominates them all — that half of the sweep passes with or without the
+/// #910 closure. The single-atom targets are what reach the bug: the untargeted
+/// atoms are spectators, nothing scores them, and before the closure a targeted
+/// atom with a spectator in front of it had no successors at all.
+///
+/// Three properties, in decreasing order of how negotiable they are:
+///
+/// 1. **No impossible plans.** A `Solved` result must correspond to a reachable
+///    target, and its length must be at least the optimum. Violating either means
+///    the router used a move the architecture does not have — the failure mode a
+///    chain-assembly bug would produce, since a chain that "completes" without a
+///    free head is a rotation.
+/// 2. **No missed solutions.** Every reachable target is found. This one *is*
+///    negotiable in principle — the heuristic generators deliberately offer less
+///    than the architecture, so a search failing to find a plan is a quality
+///    result, not a correctness one — but at these sizes it currently holds
+///    exactly.
+/// 3. **Optimal length.** Every plan found is exactly as long as the optimum.
+#[test]
+fn router_matches_a_brute_force_optimum_on_every_1d_instance() {
+    // (sites, atoms). Sizes are bounded by running three strategies per instance;
+    // these cover 1 to 3 holes across three shapes.
+    for (n_sites, n_atoms) in [(4u32, 2u32), (5, 3), (5, 4)] {
+        let engine = line_engine(n_sites);
+        let index = LaneIndex::new(
+            serde_json::from_str::<ArchSpec>(&line_arch_json(n_sites)).expect("parses"),
+        );
+        let all = placements(n_sites, n_atoms);
+
+        // Total targets: every atom placed. Partial targets: one atom placed, the
+        // rest left as spectators.
+        let mut targets: Vec<Vec<(u32, LocationAddr)>> = all
+            .iter()
+            .map(|sites| {
+                sites
+                    .iter()
+                    .enumerate()
+                    .map(|(q, &s)| (q as u32, site(s)))
+                    .collect()
+            })
+            .collect();
+        for qid in 0..n_atoms {
+            for s in 0..n_sites {
+                targets.push(vec![(qid, site(s))]);
+            }
+        }
+
+        for start_sites in all.iter().filter(|v| v.windows(2).all(|w| w[0] < w[1])) {
+            let initial: Vec<(u32, LocationAddr)> = start_sites
+                .iter()
+                .enumerate()
+                .map(|(q, &s)| (q as u32, site(s)))
+                .collect();
+            let root = Config::new(initial.iter().copied()).expect("placement is injective");
+            let distances = optimal_distances_from(&index, &root);
+
+            for target in &targets {
+                let optimal = optimal_for_target(&distances, target);
+                let budget = SWEEP_BUDGET;
+
+                for (name, search) in searches() {
+                    let solver = TargetSolver::new(Arc::clone(&engine), search);
+                    let result = solver
+                        .solve(
+                            initial.iter().copied(),
+                            target.iter().copied(),
+                            std::iter::empty(),
+                            Some(budget),
+                        )
+                        .expect("instance is well formed");
+                    let label = format!(
+                        "{name}: {n_atoms} atoms on {n_sites} sites, {start_sites:?} -> {:?}",
+                        target
+                            .iter()
+                            .map(|&(q, l)| (q, l.site_id))
+                            .collect::<Vec<_>>()
+                    );
+
+                    match optimal {
+                        // Unreachable: no plan may be claimed.
+                        None => assert_ne!(
+                            result.status,
+                            SolveStatus::Solved,
+                            "{label}: claimed a plan for an unreachable target; got {:?}",
+                            result.move_layers
+                        ),
+                        Some(optimal) => {
+                            assert_eq!(
+                                result.status,
+                                SolveStatus::Solved,
+                                "{label}: reported {:?} on a target reachable in {optimal} \
+                                 operations",
+                                result.status
+                            );
+                            for &(qid, wanted) in target {
+                                assert_eq!(
+                                    result.goal_config.location_of(qid),
+                                    Some(wanted),
+                                    "{label}: q{qid} did not reach its target"
+                                );
+                            }
+                            assert!(
+                                result.move_layers.len() >= optimal,
+                                "{label}: returned {} operations, fewer than the optimum \
+                                 {optimal} — the plan uses a move the architecture does \
+                                 not have",
+                                result.move_layers.len()
+                            );
+                            assert_eq!(
+                                result.move_layers.len(),
+                                optimal,
+                                "{label}: returned {} operations against an optimum of \
+                                 {optimal}",
+                                result.move_layers.len()
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/bloqade-lanes-search/tests/conveyor_1d.rs
+++ b/crates/bloqade-lanes-search/tests/conveyor_1d.rs
@@ -242,12 +242,18 @@ fn rigid_shifts_are_solved_in_exactly_the_optimal_number_of_operations() {
                 result.move_layers.len(),
                 result.nodes_expanded
             );
-            // The plan is not just optimal in length but *found* optimally: the
-            // whole-row shift is the top-ranked candidate at every step, so the
-            // walk is straight down with no backtracking.
-            assert_eq!(
-                result.nodes_expanded, shift,
-                "{label}: expected a straight walk of {shift} expansions, got {}",
+            // The plan is also *found* cheaply: the whole-row shift ranks at or
+            // near the top at every step, so the walk is essentially straight
+            // down. Deliberately a bound and not an equality — a scoring change
+            // that explores a node or two more on the way to the same optimal
+            // plan is not a regression, while a search that starts thrashing
+            // blows past this by orders of magnitude.
+            let expansion_budget = shift + 4;
+            assert!(
+                result.nodes_expanded <= expansion_budget,
+                "{label}: expected at most {expansion_budget} expansions for a \
+                 {shift}-operation plan, got {} — the search is no longer walking \
+                 more or less straight to it",
                 result.nodes_expanded
             );
         }
@@ -529,6 +535,23 @@ fn config_key(config: &Config) -> ConfigKey {
     v
 }
 
+/// The sorted successor-config keys `generator` produces from `config` under
+/// `ctx`. Used only to check that the oracle's successor relation does not
+/// depend on the target set.
+fn successor_keys(
+    generator: &ExhaustiveGenerator,
+    config: &Config,
+    node: bloqade_lanes_search::primitives::graph::NodeId,
+    state: &mut SearchState,
+    ctx: &SearchContext,
+) -> Vec<ConfigKey> {
+    let mut out = Vec::new();
+    generator.generate(config, node, ctx, state, &mut out);
+    let mut keys: Vec<ConfigKey> = out.iter().map(|c| config_key(&c.new_config)).collect();
+    keys.sort();
+    keys
+}
+
 /// Optimal operation count from `start` to **every** reachable configuration, by
 /// breadth-first search over
 /// [`ExhaustiveGenerator`](bloqade_lanes_search::generators::exhaustive::ExhaustiveGenerator).
@@ -559,6 +582,28 @@ fn optimal_distances_from(index: &LaneIndex, start: &Config) -> HashMap<ConfigKe
     let scratch = SearchGraph::new(start.clone());
     let node = scratch.root();
     let mut state = SearchState::default();
+
+    // Enforce the target-independence this whole function rests on, rather than
+    // asserting it in prose. One BFS serves every target only because the
+    // successor relation ignores `ctx.targets` and `ctx.dist_table`; if that ever
+    // stops being true the oracle would keep returning *an* answer, silently the
+    // wrong one, and the sweep below would pass while comparing the router
+    // against corrupted ground truth.
+    debug_assert_eq!(
+        successor_keys(&generator, start, node, &mut state, &ctx),
+        successor_keys(
+            &generator,
+            start,
+            node,
+            &mut state,
+            &SearchContext {
+                targets: &[(0u32, 0u64)],
+                ..ctx
+            },
+        ),
+        "the oracle's successor relation now depends on the target set, so one \
+         BFS per start no longer serves every target"
+    );
 
     let mut dist: HashMap<ConfigKey, usize> = HashMap::new();
     dist.insert(config_key(start), 0);

--- a/python/bloqade/lanes/bytecode/_native.pyi
+++ b/python/bloqade/lanes/bytecode/_native.pyi
@@ -1158,7 +1158,14 @@ class SolveResult:
 
     @property
     def deadlocks(self) -> int:
-        """Number of deadlocks encountered during search."""
+        """Number of nodes at which the generator had nothing useful to offer.
+
+        Counts both "nothing scored an improvement" and "nothing was executable"
+        (every rectangle rejected). **Not** a count of escape moves taken: the
+        counter is incremented before ``deadlock_policy`` is consulted, so under
+        the default ``SKIP`` it records nodes where nothing was generated in
+        response. Read it as "how often the search got stuck".
+        """
         ...
 
     @property

--- a/python/bloqade/lanes/bytecode/_native.pyi
+++ b/python/bloqade/lanes/bytecode/_native.pyi
@@ -1121,7 +1121,13 @@ class SolveResult:
 
     @property
     def status(self) -> str:
-        """Status: ``"solved"``, ``"unsolvable"``, or ``"budget_exceeded"``."""
+        """Status: ``"solved"``, ``"unsolvable"``, or ``"budget_exceeded"``.
+
+        ``"unsolvable"`` is a proof only from the ``push_rotate`` strategy. From
+        a search strategy it means the search exhausted the moves its generator
+        offered — which is deliberately less than the architecture allows — not
+        that no solution exists.
+        """
         ...
 
     @property


### PR DESCRIPTION
Closes #910. Split out of the now-closed #918; the breaking half is #NEXT.

**Everything here is non-breaking and backportable.** It fixes both instances the
issue reports, so a `release-0-11` backport gets the whole benefit without the
semantics change that lives in the companion PR.

## The issue's own diagnosis was wrong, and that is the main finding

#910 prescribed #887's chain-aware joint selection. That fix is real and is in
here — but it does **not** fix the instance #910 reports. Validating against the
reporter's harness turned up two different root causes, both producing the same
symptom: `unsolvable` in seconds, identical at 1e5 and 1e8 expansions.

**Cause 1 — the escape hatch was gated on the wrong predicate.**
`HeuristicGenerator` fired its deadlock escape on `!has_positive`, a step-2 claim
about *distance* made before any AOD geometry exists. Whether a candidate can
actually execute is decided two steps later by `build_aod_grids`. When every
positive-scoring candidate's rectangle turned out unexecutable, the call emitted
nothing and — because something had scored positive — no escape was generated.
Zero successors, open list drains.

The counters name it: the reported instance died at `nodes_expanded = 2,
deadlocks = 0`. A zero deadlock count means the generator never knew it was
stuck. Now gated on "this call produced nothing" as well, compared against a mark
taken on entry rather than `out.is_empty()`, since `generate` appends.

**Cause 2 — an explicit `AllMoves` was silently downgraded.**
`run_with_components` threaded the caller's `deadlock_policy` into IDS/DFS/entropy
but hardcoded `MoveBlockers` for A*, BFS, greedy and the cascade's A* refinement.
The two are not interchangeable: `MoveBlockers` only frees atoms standing *on* an
unresolved target, so when a mover's target is merely far away rather than
occupied it emits nothing at all. `MoveBlockers` stays a **floor** here — raising
`Skip` keeps default-configured solves working exactly as before — and only the
downgrade is removed, which is what keeps this PR non-breaking.

**Cause 3 (the prescribed one) — selection never closed its mover set over
chains.** `build_aod_grids` derives movers from `entries.keys()`, and #896's
repair closure can only pull in cells whose source is already an entry — it must
never promote a stationary atom, or the plan and the hardware disagree. So a
chain assembled only when every follower happened to be nominated on its own
merit, which on a packed block does not happen: a follower already on its target
is never scored, and one scoring `<= 0` is pruned. `close_chain_entries` now
co-selects the atom ahead, transitively to the free head.

## Evidence

Reporter's 98-atom ising stage phase (gate+memory 5x16, 49 CZ pairs, fixed-home
staging), and the 37-atom single-mover `bv_n70` phase:

| instance | strategy | before | after |
|---|---|---|---|
| ising_n98 | ids | `unsolvable` | solved, 16 nodes, 16 layers |
| ising_n98 | astar | `unsolvable` | solved, 15 layers |
| ising_n98 | entropy | solved, 21 layers | unchanged |
| bv_n70 | astar | `unsolvable`, 1 node | solved, 3 nodes, 3 layers |

A* now also beats entropy on plan length (15 vs 21) — the move-count reference
#910 asked for and could not get. Across the reporter's 18-kernel sweep on
`all_hv_shift_5x16` under astar: **15 ok / 2 failed to 17 ok / 1 failed**. The
remaining failure is `ising_n98` at `budget_exceeded`, which reproduces
identically with these fixes reverted — pre-existing and orthogonal.

## Benchmarks

**No differences, physical or logical.** The chain closure cannot fire on the
shipped endpoint-disjoint specs, the escape body is a no-op under the default
`Skip`, and the `MoveBlockers` floor reproduces the previous hardcoded value
exactly.

## Also in here

- `SolveStatus::Unsolvable` documented honestly: a proof only from
  `push_rotate`; from a search strategy it means the generator's move vocabulary
  was exhausted, which is deliberately less than the architecture allows.
  Mirrored on the PyO3 getter and `_native.pyi`.
- `SolveResult::deadlocks` likewise — it counts nodes where the search got stuck,
  *not* escape moves taken, and it increments under `Skip` where nothing is
  generated in response.
- `perf`: the chain closure reached `Config::qubit_at` (a documented O(atoms)
  scan) once per selected mover per bus group on *every* spec, including those
  where it can never fire. Reordered cheapest-test-first behind a hash probe;
  bit-identical by construction.

## Tests

- `close_chain_entries` unit coverage: transitive walk, broken chain, blocked
  head, already-a-mover, no-op on endpoint-disjoint buses.
- The packed witness at generator level for *both* generators, and end to end.
  The entropy driver was **not** immune — it shares the mover-set shape and fails
  the same witness; it escaped the reported instance only because enough atoms
  there happened to be unresolved movers.
- `a_node_whose_rectangles_all_fail_still_gets_escape_moves` pins cause 1, and
  pins the `Skip` half too, so a future change to the default cannot silently
  switch the fix on or off for every default caller.
- `tests/conveyor_1d.rs`: a 1D conveyor suite where the optimum is provable.
  Rigid shifts hit exactly `d` operations; rotations and transpositions are never
  claimed (they would need the one operation the architecture lacks); and an
  exhaustive sweep checks **every** instance at three sizes against a brute-force
  optimum from BFS over `ExhaustiveGenerator`.

Every new test was verified to fail with its fix stubbed out.

## Known limits, deliberately not fixed here

- The escape-gate fix is **opt-in**: `Skip` is the default and generates nothing,
  so this benefits callers that set `MoveBlockers`/`AllMoves` — as the reporting
  harness does.
- `dsl::pipeline::pack_aod_rectangles` is a fourth caller of `build_aod_grids`
  that still lacks the chain closure, so a Starlark policy retains cause 3 on a
  chain-capable spec. Documented on `build_aod_grids` rather than left silent.
- Rectangle growth can force cells in *other* rows whose occupants selection
  never nominated; `rect_outcome` rejects those with no way to ask for more
  movers. Derived from the code, not demonstrated — the 1D suite cannot reach it.
- `AllMoves` fan-out is (atoms x free lanes) — 849 and 12,250 successors on the
  two instances above. Under A* every child is a full `Config` clone, so a dense
  instance with a very large `max_expansions` may exhaust memory where it
  previously returned a fast wrong `unsolvable`.
