### PR TITLE
fix(validation): validate total qubit allocation in Gemini logical kernels

### DIFF
--- a/python/bloqade/gemini/logical/validation/clifford/analysis.py
+++ b/python/bloqade/gemini/logical/validation/clifford/analysis.py
@@ -55,10 +55,22 @@ class GeminiLogicalValidation(ValidationPass):
         return "Gemini Logical Validation"
 
     def run(self, method: ir.Method) -> tuple[Any, list[ir.ValidationError]]:
-        addr_frame, _ = AddressAnalysis(method.dialects).run(method)
+        address_analysis = AddressAnalysis(method.dialects)
+        addr_frame, _ = address_analysis.run(method)
+
         analysis = _GeminiLogicalValidationAnalysis(
             method.dialects, addr_frame=addr_frame
         )
+
         frame, _ = analysis.run(method)
+
+        if address_analysis.qubit_count > analysis.max_qubits:
+            analysis.add_validation_error(
+                method.code,
+                ir.ValidationError(
+                    method.code,
+                    f"qubit allocation {address_analysis.qubit_count} exceeded {analysis.max_qubits}",
+                ),
+            )
 
         return frame, analysis.get_validation_errors()

--- a/python/bloqade/gemini/logical/validation/clifford/analysis.py
+++ b/python/bloqade/gemini/logical/validation/clifford/analysis.py
@@ -69,7 +69,7 @@ class GeminiLogicalValidation(ValidationPass):
                 method.code,
                 ir.ValidationError(
                     method.code,
-                    f"qubit allocation {address_analysis.qubit_count} exceeded {analysis.max_qubits}",
+                    f"qubit allocation {address_analysis.qubit_count} exceeded max of {analysis.max_qubits}",
                 ),
             )
 

--- a/python/bloqade/gemini/logical/validation/clifford/analysis.py
+++ b/python/bloqade/gemini/logical/validation/clifford/analysis.py
@@ -69,7 +69,8 @@ class GeminiLogicalValidation(ValidationPass):
                 method.code,
                 ir.ValidationError(
                     method.code,
-                    f"qubit allocation {address_analysis.qubit_count} exceeded max of {analysis.max_qubits}",
+                    f"kernel allocates {address_analysis.qubit_count} qubits, "
+                    f"exceeding the maximum of {analysis.max_qubits}",
                 ),
             )
 

--- a/python/bloqade/gemini/logical/validation/measurement/analysis.py
+++ b/python/bloqade/gemini/logical/validation/measurement/analysis.py
@@ -24,6 +24,9 @@ class _GeminiTerminalMeasurementValidationAnalysis(Forward[EmptyLattice]):
     def method_self(self, method: ir.Method) -> EmptyLattice:
         return self.lattice.bottom()
 
+    def run_lattice(*args, **kwargs):
+        return EmptyLattice.bottom()
+
 
 @dataclass
 class GeminiTerminalMeasurementValidation(ValidationPass):

--- a/python/bloqade/gemini/logical/validation/measurement/analysis.py
+++ b/python/bloqade/gemini/logical/validation/measurement/analysis.py
@@ -24,8 +24,26 @@ class _GeminiTerminalMeasurementValidationAnalysis(Forward[EmptyLattice]):
     def method_self(self, method: ir.Method) -> EmptyLattice:
         return self.lattice.bottom()
 
-    def run_lattice(*args, **kwargs):
-        return EmptyLattice.bottom()
+    def run_lattice(
+        self,
+        callee: EmptyLattice,
+        inputs: tuple[EmptyLattice, ...],
+        keys: tuple[str, ...],
+        kwargs: tuple[EmptyLattice, ...],
+    ) -> EmptyLattice:
+        """Handle a dynamic ``func.Call``.
+
+        Required, not optional: ``impls.Func`` subclasses the address analysis'
+        ``func`` method table, so this analysis inherits a ``func.Call`` impl
+        that calls ``run_lattice`` on the interpreter. Without an override, any
+        kernel containing a dynamic call dies with an ``AttributeError``.
+
+        Dynamic callees are deliberately not descended into. ``EmptyLattice``
+        carries no information, so a callee's return value would add nothing to
+        the frame; the cost is that a terminal-measurement violation *inside* a
+        dynamically called kernel goes unreported.
+        """
+        return self.lattice.bottom()
 
 
 @dataclass

--- a/python/tests/gemini/analysis/test_logical_validation.py
+++ b/python/tests/gemini/analysis/test_logical_validation.py
@@ -296,3 +296,34 @@ def test_allocation_at_limit_is_valid():
 
     validator = ValidationSuite([GeminiLogicalValidation])
     validator.validate(main).raise_if_invalid()
+
+
+def test_dynamic_call_through_parameter_does_not_crash_validation():
+    """A dynamic `func.Call` must not blow up the terminal measurement pass.
+
+    `measurement.impls.Func` subclasses the address analysis' `func` method
+    table, so the measurement analysis *inherits* a `func.Call` impl that calls
+    `run_lattice` on the interpreter. Without the override on
+    `_GeminiTerminalMeasurementValidationAnalysis`, compiling any kernel that
+    calls one of its own parameters fails with
+    `AttributeError: ... has no attribute 'run_lattice'`.
+
+    No other kernel in the suite performs a dynamic call, so nothing else covers
+    this.
+    """
+    from bloqade.analysis.address.impls import Func as AddressFuncMethodTable
+
+    from bloqade.gemini.logical.validation.measurement.impls import (
+        Func as MeasurementFuncMethodTable,
+    )
+
+    # The coupling is what makes the override mandatory. If this stops holding,
+    # re-check whether the override is still needed before removing it.
+    assert issubclass(MeasurementFuncMethodTable, AddressFuncMethodTable)
+
+    @gemini.logical.kernel
+    def higher_order(f):
+        f()
+
+    validator = ValidationSuite([GeminiTerminalMeasurementValidation])
+    validator.validate(higher_order).raise_if_invalid()

--- a/python/tests/gemini/analysis/test_logical_validation.py
+++ b/python/tests/gemini/analysis/test_logical_validation.py
@@ -244,3 +244,55 @@ def test_allocation():
             reg = squin.qalloc(12)
             squin.h(reg[0])
             squin.cx(reg[0], reg[1])
+
+
+MAX_QUBITS = _GeminiLogicalValidationAnalysis.max_qubits
+
+
+def _error_messages(err: ValidationErrorGroup) -> list[str]:
+    return [e.args[0] if e.args else str(e) for e in err.errors]
+
+
+def test_allocation_exceeded_without_unroll():
+    # NOTE: the per-`qubit.New` check only fires once a register has been
+    # expanded into individual qubits, so without unrolling the total
+    # allocation is the only thing that can catch this.
+    with pytest.raises(ValidationErrorGroup) as exc_info:
+
+        @gemini.logical.kernel
+        def main():
+            reg = squin.qalloc(MAX_QUBITS + 1)
+            squin.h(reg[0])
+
+    assert any(
+        f"kernel allocates {MAX_QUBITS + 1} qubits, "
+        f"exceeding the maximum of {MAX_QUBITS}" in message
+        for message in _error_messages(exc_info.value)
+    )
+
+
+def test_allocation_exceeded_summed_across_registers():
+    with pytest.raises(ValidationErrorGroup) as exc_info:
+
+        @gemini.logical.kernel
+        def main():
+            first = squin.qalloc(MAX_QUBITS)
+            second = squin.qalloc(1)
+            squin.h(first[0])
+            squin.h(second[0])
+
+    assert any(
+        f"kernel allocates {MAX_QUBITS + 1} qubits, "
+        f"exceeding the maximum of {MAX_QUBITS}" in message
+        for message in _error_messages(exc_info.value)
+    )
+
+
+def test_allocation_at_limit_is_valid():
+    @gemini.logical.kernel
+    def main():
+        reg = squin.qalloc(MAX_QUBITS)
+        squin.h(reg[0])
+
+    validator = ValidationSuite([GeminiLogicalValidation])
+    validator.validate(main).raise_if_invalid()


### PR DESCRIPTION
Validates the total number of qubits a Gemini logical kernel allocates.

Split out of the original #922 scope; the recursion guard now lives in its own PR. The two are independent — disjoint files, mergeable in either order.

## The gap

The per-qubit check in `clifford/impls.py` only fires once a register has been expanded into individual `qubit.New` statements. Without `aggressive_unroll=True` that never happens, so over-allocation validated clean:

| kernel | before | after |
|---|---|---|
| `qalloc(11)` | passed | rejected |
| `qalloc(12)` | passed | rejected |
| `qalloc(6) + qalloc(6)` | passed | rejected |
| `qalloc(10)` (at limit) | passed | passed |
| `qalloc(12)` with `aggressive_unroll=True` | rejected | rejected |

The existing `test_allocation` case used `aggressive_unroll=True`, so it passed with or without the fix and left the new check untested. Three cases now pin the gap the check actually closes, and reference `_GeminiLogicalValidationAnalysis.max_qubits` rather than hardcoding 10 so they track the limit.

The message now reads `kernel allocates 11 qubits, exceeding the maximum of 10`.

## `run_lattice` on the measurement analysis

The override shipped alongside this fix looks like dead code — nothing names it, and deleting it leaves the whole suite green. It is not dead. `measurement/impls.py` registers `class Func(AddressFuncMethodTable)`, so the analysis inherits the address analysis' `func.Call` impl, which calls `run_lattice` on the interpreter. Removing the override makes any kernel that calls one of its own parameters fail with `AttributeError: ... has no attribute 'run_lattice'`. Grepping for call sites does not reveal this; only the traceback does.

Given a real signature and a docstring stating why it exists and what the bottom return costs (a terminal-measurement violation inside a dynamically called kernel goes unreported), plus the missing test. The test also asserts the subclass coupling, so if that is ever broken the override can be re-evaluated rather than silently kept.

## Testing

- 1641 passed, 6 skipped, 1 xpassed
- Both allocation tests verified to fail on `main`; the `run_lattice` test verified to fail without the override
- black / isort / ruff / pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
