### PR TITLE
fix(demo): correct GHZ preparation in ghz_moves_demo

### DIFF
--- a/demo/ghz_moves_demo.py
+++ b/demo/ghz_moves_demo.py
@@ -32,11 +32,13 @@ def ghz_optimal():
     squin.broadcast.sqrt_y(qs)
     squin.z(qs[0])
     squin.cz(qs[0], qs[5])
+    squin.sqrt_y_adj(qs[5])
     squin.broadcast.cz(ilist.IList([qs[0], qs[5]]), ilist.IList([qs[1], qs[6]]))
+    squin.broadcast.sqrt_y_adj(ilist.IList([qs[1], qs[6]]))
     squin.broadcast.cz(qs[:2] + qs[5:7], qs[2:4] + qs[7:9])
+    squin.broadcast.sqrt_y_adj(qs[2:4] + qs[7:9])
     squin.broadcast.cz(ilist.IList([qs[3], qs[8]]), ilist.IList([qs[4], qs[9]]))
-    squin.broadcast.sqrt_y(qs)
-    squin.sqrt_y_adj(qs[0])
+    squin.broadcast.sqrt_y_adj(ilist.IList([qs[4], qs[9]]))
 
 
 mt = LogicalPipeline().emit(log_depth_ghz)


### PR DESCRIPTION
## Summary

Fixes the `ghz_optimal` kernel in [`demo/ghz_moves_demo.py`](demo/ghz_moves_demo.py), which prepared the **wrong quantum state** (reported in #930).

The original kernel deferred every basis-change rotation to a single global `sqrt_y` pulse at the end. Those rotations do not commute through the intervening CZ layers, so the kernel produced a tree graph state — uniform support over 128 computational-basis states — instead of the intended 10-qubit GHZ state $(|0\cdots0\rangle + |1\cdots1\rangle)/\sqrt{2}$.

The fix (as proposed in the issue) applies `sqrt_y_adj` to each layer's newly connected targets immediately after that layer, and removes the trailing global rotations.

## Verification

Using `bloqade.lanes.utils.check_circuit` to compare state vectors against a reference GHZ (textbook `H` + `CX` chain — a GHZ state is permutation-symmetric, so qubit ordering doesn't matter):

| kernel | nonzero basis states | P(0…0) | P(1…1) | `check_circuit` vs reference GHZ |
|---|---|---|---|---|
| reference GHZ (H + CX chain) | 2 | 0.500000 | 0.500000 | — |
| `ghz_optimal` (original) | 128 | 0.000000 | 0.000000 | ❌ `False` |
| `ghz_optimal` (fixed) | 2 | 0.500000 | 0.500000 | ✅ `True` |

The fixed kernel is state-vector-equivalent (up to global phase) to a correct GHZ preparation.

Closes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)