### PR TITLE
feat(metrics): unify the FLAIR constant-jerk timing model into a shared MotionModel

### DIFF
--- a/crates/bloqade-lanes-bytecode-core/src/arch/metrics.rs
+++ b/crates/bloqade-lanes-bytecode-core/src/arch/metrics.rs
@@ -1,0 +1,222 @@
+//! Move-duration metrics: the FLAIR constant-jerk motion/timing model.
+//!
+//! [`MotionModel`] owns the physical timing constants (ramp rate, max jerk,
+//! max acceleration) and the derived move-duration formula. It is the single
+//! source of truth for lane-duration timing across the whole workspace: the
+//! Rust search ([`crate`] consumers via `bloqade-lanes-search`) and the Python
+//! layer both compute durations through this type, the latter via the
+//! `bloqade.lanes.bytecode.MotionModel` PyO3 binding.
+//!
+//! The model is *configurable*: [`MotionModel::default`] reproduces the FLAIR
+//! constants exactly (see [`FLAIR_MAX_RAMP_US`] and friends), but callers may
+//! construct a [`MotionModel`] with different constants to model a different
+//! motion profile without touching this code.
+
+/// FLAIR maximum amplitude ramp rate (amplitude units per µs).
+///
+/// The ramp time for a pick or drop is `amplitude / max_ramp_us`.
+/// Extracted from bloqade-flair's constant-jerk motion model.
+pub const FLAIR_MAX_RAMP_US: f64 = 0.2;
+/// FLAIR maximum jerk in µm/µs³. Extracted from bloqade-flair.
+pub const FLAIR_MAX_JERK_UM_PER_US3: f64 = 0.0004;
+/// FLAIR maximum acceleration in µm/µs². Extracted from bloqade-flair.
+pub const FLAIR_MAX_ACCEL_UM_PER_US2: f64 = 0.0015;
+
+/// Distance below which a move is treated as zero-duration (µm).
+const MIN_MOVE_DISTANCE_UM: f64 = 1e-8;
+
+/// Constant-jerk motion/timing model for AOD moves.
+///
+/// Holds the three timing constants and computes move durations from a
+/// waypoint path. Defaults to the FLAIR constants; construct with
+/// [`MotionModel::new`] to override them.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MotionModel {
+    /// Maximum amplitude ramp rate (amplitude units per µs). Must be > 0.
+    pub max_ramp_us: f64,
+    /// Maximum jerk in µm/µs³. Must be > 0.
+    pub max_jerk_um_per_us3: f64,
+    /// Maximum acceleration in µm/µs². Must be > 0.
+    pub max_accel_um_per_us2: f64,
+}
+
+impl Default for MotionModel {
+    /// The FLAIR constant-jerk motion model.
+    fn default() -> Self {
+        Self {
+            max_ramp_us: FLAIR_MAX_RAMP_US,
+            max_jerk_um_per_us3: FLAIR_MAX_JERK_UM_PER_US3,
+            max_accel_um_per_us2: FLAIR_MAX_ACCEL_UM_PER_US2,
+        }
+    }
+}
+
+impl MotionModel {
+    /// Construct a motion model from explicit constants.
+    ///
+    /// All three constants must be positive and finite. `max_ramp_us` and
+    /// `max_jerk_um_per_us3` appear as divisors; a non-positive
+    /// `max_accel_um_per_us2` drives `t1` to zero (or negative), which makes
+    /// the trajectory solver return `NaN`/negative durations. Returns `None`
+    /// for any non-physical constant.
+    pub fn new(
+        max_ramp_us: f64,
+        max_jerk_um_per_us3: f64,
+        max_accel_um_per_us2: f64,
+    ) -> Option<Self> {
+        if !max_ramp_us.is_finite()
+            || !max_jerk_um_per_us3.is_finite()
+            || !max_accel_um_per_us2.is_finite()
+            || max_ramp_us <= 0.0
+            || max_jerk_um_per_us3 <= 0.0
+            || max_accel_um_per_us2 <= 0.0
+        {
+            return None;
+        }
+        Some(Self {
+            max_ramp_us,
+            max_jerk_um_per_us3,
+            max_accel_um_per_us2,
+        })
+    }
+
+    /// The FLAIR constant-jerk motion model (alias for [`Default`]).
+    pub fn flair() -> Self {
+        Self::default()
+    }
+
+    /// Minimum duration (µs) for a constant-jerk move over `max_dist_um`.
+    ///
+    /// Solves the constant-jerk trajectory: below the acceleration cap the
+    /// move is jerk-limited (four jerk phases); above it, two extra
+    /// constant-acceleration phases are inserted.
+    pub fn const_jerk_min_duration_us(&self, max_dist_um: f64) -> f64 {
+        let max_dist_um = max_dist_um.abs();
+        if max_dist_um < MIN_MOVE_DISTANCE_UM {
+            return 0.0;
+        }
+
+        let t1 = self.max_accel_um_per_us2 / self.max_jerk_um_per_us3;
+        let a = self.max_jerk_um_per_us3 * t1;
+        let b = 3.0 * self.max_jerk_um_per_us3 * t1 * t1;
+        let c = 2.0 * self.max_jerk_um_per_us3 * t1 * t1 * t1 - max_dist_um;
+
+        if c >= 0.0 {
+            let t1_jerk = (max_dist_um / (2.0 * self.max_jerk_um_per_us3)).cbrt();
+            return 4.0 * t1_jerk;
+        }
+
+        let discriminant = b * b - 4.0 * a * c;
+        let t2 = (-b + discriminant.sqrt()) / (2.0 * a);
+        4.0 * t1 + 2.0 * t2
+    }
+
+    /// Compute lane duration (µs) from a waypoint path:
+    /// `ramp + Σ per-segment const-jerk duration + ramp`.
+    ///
+    /// The pick and drop ramps are always charged, so a path with no motion
+    /// segments (fewer than two waypoints) still costs `2 * ramp` rather than
+    /// collapsing to a free move. `amplitude_delta` scales the ramp time; its
+    /// sign is ignored.
+    pub fn lane_duration_us(&self, waypoints: &[[f64; 2]], amplitude_delta: f64) -> f64 {
+        let ramp = amplitude_delta.abs() / self.max_ramp_us;
+        let segment_sum: f64 = waypoints
+            .windows(2)
+            .map(|w| {
+                let dx = w[1][0] - w[0][0];
+                let dy = w[1][1] - w[0][1];
+                self.const_jerk_min_duration_us((dx * dx + dy * dy).sqrt())
+            })
+            .sum();
+        ramp + segment_sum + ramp
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_matches_flair_constants() {
+        let m = MotionModel::default();
+        assert_eq!(m.max_ramp_us, FLAIR_MAX_RAMP_US);
+        assert_eq!(m.max_jerk_um_per_us3, FLAIR_MAX_JERK_UM_PER_US3);
+        assert_eq!(m.max_accel_um_per_us2, FLAIR_MAX_ACCEL_UM_PER_US2);
+        assert_eq!(m, MotionModel::flair());
+    }
+
+    #[test]
+    fn zero_and_tiny_distance_is_zero_duration() {
+        let m = MotionModel::default();
+        assert_eq!(m.const_jerk_min_duration_us(0.0), 0.0);
+        assert_eq!(m.const_jerk_min_duration_us(1e-12), 0.0);
+    }
+
+    #[test]
+    fn duration_is_even_in_sign_and_increasing() {
+        let m = MotionModel::default();
+        let d10 = m.const_jerk_min_duration_us(10.0);
+        assert_eq!(d10, m.const_jerk_min_duration_us(-10.0));
+        assert!(d10 > 0.0);
+        assert!(m.const_jerk_min_duration_us(50.0) > d10);
+    }
+
+    #[test]
+    fn both_trajectory_branches_are_exercised() {
+        let m = MotionModel::default();
+        // t1 = accel/jerk = 3.75 µs; jerk-only reach = 2*jerk*t1^3 ≈ 0.0422 µm.
+        // A sub-threshold distance takes the pure-jerk (cbrt) branch; a large
+        // one takes the constant-acceleration (quadratic) branch. Both must be
+        // finite and ordered.
+        let small = m.const_jerk_min_duration_us(0.01);
+        let large = m.const_jerk_min_duration_us(100.0);
+        assert!(small.is_finite() && small > 0.0);
+        assert!(large.is_finite() && large > small);
+    }
+
+    #[test]
+    fn lane_duration_is_ramp_plus_segments_plus_ramp() {
+        let m = MotionModel::default();
+        let waypoints = [[0.0, 0.0], [3.0, 4.0]]; // one 5 µm segment
+        let ramp = 1.0 / m.max_ramp_us;
+        let expected = ramp + m.const_jerk_min_duration_us(5.0) + ramp;
+        assert_eq!(m.lane_duration_us(&waypoints, 1.0), expected);
+    }
+
+    #[test]
+    fn lane_duration_of_pathless_move_is_two_ramps() {
+        let m = MotionModel::default();
+        // No motion segments — still pays the pick and drop ramps, never free.
+        let two_ramps = 2.0 * (1.0 / m.max_ramp_us);
+        assert_eq!(m.lane_duration_us(&[], 1.0), two_ramps);
+        assert_eq!(m.lane_duration_us(&[[1.0, 2.0]], 1.0), two_ramps);
+    }
+
+    #[test]
+    fn amplitude_scales_ramp_only() {
+        let m = MotionModel::default();
+        let waypoints = [[0.0, 0.0], [3.0, 4.0]];
+        let seg = m.const_jerk_min_duration_us(5.0);
+        // ramp = amp / max_ramp; total ramp contribution is 2 * ramp.
+        assert_eq!(
+            m.lane_duration_us(&waypoints, 2.0),
+            2.0 * (2.0 / m.max_ramp_us) + seg
+        );
+        // Sign of amplitude is ignored.
+        assert_eq!(
+            m.lane_duration_us(&waypoints, -1.0),
+            m.lane_duration_us(&waypoints, 1.0)
+        );
+    }
+
+    #[test]
+    fn new_rejects_non_physical_constants() {
+        assert!(MotionModel::new(0.0, 1.0, 1.0).is_none());
+        assert!(MotionModel::new(1.0, 0.0, 1.0).is_none());
+        assert!(MotionModel::new(1.0, 1.0, 0.0).is_none());
+        assert!(MotionModel::new(1.0, 1.0, -1.0).is_none());
+        assert!(MotionModel::new(-1.0, 1.0, 1.0).is_none());
+        assert!(MotionModel::new(f64::NAN, 1.0, 1.0).is_none());
+        assert!(MotionModel::new(0.2, 0.0004, 0.0015).is_some());
+    }
+}

--- a/crates/bloqade-lanes-bytecode-core/src/arch/metrics.rs
+++ b/crates/bloqade-lanes-bytecode-core/src/arch/metrics.rs
@@ -90,6 +90,9 @@ impl MotionModel {
     /// Solves the constant-jerk trajectory: below the acceleration cap the
     /// move is jerk-limited (four jerk phases); above it, two extra
     /// constant-acceleration phases are inserted.
+    ///
+    /// The sign of `max_dist_um` is ignored (the absolute distance is used);
+    /// a distance below ~1e-8 µm is treated as no move and returns 0.0.
     pub fn const_jerk_min_duration_us(&self, max_dist_um: f64) -> f64 {
         let max_dist_um = max_dist_um.abs();
         if max_dist_um < MIN_MOVE_DISTANCE_UM {

--- a/crates/bloqade-lanes-bytecode-core/src/arch/mod.rs
+++ b/crates/bloqade-lanes-bytecode-core/src/arch/mod.rs
@@ -13,6 +13,7 @@
 //! - [`Direction`], [`MoveType`] — transport enums
 
 pub mod addr;
+pub mod metrics;
 pub mod query;
 pub mod types;
 pub mod validate;
@@ -20,6 +21,7 @@ pub mod validate;
 pub use addr::{
     Direction, LaneAddr, LocationAddr, MoveType, SiteRef, WordRef, ZoneAddr, ZonedWordRef,
 };
+pub use metrics::MotionModel;
 pub use query::ArchSpecLoadError;
 pub use types::{ArchSpec, Bus, Grid, Mode, TransportPath, Word, Zone};
 pub use validate::ArchSpecError;

--- a/crates/bloqade-lanes-bytecode-python/src/lib.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/lib.rs
@@ -18,6 +18,7 @@ mod arch_python;
 mod atom_state_python;
 pub(crate) mod errors;
 mod instruction_python;
+mod metrics_python;
 mod policy_runner_python;
 mod program_python;
 mod search_python;
@@ -37,6 +38,9 @@ fn bloqade_lanes_bytecode(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<arch_python::PyZone>()?;
     m.add_class::<arch_python::PyMode>()?;
     m.add_class::<arch_python::PyTransportPath>()?;
+
+    // Move-metric timing model
+    m.add_class::<metrics_python::PyMotionModel>()?;
 
     // Address types and enums
     m.add_class::<arch_python::PyDirection>()?;

--- a/crates/bloqade-lanes-bytecode-python/src/metrics_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/metrics_python.rs
@@ -1,0 +1,101 @@
+//! PyO3 binding for the FLAIR constant-jerk motion/timing model.
+//!
+//! Exposes [`bloqade_lanes_bytecode_core::arch::metrics::MotionModel`] to
+//! Python as `bloqade.lanes.bytecode.MotionModel`, so the Python layer computes
+//! lane durations through the same implementation as the Rust search rather
+//! than a hand-maintained transcription.
+
+use pyo3::prelude::*;
+
+use bloqade_lanes_bytecode_core::arch::metrics as rs;
+
+/// Constant-jerk motion/timing model for AOD move durations.
+///
+/// Defaults to the FLAIR constants; pass explicit values to model a different
+/// motion profile. The pick/drop ramp and per-segment jerk math are computed
+/// in Rust and shared with the move-search solver.
+#[pyclass(
+    name = "MotionModel",
+    frozen,
+    module = "bloqade.lanes.bytecode._native"
+)]
+#[derive(Clone)]
+pub struct PyMotionModel {
+    pub(crate) inner: rs::MotionModel,
+}
+
+#[pymethods]
+impl PyMotionModel {
+    #[new]
+    #[pyo3(signature = (
+        max_ramp_us = rs::FLAIR_MAX_RAMP_US,
+        max_jerk_um_per_us3 = rs::FLAIR_MAX_JERK_UM_PER_US3,
+        max_accel_um_per_us2 = rs::FLAIR_MAX_ACCEL_UM_PER_US2,
+    ))]
+    fn new(
+        max_ramp_us: f64,
+        max_jerk_um_per_us3: f64,
+        max_accel_um_per_us2: f64,
+    ) -> PyResult<Self> {
+        match rs::MotionModel::new(max_ramp_us, max_jerk_um_per_us3, max_accel_um_per_us2) {
+            Some(inner) => Ok(Self { inner }),
+            None => Err(pyo3::exceptions::PyValueError::new_err(
+                "MotionModel requires finite constants with max_ramp_us > 0, \
+                 max_jerk_um_per_us3 > 0, and max_accel_um_per_us2 > 0",
+            )),
+        }
+    }
+
+    /// The FLAIR constant-jerk motion model (the default constants).
+    #[staticmethod]
+    fn flair() -> Self {
+        Self {
+            inner: rs::MotionModel::flair(),
+        }
+    }
+
+    /// Maximum amplitude ramp rate (amplitude units per µs).
+    #[getter]
+    fn max_ramp_us(&self) -> f64 {
+        self.inner.max_ramp_us
+    }
+
+    /// Maximum jerk in µm/µs³.
+    #[getter]
+    fn max_jerk_um_per_us3(&self) -> f64 {
+        self.inner.max_jerk_um_per_us3
+    }
+
+    /// Maximum acceleration in µm/µs².
+    #[getter]
+    fn max_accel_um_per_us2(&self) -> f64 {
+        self.inner.max_accel_um_per_us2
+    }
+
+    /// Minimum duration (µs) of a constant-jerk move over `max_dist_um`.
+    fn const_jerk_min_duration_us(&self, max_dist_um: f64) -> f64 {
+        self.inner.const_jerk_min_duration_us(max_dist_um)
+    }
+
+    /// Lane duration (µs) over a waypoint path: ramp + Σ segments + ramp.
+    ///
+    /// `waypoints` are `(x, y)` coordinates in µm. The pick/drop ramps are
+    /// always charged, so a path with no motion segments (fewer than two
+    /// waypoints) still costs `2 * ramp` rather than zero.
+    #[pyo3(signature = (waypoints, amplitude_delta = 1.0))]
+    fn lane_duration_us(&self, waypoints: Vec<(f64, f64)>, amplitude_delta: f64) -> f64 {
+        let waypoints: Vec<[f64; 2]> = waypoints.into_iter().map(|(x, y)| [x, y]).collect();
+        self.inner.lane_duration_us(&waypoints, amplitude_delta)
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "MotionModel(max_ramp_us={}, max_jerk_um_per_us3={}, max_accel_um_per_us2={})",
+            self.inner.max_ramp_us, self.inner.max_jerk_um_per_us3, self.inner.max_accel_um_per_us2,
+        )
+    }
+
+    fn __eq__(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}

--- a/crates/bloqade-lanes-bytecode-python/src/metrics_python.rs
+++ b/crates/bloqade-lanes-bytecode-python/src/metrics_python.rs
@@ -73,6 +73,9 @@ impl PyMotionModel {
     }
 
     /// Minimum duration (µs) of a constant-jerk move over `max_dist_um`.
+    ///
+    /// The sign of `max_dist_um` is ignored; a distance below ~1e-8 µm is
+    /// treated as no move and returns 0.0.
     fn const_jerk_min_duration_us(&self, max_dist_um: f64) -> f64 {
         self.inner.const_jerk_min_duration_us(max_dist_um)
     }
@@ -81,7 +84,8 @@ impl PyMotionModel {
     ///
     /// `waypoints` are `(x, y)` coordinates in µm. The pick/drop ramps are
     /// always charged, so a path with no motion segments (fewer than two
-    /// waypoints) still costs `2 * ramp` rather than zero.
+    /// waypoints) still costs `2 * ramp` rather than zero. `amplitude_delta`
+    /// scales the ramp time; its sign is ignored.
     #[pyo3(signature = (waypoints, amplitude_delta = 1.0))]
     fn lane_duration_us(&self, waypoints: Vec<(f64, f64)>, amplitude_delta: f64) -> f64 {
         let waypoints: Vec<[f64; 2]> = waypoints.into_iter().map(|(x, y)| [x, y]).collect();

--- a/crates/bloqade-lanes-search/src/primitives/lane_index.rs
+++ b/crates/bloqade-lanes-search/src/primitives/lane_index.rs
@@ -7,6 +7,7 @@
 use std::collections::HashMap;
 
 use bloqade_lanes_bytecode_core::arch::addr::{Direction, LaneAddr, LocationAddr, MoveType};
+use bloqade_lanes_bytecode_core::arch::metrics::MotionModel;
 use bloqade_lanes_bytecode_core::arch::types::ArchSpec;
 
 use crate::primitives::bus_grid_maps::BusGridMaps;
@@ -56,10 +57,20 @@ impl LaneIndex {
 
     /// Build a lane index from an architecture specification.
     ///
+    /// Uses the default ([`MotionModel::default`], i.e. FLAIR) timing model to
+    /// price lane durations. Use [`with_motion_model`](Self::with_motion_model)
+    /// to supply a different motion profile.
+    pub fn new(arch_spec: ArchSpec) -> Self {
+        Self::with_motion_model(arch_spec, MotionModel::default())
+    }
+
+    /// Build a lane index, pricing lane durations with `motion_model`.
+    ///
     /// Iterates all zones and their buses, computes lane addresses,
     /// resolves endpoints, and lazily caches positions as endpoints
-    /// are discovered.
-    pub fn new(arch_spec: ArchSpec) -> Self {
+    /// are discovered. Lane durations are derived from the architecture's
+    /// transport paths via `motion_model`.
+    pub fn with_motion_model(arch_spec: ArchSpec, motion_model: MotionModel) -> Self {
         let mut lanes_by_triplet: HashMap<(MoveType, u32, u32, Direction), Vec<LaneAddr>> =
             HashMap::new();
         let mut lane_by_src: HashMap<(MoveType, u32, u32, Direction), HashMap<u64, LaneAddr>> =
@@ -213,7 +224,16 @@ impl LaneIndex {
         let mut fastest: Option<f64> = None;
         if let Some(paths) = &arch_spec.paths {
             for tp in paths {
-                let duration = compute_lane_duration_us(&tp.waypoints);
+                // A transport path needs at least two waypoints to describe
+                // motion. Skip degenerate/path-less entries so they carry no
+                // lane duration — `MotionModel` still charges pick/drop ramps
+                // for such a path, but the search treats a lane with no real
+                // trajectory as having no timing data (pre-`MotionModel`
+                // behaviour, preserved so lane durations are unchanged).
+                if tp.waypoints.len() <= 1 {
+                    continue;
+                }
+                let duration = motion_model.lane_duration_us(&tp.waypoints, 1.0);
                 if duration > 0.0 {
                     lane_durations.insert(tp.lane, duration);
                     fastest = Some(fastest.map_or(duration, |f: f64| f.min(duration)));
@@ -395,56 +415,11 @@ impl LaneIndex {
     }
 }
 
-// ── FLAIR timing model ────────────────────────────────────────────
-
-/// Constants from bloqade-flair's constant-jerk motion model.
-const FLAIR_MAX_RAMP_US: f64 = 0.2;
-const FLAIR_MAX_JERK_UM_PER_US3: f64 = 0.0004;
-const FLAIR_MAX_ACCEL_UM_PER_US2: f64 = 0.0015;
-
-/// Minimum duration (µs) for a constant-jerk move over `max_dist_um`.
-///
-/// Port of Python `MoveMetricCalculator._const_jerk_min_duration_us`.
-fn const_jerk_min_duration_us(max_dist_um: f64) -> f64 {
-    let max_dist_um = max_dist_um.abs();
-    if max_dist_um < 1e-8 {
-        return 0.0;
-    }
-
-    let t1 = FLAIR_MAX_ACCEL_UM_PER_US2 / FLAIR_MAX_JERK_UM_PER_US3;
-    let a = FLAIR_MAX_JERK_UM_PER_US3 * t1;
-    let b = 3.0 * FLAIR_MAX_JERK_UM_PER_US3 * t1 * t1;
-    let c = 2.0 * FLAIR_MAX_JERK_UM_PER_US3 * t1 * t1 * t1 - max_dist_um;
-
-    if c >= 0.0 {
-        let t1_jerk = (max_dist_um / (2.0 * FLAIR_MAX_JERK_UM_PER_US3)).cbrt();
-        return 4.0 * t1_jerk;
-    }
-
-    let discriminant = b * b - 4.0 * a * c;
-    let t2 = (-b + discriminant.sqrt()) / (2.0 * a);
-    4.0 * t1 + 2.0 * t2
-}
-
-/// Compute lane duration from waypoints: ramp + sum(segment durations) + ramp.
-fn compute_lane_duration_us(waypoints: &[[f64; 2]]) -> f64 {
-    if waypoints.len() <= 1 {
-        return 0.0;
-    }
-    // Assumes unit amplitude for search-time cost estimation;
-    // exact timing uses FLAIR bytecode values.
-    let ramp = 1.0 / FLAIR_MAX_RAMP_US;
-    let segment_sum: f64 = waypoints
-        .windows(2)
-        .map(|w| {
-            let dx = w[1][0] - w[0][0];
-            let dy = w[1][1] - w[0][1];
-            let dist = (dx * dx + dy * dy).sqrt();
-            const_jerk_min_duration_us(dist)
-        })
-        .sum();
-    ramp + segment_sum + ramp
-}
+// The FLAIR constant-jerk timing model now lives in
+// `bloqade_lanes_bytecode_core::arch::metrics::MotionModel`, the single source
+// of truth shared with the Python layer. Lane durations above are priced by
+// `MotionModel::lane_duration_us` at unit amplitude (the search-time
+// convention; exact timing uses FLAIR bytecode values).
 
 #[cfg(test)]
 mod tests {

--- a/python/bloqade/lanes/arch/metrics.py
+++ b/python/bloqade/lanes/arch/metrics.py
@@ -1,24 +1,30 @@
 import itertools
 import math
-from dataclasses import dataclass
-from typing import Any, ClassVar
+from dataclasses import dataclass, field
+from typing import Any
+
+from bloqade.lanes.bytecode import MotionModel
 
 
 @dataclass
 class MoveMetricCalculator:
     """Move-metric computation: lane durations, distances, and costs.
 
-    Owns timing constants extracted from bloqade-flair and provides
-    cached lane duration / cost lookups.  Lives in the ``layout``
-    package so that ``PathFinder`` and heuristics can consume it
-    without pulling in the heavy compilation imports of ``Metrics``.
+    The constant-jerk timing model (ramp/jerk/accel constants and the
+    move-duration formula) lives in the Rust
+    :class:`~bloqade.lanes.bytecode.MotionModel`, the single source of truth
+    shared with the move-search solver.  This calculator delegates all timing
+    to that object (defaulting to the FLAIR constants) and adds cached lane
+    duration / cost lookups on top.  Lives in the ``arch`` package so that
+    ``PathFinder`` and heuristics can consume it without pulling in the heavy
+    compilation imports of ``Metrics``.
+
+    Pass a non-default ``motion_model`` to price durations with a different
+    motion profile.
     """
 
     arch_spec: Any  # ArchSpec — use Any to avoid circular import
-
-    _FLAIR_MAX_RAMP_US: ClassVar[float] = 0.2
-    _FLAIR_MAX_JERK_UM_PER_US3: ClassVar[float] = 0.0004
-    _FLAIR_MAX_ACCEL_UM_PER_US2: ClassVar[float] = 0.0015
+    motion_model: MotionModel = field(default_factory=MotionModel)
 
     def __post_init__(self) -> None:
         self._lane_duration_cache_us: dict[tuple[Any, float], float] = {}
@@ -34,23 +40,6 @@ class MoveMetricCalculator:
             for (x0, y0), (x1, y1) in itertools.pairwise(path)
         )
 
-    def _const_jerk_min_duration_us(self, max_dist_um: float) -> float:
-        max_dist_um = abs(max_dist_um)
-        if max_dist_um < 1e-8:
-            return 0.0
-
-        t1 = self._FLAIR_MAX_ACCEL_UM_PER_US2 / self._FLAIR_MAX_JERK_UM_PER_US3
-        a = self._FLAIR_MAX_JERK_UM_PER_US3 * t1
-        b = 3 * self._FLAIR_MAX_JERK_UM_PER_US3 * t1**2
-        c = 2 * self._FLAIR_MAX_JERK_UM_PER_US3 * t1**3 - max_dist_um
-        if c >= 0:
-            t1_jerk = (max_dist_um / (2 * self._FLAIR_MAX_JERK_UM_PER_US3)) ** (1 / 3)
-            return 4 * t1_jerk
-
-        discriminant = b**2 - 4 * a * c
-        t2 = (-b + math.sqrt(discriminant)) / (2 * a)
-        return 4 * t1 + 2 * t2
-
     def get_lane_duration_us(
         self, lane_address: Any, *, amplitude_delta: float = 1.0
     ) -> float:
@@ -60,14 +49,8 @@ class MoveMetricCalculator:
         if (duration_us := self._lane_duration_cache_us.get(cache_key)) is not None:
             return duration_us
 
-        segment_distances = self.path_segment_distances_um(
-            self.arch_spec.get_path(lane_address)
-        )
-        ramp_time_us = normalized_amp / self._FLAIR_MAX_RAMP_US
-        duration_us = (
-            ramp_time_us
-            + sum(self._const_jerk_min_duration_us(dist) for dist in segment_distances)
-            + ramp_time_us
+        duration_us = self.motion_model.lane_duration_us(
+            self.arch_spec.get_path(lane_address), normalized_amp
         )
         self._lane_duration_cache_us[cache_key] = duration_us
         return duration_us

--- a/python/bloqade/lanes/bytecode/__init__.py
+++ b/python/bloqade/lanes/bytecode/__init__.py
@@ -17,6 +17,7 @@ Architecture building blocks:
     - :class:`Word`, :class:`Grid`
     - :class:`SiteBus`, :class:`WordBus`, :class:`ZoneBus`
     - :class:`Zone`, :class:`Mode`, :class:`TransportPath`
+    - :class:`MotionModel` -- configurable constant-jerk move-duration model
 
 Enums:
     - :class:`Direction` -- FORWARD / BACKWARD
@@ -56,6 +57,7 @@ from bloqade.lanes.bytecode._native import (
     LocationAddress as LocationAddress,
     LooseGoalCzPlacement as LooseGoalCzPlacement,
     Mode as Mode,
+    MotionModel as MotionModel,
     MoveSearch as MoveSearch,
     MovesetMetrics as MovesetMetrics,
     MoveType as MoveType,

--- a/python/bloqade/lanes/bytecode/_native.pyi
+++ b/python/bloqade/lanes/bytecode/_native.pyi
@@ -617,6 +617,9 @@ class MotionModel:
             Defaults to the FLAIR value. Must be > 0.
         max_jerk_um_per_us3 (float): Maximum jerk in µm/µs³. Must be > 0.
         max_accel_um_per_us2 (float): Maximum acceleration in µm/µs². Must be > 0.
+
+    Raises:
+        ValueError: If any constant is non-finite or not strictly positive.
     """
 
     def __init__(
@@ -646,7 +649,11 @@ class MotionModel:
         ...
 
     def const_jerk_min_duration_us(self, max_dist_um: float) -> float:
-        """Minimum duration (µs) of a constant-jerk move over ``max_dist_um``."""
+        """Minimum duration (µs) of a constant-jerk move over ``max_dist_um``.
+
+        The sign of ``max_dist_um`` is ignored; a distance below ~1e-8 µm is
+        treated as no move and returns ``0.0``.
+        """
         ...
 
     def lane_duration_us(
@@ -658,6 +665,7 @@ class MotionModel:
 
         The pick and drop ramps are always charged, so a path with fewer than
         two waypoints still costs ``2 * ramp`` rather than zero.
+        ``amplitude_delta`` scales the ramp time; its sign is ignored.
         """
         ...
 

--- a/python/bloqade/lanes/bytecode/_native.pyi
+++ b/python/bloqade/lanes/bytecode/_native.pyi
@@ -603,6 +603,68 @@ class TransportPath:
     def __hash__(self) -> int: ...
 
 @final
+class MotionModel:
+    """Constant-jerk motion/timing model for AOD move durations.
+
+    Owns the physical timing constants and the derived move-duration formula.
+    Defaults to the FLAIR constants extracted from bloqade-flair; construct
+    with explicit values to model a different motion profile. This is the
+    single source of truth shared with the Rust move-search solver.
+
+    Args:
+        max_ramp_us (float): Maximum amplitude ramp rate (amplitude units per
+            µs); the pick/drop ramp time is ``amplitude / max_ramp_us``.
+            Defaults to the FLAIR value. Must be > 0.
+        max_jerk_um_per_us3 (float): Maximum jerk in µm/µs³. Must be > 0.
+        max_accel_um_per_us2 (float): Maximum acceleration in µm/µs². Must be > 0.
+    """
+
+    def __init__(
+        self,
+        max_ramp_us: float = ...,
+        max_jerk_um_per_us3: float = ...,
+        max_accel_um_per_us2: float = ...,
+    ) -> None: ...
+    @staticmethod
+    def flair() -> MotionModel:
+        """The FLAIR constant-jerk motion model (the default constants)."""
+        ...
+
+    @property
+    def max_ramp_us(self) -> float:
+        """Maximum amplitude ramp rate (amplitude units per µs)."""
+        ...
+
+    @property
+    def max_jerk_um_per_us3(self) -> float:
+        """Maximum jerk in µm/µs³."""
+        ...
+
+    @property
+    def max_accel_um_per_us2(self) -> float:
+        """Maximum acceleration in µm/µs²."""
+        ...
+
+    def const_jerk_min_duration_us(self, max_dist_um: float) -> float:
+        """Minimum duration (µs) of a constant-jerk move over ``max_dist_um``."""
+        ...
+
+    def lane_duration_us(
+        self,
+        waypoints: list[tuple[float, float]],
+        amplitude_delta: float = 1.0,
+    ) -> float:
+        """Lane duration (µs) over a waypoint path: ramp + Σ segments + ramp.
+
+        The pick and drop ramps are always charged, so a path with fewer than
+        two waypoints still costs ``2 * ramp`` rather than zero.
+        """
+        ...
+
+    def __repr__(self) -> str: ...
+    def __eq__(self, other: object) -> bool: ...
+
+@final
 class ArchSpec:
     """Architecture specification for a quantum device.
 

--- a/python/bloqade/lanes/metrics.py
+++ b/python/bloqade/lanes/metrics.py
@@ -218,10 +218,11 @@ class Metrics:
                 path = self.arch_spec.get_path(lane)
                 segment_distances_um = list(mc.path_segment_distances_um(path))
                 segment_durations_us = [
-                    mc._const_jerk_min_duration_us(d) for d in segment_distances_um
+                    mc.motion_model.const_jerk_min_duration_us(d)
+                    for d in segment_distances_um
                 ]
                 normalized_amp = abs(float(flair_amplitude_delta))
-                ramp_time_us = normalized_amp / mc._FLAIR_MAX_RAMP_US
+                ramp_time_us = normalized_amp / mc.motion_model.max_ramp_us
                 lane_duration_us = (
                     ramp_time_us + sum(segment_durations_us) + ramp_time_us
                 )

--- a/python/tests/layout/test_metrics.py
+++ b/python/tests/layout/test_metrics.py
@@ -4,11 +4,38 @@ import pytest
 
 from bloqade.lanes.arch.gemini import logical
 from bloqade.lanes.arch.metrics import MoveMetricCalculator
+from bloqade.lanes.bytecode import MotionModel
 
 
 def _build_move_calc() -> MoveMetricCalculator:
     arch_spec = logical.get_arch_spec()
     return MoveMetricCalculator(arch_spec=arch_spec)
+
+
+def test_motion_model_pins_flair_defaults_and_known_durations():
+    """Guard the shared FLAIR model reachable from Python.
+
+    Pins the default constants and known durations so an accidental edit to
+    the Rust constants/formula — or to the ``bytecode.MotionModel`` binding
+    wiring — is caught by the Python suite, not only the Rust tests.
+    """
+    model = MotionModel()
+    assert (
+        model.max_ramp_us,
+        model.max_jerk_um_per_us3,
+        model.max_accel_um_per_us2,
+    ) == (0.2, 0.0004, 0.0015)
+    assert MotionModel.flair() == model
+
+    # Known constant-jerk duration for a 5 µm move (quadratic-branch value).
+    assert model.const_jerk_min_duration_us(5.0) == pytest.approx(
+        119.280930201974, rel=1e-12
+    )
+    # Lane duration = pick ramp + one 5 µm segment + drop ramp.
+    ramp_us = 1.0 / 0.2
+    assert model.lane_duration_us([(0.0, 0.0), (3.0, 4.0)], 1.0) == pytest.approx(
+        ramp_us + model.const_jerk_min_duration_us(5.0) + ramp_us, rel=1e-12
+    )
 
 
 def test_metrics_get_lane_duration_us_positive():

--- a/python/tests/test_metrics_motion.py
+++ b/python/tests/test_metrics_motion.py
@@ -189,3 +189,71 @@ def test_per_cz_motion_rejects_inexecutable_move():
     with pytest.raises(MoveValidationError) as excinfo:
         metrics.analyze_per_cz_motion(main)
     assert any(isinstance(e, DestinationOccupiedError) for e in excinfo.value.errors)
+
+
+def test_analyze_move_time_prices_events_through_motion_model():
+    """Cover the move-time reporting path.
+
+    ``analyze_move_time_from_move_ir`` walks each ``move`` event and prices its
+    lanes through the shared ``MotionModel`` (pick/drop ramps + per-segment
+    constant-jerk durations). This exercises that per-lane loop end to end.
+    """
+    arch_spec = ArchSpec(RustArchSpec.from_json_validated(CHAIN_ARCH_JSON))
+
+    @kernel
+    def main():
+        state0 = move.load()
+        state1 = move.fill(
+            state0,
+            location_addresses=(
+                move.LocationAddress(0, 0),
+                move.LocationAddress(1, 0),
+            ),
+        )
+        state2 = move.logical_initialize(
+            state1,
+            thetas=(0.0, 0.0),
+            phis=(0.0, 0.0),
+            lams=(0.0, 0.0),
+            location_addresses=(
+                move.LocationAddress(0, 0),
+                move.LocationAddress(1, 0),
+            ),
+        )
+        state3 = move.move(
+            state2,
+            lanes=(WordLaneAddress(0, 0, 0), WordLaneAddress(1, 0, 0)),
+        )
+        state4 = move.cz(state3, zone_address=ZoneAddress(0))
+        future = move.end_measure(state4, zone_addresses=(move.ZoneAddress(0),))
+        return move.get_future_result(
+            future,
+            zone_address=move.ZoneAddress(0),
+            location_address=move.LocationAddress(1, 0),
+        )
+
+    metrics = Metrics(arch_spec=arch_spec)
+    result = metrics.analyze_move_time_from_move_ir(main)
+
+    assert result.timing_model == "flair_extracted_const_jerk"
+    assert len(result.events) == 1
+    event = result.events[0]
+    assert event.lane_count == 2
+
+    motion_model = metrics.move_calc.motion_model
+    # Pick/drop ramps are geometry-independent and come from the shared model.
+    expected_ramp_us = 1.0 / motion_model.max_ramp_us
+    assert event.pick_time_us == pytest.approx(expected_ramp_us)
+    assert event.drop_time_us == pytest.approx(expected_ramp_us)
+    # Per-segment durations are priced through the shared MotionModel.
+    assert event.segment_distances_um
+    for dist, dur in zip(event.segment_distances_um, event.segment_durations_us):
+        assert dur == pytest.approx(motion_model.const_jerk_min_duration_us(dist))
+    # Lane duration is ramp + Σ segment durations + ramp; the event duration is
+    # the max over the event's lanes and the total is the sum over events.
+    assert max(event.lane_durations_us) == pytest.approx(
+        event.pick_time_us + sum(event.segment_durations_us) + event.drop_time_us
+    )
+    assert event.event_duration_us == pytest.approx(max(event.lane_durations_us))
+    assert event.event_duration_us > 0.0
+    assert result.total_move_time_us == pytest.approx(event.event_duration_us)


### PR DESCRIPTION
## What

The FLAIR constant-jerk move-duration model — the three physical constants plus the min-duration solver and the `ramp + Σsegments + ramp` assembly — was hand-transcribed into **three** places with no shared definition and no test that the copies agreed:

- `MoveMetricCalculator` (`python/bloqade/lanes/arch/metrics.py`) — canonical Python copy
- `Metrics.analyze_move_time_from_move_ir` (`python/bloqade/lanes/metrics.py`) — an inline re-implementation of the assembly
- `lane_index.rs` in the search crate — a hand-maintained Rust port

Because the model drives routing on **both** sides (the entropy driver's time-blended heuristic defaults to `w_t = 0.95`; PathFinder's default edge weight is `get_lane_duration_us`), a silent drift between the copies would make the Python heuristics and the Rust solver optimize against different cost landscapes.

This PR consolidates the model into a single configurable source of truth.

## Changes

**1. `MotionModel` in `bloqade-lanes-bytecode-core`** (the arch crate, depended on by both the search crate and the PyO3 bindings)
- The three FLAIR constants are now struct fields, not hardcoded `const`s. `MotionModel::new` validates them; `default()` / `flair()` reproduce the FLAIR values exactly.
- Owns `const_jerk_min_duration_us` and `lane_duration_us`.

**2. Rust search wired to it**
- `LaneIndex::new` prices durations via `MotionModel::default()`; new `LaneIndex::with_motion_model` makes the search side configurable. The private port in `lane_index.rs` is removed.

**3. Python binding + delegation**
- Exposed as `bloqade.lanes.bytecode.MotionModel` (`metrics_python.rs`, registered in `lib.rs`, re-exported, stubbed in `_native.pyi`).
- `MoveMetricCalculator` holds a `motion_model` field (default FLAIR) and delegates — the previously hardcoded `_FLAIR_MAX_*` Python constants now come from Rust. Public method signatures are unchanged, so PathFinder / target generator / placement / `Metrics` need no edits.

## Review fixes folded in

- `MotionModel::new` rejects a non-positive `max_accel_um_per_us2` (previously only checked finiteness, so `accel <= 0` yielded NaN / negative durations from a validated constructor).
- `lane_duration_us` always charges the pick/drop ramps — a path-less move costs `2·ramp` instead of collapsing to a free `0.0`; `LaneIndex` explicitly skips degenerate (< 2 waypoint) transport paths so the search's lane-duration map is byte-identical.
- Added a Python golden-value test pinning the FLAIR defaults and known durations through the binding.

## Verification

- **Rust:** `MotionModel` unit tests + core/search/cli tests pass; `cargo fmt --check` clean; clippy `-D warnings` clean on core+cli (CI gate) and search.
- **Python:** full suite passes; black / isort / ruff clean; pyright 0 errors.
- **Benchmarks:** logical and physical both report **no differences** on every deterministic metric.

## Reviewer notes

- **Runtime-only config** — the motion model is *not* serialized into the ArchSpec JSON (no schema / bundled-spec / C-header churn); it defaults to FLAIR and is overridable in code.
- **Only numeric change** is Python-side: the shared cube root is now Rust's `.cbrt()` instead of Python's `x ** (1/3)`, a ≤ 1 ULP shift (small-distance jerk branch only) that leaves routing unchanged — confirmed by the benchmark compare.
- Non-breaking; should get a `status: backport` label per AGENT.md if it's wanted on `release-0-11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)