### PR TITLE
feat: first pass at impl result postproc

### DIFF
--- a/python/bloqade/gemini/device/logical/result.py
+++ b/python/bloqade/gemini/device/logical/result.py
@@ -62,7 +62,8 @@ class GeminiLogicalResult(Result, Generic[RetType]):
             kernel_json = program["content"]
             kernel_mt = logical.kernel.decode_json(kernel_json)  # type: ignore[attr-defined]
             slm_to_raw, postprocessing_function = get_slm_mapping_postprocessing(
-                kernel_mt
+                kernel_mt,
+                invert_bits=True,
             )
             # NOTE: what if err in postproc fn generation/errors here??
             postprocessing_functions[idx] = (slm_to_raw, postprocessing_function)

--- a/python/bloqade/gemini/device/logical/result.py
+++ b/python/bloqade/gemini/device/logical/result.py
@@ -1,18 +1,26 @@
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import TypeVar
+from functools import cached_property
+from typing import Generic, TypeVar, overload
 
 import numpy as np
 from bloqade.core.device import Result
 
 from bloqade.gemini import logical
 from bloqade.gemini.post_processing import generate_post_processing
+from bloqade.lanes.analysis.atom import PostProcessing
+
+from .utils import (
+    aligned_detected_and_sorted_shots_for_subtasks,
+    get_slm_mapping_postprocessing,
+    shot_results_for_subtasks,
+)
 
 RetType = TypeVar("RetType")
 
 
 @dataclass(kw_only=True)
-class GeminiLogicalResult(Result):
+class GeminiLogicalResult(Result, Generic[RetType]):
     """Result view over stored Gemini logical shots.
 
     Merge-oriented methods assume each selected task ID has the same subtask
@@ -26,7 +34,13 @@ class GeminiLogicalResult(Result):
             subtask scope. Defaults to the DETECTED frame type.
     """
 
-    def postprocessing_functions(self) -> dict[int, Callable | None]:
+    @cached_property
+    def _slm_postprocessing_functions(
+        self,
+    ) -> dict[
+        int,
+        tuple[Callable[[np.ndarray], list[list[bool]]], PostProcessing[RetType]],
+    ]:
         """Decode stored programs and build post-processing functions.
 
         Program records are scoped by `shot_filter.task_ids`. When multiple
@@ -46,11 +60,64 @@ class GeminiLogicalResult(Result):
                 # NOTE: merging across task_ids means we assume all of them identical
                 continue
             kernel_json = program["content"]
-            kernel_mt = logical.kernel.decode_json(kernel_json)
-            postprocessing_function = generate_post_processing(kernel_mt)
-            postprocessing_functions[idx] = postprocessing_function
+            kernel_mt = logical.kernel.decode_json(kernel_json)  # type: ignore[attr-defined]
+            slm_to_raw, postprocessing_function = get_slm_mapping_postprocessing(
+                kernel_mt
+            )
+            # NOTE: what if err in postproc fn generation/errors here??
+            postprocessing_functions[idx] = (slm_to_raw, postprocessing_function)
 
         return postprocessing_functions
+
+    def postprocessing_functions(self) -> dict[int, Callable | None]:
+        """Build legacy compact-shot postprocessors from stored programs.
+
+        This method preserves the original ``GeminiLogicalResult`` API for
+        result stores whose bitstrings are already in compact physical
+        measurement order. Raw 160-site SLM frames use
+        ``_slm_postprocessing_functions`` instead.
+        """
+        task_ids = self.shot_filter.task_ids
+        programs = self.storage.get_programs(task_ids=task_ids)
+        postprocessing_functions = {}
+        for program in programs:
+            idx = program["program_index"]
+            if idx in postprocessing_functions:
+                continue
+            kernel_mt = logical.kernel.decode_json(program["content"])  # type: ignore[attr-defined]
+            postprocessing_functions[idx] = generate_post_processing(kernel_mt)
+
+        return postprocessing_functions
+
+    @cached_property
+    def measurements(self) -> Sequence[Sequence[Sequence[bool]]]:
+        ret_vals: list[list[list[bool]]] = []
+        # TODO: OK to set verify=True?
+        subtasks = self.subtasks(verify=True)
+        postprocessing_functions = self._slm_postprocessing_functions
+        shot_results = shot_results_for_subtasks(
+            self.storage, self.shot_filter, subtasks, frame_type="DETECTED"
+        )
+
+        for shot_result, subtask in zip(shot_results, subtasks):
+            func = postprocessing_functions[subtask["program_index"]][0]
+            ret_vals.append(func(shot_result))
+
+        return ret_vals
+
+    @overload
+    def logical_results(
+        self,
+        verify: bool = True,
+        postprocessing_functions: None = None,
+    ) -> list[list[RetType]]: ...
+
+    @overload
+    def logical_results(
+        self,
+        verify: bool,
+        postprocessing_functions: dict[int, Callable[[np.ndarray], RetType] | None],
+    ) -> list[RetType | np.ndarray]: ...
 
     def logical_results(
         self,
@@ -58,37 +125,115 @@ class GeminiLogicalResult(Result):
         postprocessing_functions: (
             dict[int, Callable[[np.ndarray], RetType] | None] | None
         ) = None,
-    ) -> list[RetType | np.ndarray]:
-        """Return logical results grouped by merged subtask.
+    ) -> list[list[RetType]] | list[RetType | np.ndarray]:
+        """Return logical kernel results grouped by merged subtask.
+
+        When no postprocessor override is supplied, raw 160-site DETECTED
+        frames are mapped into compact physical-measurement order and evaluated
+        with the Atom postprocessor derived from each program. An explicitly
+        supplied postprocessor retains the legacy behavior: it receives the
+        raw DETECTED-frame array for its subtask.
 
         Args:
-            verify (bool): Whether to validate that selected task IDs can be
-                merged before reading shots. Defaults to True.
-            postprocessing_functions (dict[int, Callable | None] | None):
-                Optional mapping from program index to post-processing function.
-                When None, functions are built from stored programs. Defaults
-                to None.
-
-        Returns:
-            list[RetType]: Post-processed results for each merged subtask.
-                If a post-processing function is None, the physical shot array is
-                returned for that subtask.
-
-        Raises:
-            ValueError: If `verify` is True and selected task IDs cannot be
-                merged.
+            verify: Validate that selected task IDs can be merged.
+            postprocessing_functions: Optional legacy mapping from program
+                index to a function accepting that subtask's raw shot array.
         """
-        ret_vals = []
         subtasks = self.subtasks(verify=verify)
-        if postprocessing_functions is None:
-            postprocessing_functions = self.postprocessing_functions()
-        shot_results = self._shot_results_for_subtasks(subtasks)
+        shot_results = shot_results_for_subtasks(
+            self.storage,
+            self.shot_filter,
+            subtasks,
+            frame_type="DETECTED",
+        )
+
+        if postprocessing_functions is not None:
+            legacy_results: list[RetType | np.ndarray] = []
+            for shot_result, subtask in zip(shot_results, subtasks):
+                func = postprocessing_functions[subtask["program_index"]]
+                legacy_results.append(
+                    shot_result if func is None else func(shot_result)
+                )
+            return legacy_results
+
+        is_raw_slm_frame = [
+            shot_result.ndim == 2 and shot_result.shape[1] == 160
+            for shot_result in shot_results
+        ]
+        if any(is_raw_slm_frame) and not all(is_raw_slm_frame):
+            raise ValueError(
+                "Cannot combine raw 160-site SLM frames with compact physical "
+                "measurement frames in one result view."
+            )
+
+        if all(is_raw_slm_frame):
+            generated_postprocessors = self._slm_postprocessing_functions
+            return_values: list[list[RetType]] = []
+            for shot_result, subtask in zip(shot_results, subtasks):
+                slm_to_measurements, atom_postprocessor = generated_postprocessors[
+                    subtask["program_index"]
+                ]
+                return_values.append(
+                    list(
+                        atom_postprocessor.emit_return(slm_to_measurements(shot_result))
+                    )
+                )
+            return return_values
+
+        legacy_postprocessors = self.postprocessing_functions()
+        legacy_results: list[RetType | np.ndarray] = []
+        for shot_result, subtask in zip(shot_results, subtasks):
+            func = legacy_postprocessors[subtask["program_index"]]
+            legacy_results.append(shot_result if func is None else func(shot_result))
+        return legacy_results
+
+    @cached_property
+    def return_values(self) -> Sequence[Sequence[RetType]]:
+        return [
+            list(
+                self._slm_postprocessing_functions[subtask["program_index"]][
+                    1
+                ].emit_return(measurements)
+            )
+            for measurements, subtask in zip(self.measurements, self.subtasks())
+        ]
+
+    @cached_property
+    def detectors(self) -> Sequence[Sequence[Sequence[bool]]]:
+        return [
+            list(
+                self._slm_postprocessing_functions[subtask["program_index"]][
+                    1
+                ].emit_detectors(measurements)
+            )
+            for measurements, subtask in zip(self.measurements, self.subtasks())
+        ]
+
+    @cached_property
+    def observables(self) -> Sequence[Sequence[Sequence[bool]]]:
+        return [
+            list(
+                self._slm_postprocessing_functions[subtask["program_index"]][
+                    1
+                ].emit_observables(measurements)
+            )
+            for measurements, subtask in zip(self.measurements, self.subtasks())
+        ]
+
+    @cached_property
+    def filling_at_start(self) -> Sequence[Sequence[Sequence[bool]]]:
+        ret_vals: list[list[list[bool]]] = []
+        subtasks = self.subtasks(verify=True)
+        postprocessing_functions = self._slm_postprocessing_functions
+        _, shot_results = aligned_detected_and_sorted_shots_for_subtasks(
+            self.storage,
+            self.shot_filter,
+            subtasks,
+        )
 
         for shot_result, subtask in zip(shot_results, subtasks):
-            func = postprocessing_functions[subtask["program_index"]]
-            if func is None:
-                ret_vals.append(shot_result)
-            else:
-                ret_vals.append(func(shot_result))
+            func = postprocessing_functions[subtask["program_index"]][0]
+            ret_vals.append(func(shot_result))
 
+        # TOOD: can do validation later on sorted/detected frames
         return ret_vals

--- a/python/bloqade/gemini/device/logical/result.py
+++ b/python/bloqade/gemini/device/logical/result.py
@@ -34,23 +34,25 @@ class GeminiLogicalResult(Result, Generic[RetType]):
             subtask scope. Defaults to the DETECTED frame type.
     """
 
-    @cached_property
     def _slm_postprocessing_functions(
         self,
+        *,
+        invert_bits: bool = True,
     ) -> dict[
         int,
         tuple[Callable[[np.ndarray], list[list[bool]]], PostProcessing[RetType]],
     ]:
-        """Decode stored programs and build post-processing functions.
+        """Decode stored programs and build SLM-frame postprocessors.
 
-        Program records are scoped by `shot_filter.task_ids`. When multiple
-        task IDs share a `program_index`, the first stored program at that index
-        is used.
-
-        Returns:
-            dict[int, Callable | None]: Mapping from program index to its
-                generated post-processing function.
+        Results are cached independently for each bit convention. ``True`` is
+        the default because QLAM DETECTED frames encode bright/atom-present as
+        ``True``, opposite to the simulator/Atom postprocessing convention.
         """
+        cache = self._slm_postprocessing_functions_cache
+        cached = cache.get(invert_bits)
+        if cached is not None:
+            return cached
+
         task_ids = self.shot_filter.task_ids
         programs = self.storage.get_programs(task_ids=task_ids)
         postprocessing_functions = {}
@@ -63,12 +65,28 @@ class GeminiLogicalResult(Result, Generic[RetType]):
             kernel_mt = logical.kernel.decode_json(kernel_json)  # type: ignore[attr-defined]
             slm_to_raw, postprocessing_function = get_slm_mapping_postprocessing(
                 kernel_mt,
-                invert_bits=True,
+                invert_bits=invert_bits,
             )
             # NOTE: what if err in postproc fn generation/errors here??
             postprocessing_functions[idx] = (slm_to_raw, postprocessing_function)
 
+        cache[invert_bits] = postprocessing_functions
         return postprocessing_functions
+
+    @cached_property
+    def _slm_postprocessing_functions_cache(
+        self,
+    ) -> dict[
+        bool,
+        dict[
+            int,
+            tuple[
+                Callable[[np.ndarray], list[list[bool]]],
+                PostProcessing[RetType],
+            ],
+        ],
+    ]:
+        return {}
 
     def postprocessing_functions(self) -> dict[int, Callable | None]:
         """Build legacy compact-shot postprocessors from stored programs.
@@ -95,7 +113,7 @@ class GeminiLogicalResult(Result, Generic[RetType]):
         ret_vals: list[list[list[bool]]] = []
         # TODO: OK to set verify=True?
         subtasks = self.subtasks(verify=True)
-        postprocessing_functions = self._slm_postprocessing_functions
+        postprocessing_functions = self._slm_postprocessing_functions()
         shot_results = shot_results_for_subtasks(
             self.storage, self.shot_filter, subtasks, frame_type="DETECTED"
         )
@@ -168,7 +186,7 @@ class GeminiLogicalResult(Result, Generic[RetType]):
             )
 
         if all(is_raw_slm_frame):
-            generated_postprocessors = self._slm_postprocessing_functions
+            generated_postprocessors = self._slm_postprocessing_functions()
             return_values: list[list[RetType]] = []
             for shot_result, subtask in zip(shot_results, subtasks):
                 slm_to_measurements, atom_postprocessor = generated_postprocessors[
@@ -192,7 +210,7 @@ class GeminiLogicalResult(Result, Generic[RetType]):
     def return_values(self) -> Sequence[Sequence[RetType]]:
         return [
             list(
-                self._slm_postprocessing_functions[subtask["program_index"]][
+                self._slm_postprocessing_functions()[subtask["program_index"]][
                     1
                 ].emit_return(measurements)
             )
@@ -203,7 +221,7 @@ class GeminiLogicalResult(Result, Generic[RetType]):
     def detectors(self) -> Sequence[Sequence[Sequence[bool]]]:
         return [
             list(
-                self._slm_postprocessing_functions[subtask["program_index"]][
+                self._slm_postprocessing_functions()[subtask["program_index"]][
                     1
                 ].emit_detectors(measurements)
             )
@@ -214,7 +232,7 @@ class GeminiLogicalResult(Result, Generic[RetType]):
     def observables(self) -> Sequence[Sequence[Sequence[bool]]]:
         return [
             list(
-                self._slm_postprocessing_functions[subtask["program_index"]][
+                self._slm_postprocessing_functions()[subtask["program_index"]][
                     1
                 ].emit_observables(measurements)
             )
@@ -225,7 +243,7 @@ class GeminiLogicalResult(Result, Generic[RetType]):
     def filling_at_start(self) -> Sequence[Sequence[Sequence[bool]]]:
         ret_vals: list[list[list[bool]]] = []
         subtasks = self.subtasks(verify=True)
-        postprocessing_functions = self._slm_postprocessing_functions
+        postprocessing_functions = self._slm_postprocessing_functions(invert_bits=False)
         _, shot_results = aligned_detected_and_sorted_shots_for_subtasks(
             self.storage,
             self.shot_filter,

--- a/python/bloqade/gemini/device/logical/utils.py
+++ b/python/bloqade/gemini/device/logical/utils.py
@@ -1,0 +1,214 @@
+from collections.abc import Callable, Sequence
+from dataclasses import replace
+from typing import Any, TypeVar
+
+import numpy as np
+from kirin import ir
+
+from bloqade.lanes.analysis import atom
+from bloqade.lanes.arch.gemini import physical
+from bloqade.lanes.bytecode.encoding import ZoneAddress
+from bloqade.lanes.transform import LogicalPipeline
+
+RetType = TypeVar("RetType")
+
+
+def _shot_identity(shot) -> tuple[str, int, int, int]:
+    """Return the storage identity shared by a shot's frame records."""
+    return (
+        shot.task_id,
+        shot.subtask_index,
+        shot.subtask_shot_index,
+        shot.shot_index,
+    )
+
+
+def _shots_for_subtask_frame(storage, shot_filter, subtask_index, frame_type):
+    subtask_filter = replace(
+        shot_filter,
+        subtask_indices=(subtask_index,),
+        frame_type=frame_type,
+    )
+    return sorted(
+        storage.get_shots(shot_filter=subtask_filter),
+        key=_shot_identity,
+    )
+
+
+def shot_results_for_subtasks(
+    storage,
+    shot_filter,
+    subtasks: Sequence[dict],
+    *,
+    frame_type: str | None = None,
+) -> list[np.ndarray]:
+    """Return selected shot bitstrings grouped and sorted by subtask.
+
+    ``StorageBackend.get_shots`` does not promise an ordering.  This helper
+    preserves the caller-provided subtask order and sorts each subtask by its
+    full storage identity. ``frame_type`` optionally overrides the frame type
+    already present in ``shot_filter``.
+    """
+    results = []
+    for subtask in subtasks:
+        selected_frame = shot_filter.frame_type if frame_type is None else frame_type
+        rows = _shots_for_subtask_frame(
+            storage,
+            shot_filter,
+            subtask["subtask_index"],
+            selected_frame,
+        )
+        results.append(np.asarray([row.bitstring for row in rows], dtype=bool))
+
+    return results
+
+
+def aligned_detected_and_sorted_shots_for_subtasks(
+    storage,
+    shot_filter,
+    subtasks: Sequence[dict],
+) -> tuple[list[np.ndarray], list[np.ndarray]]:
+    """Return DETECTED and SORTED frames aligned shot-for-shot per subtask.
+
+    Each frame is ordered by the complete storage identity. A mismatch means
+    that the two frames cannot safely be compared by array position.
+    """
+    detected_results = []
+    sorted_results = []
+
+    for subtask in subtasks:
+        subtask_index = subtask["subtask_index"]
+        detected_rows = _shots_for_subtask_frame(
+            storage, shot_filter, subtask_index, "DETECTED"
+        )
+        sorted_rows = _shots_for_subtask_frame(
+            storage, shot_filter, subtask_index, "SORTED"
+        )
+
+        detected_keys = tuple(map(_shot_identity, detected_rows))
+        sorted_keys = tuple(map(_shot_identity, sorted_rows))
+        if detected_keys != sorted_keys:
+            detected_only = sorted(set(detected_keys) - set(sorted_keys))
+            sorted_only = sorted(set(sorted_keys) - set(detected_keys))
+            raise ValueError(
+                "DETECTED and SORTED frames are not aligned for "
+                f"subtask_index={subtask_index}: "
+                f"missing SORTED={detected_only}, missing DETECTED={sorted_only}."
+            )
+
+        detected_results.append(
+            np.asarray([row.bitstring for row in detected_rows], dtype=bool)
+        )
+        sorted_results.append(
+            np.asarray([row.bitstring for row in sorted_rows], dtype=bool)
+        )
+
+    return detected_results, sorted_results
+
+
+def get_slm_mapping_postprocessing(
+    sim_kernel: ir.Method[..., RetType], *, invert_bits=False
+) -> tuple[Callable[[np.ndarray], Any], atom.PostProcessing[RetType]]:
+    """Create a logical_results-compatible postprocessor for Zone-0 shots."""
+
+    arch_spec = physical.get_arch_spec()
+    physical_move_kernel = LogicalPipeline(transversal_rewrite=True).emit(sim_kernel)
+    zone0 = ZoneAddress(0)
+
+    interpreter = atom.AtomInterpreter(
+        physical_move_kernel.dialects,
+        arch_spec=arch_spec,
+    )
+    frame, _ = interpreter.run(physical_move_kernel)
+
+    # Each MeasureResult identifies both:
+    # - its compact measurement-record column expected by post-processing
+    # - the physical SLM location at which it was measured.
+    records_by_id = {}
+
+    for value in frame.entries.values():
+        if not isinstance(value, atom.MeasureResult):
+            continue
+
+        previous = records_by_id.get(value.measurement_id)
+        if previous is not None and (
+            previous.location_address != value.location_address
+            or previous.qubit_id != value.qubit_id
+        ):
+            raise ValueError(
+                f"Measurement record {value.measurement_id} maps inconsistently: "
+                f"{previous} versus {value}."
+            )
+
+        records_by_id[value.measurement_id] = value
+
+    if not records_by_id:
+        raise ValueError("No physical measurement records were found.")
+
+    ids = sorted(records_by_id)
+    if ids != list(range(len(ids))):
+        raise ValueError(f"Unexpected measurement-record IDs: {ids}")
+
+    records = [records_by_id[measurement_id] for measurement_id in ids]
+
+    if not records:
+        raise ValueError("No physical measurement records were found.")
+
+    ids = [record.measurement_id for record in records]
+    if ids != list(range(len(records))):
+        raise ValueError(f"Unexpected measurement-record IDs: {ids}")
+
+    # `get_zone_index()` is word-major; QLAM-style SLM frames are conventionally
+    # arranged bottom-to-top in rows, left-to-right within each row. Translate
+    # through physical coordinates instead of treating a Zone-0 index as an SLM
+    # bitstring column.
+    zone0_locations = list(arch_spec.yield_zone_locations(zone0))
+    positions_by_location = {
+        location: arch_spec.get_position(location) for location in zone0_locations
+    }
+    x_coordinates = sorted({position[0] for position in positions_by_location.values()})
+    y_coordinates = sorted({position[1] for position in positions_by_location.values()})
+
+    if len(x_coordinates) * len(y_coordinates) != len(zone0_locations):
+        raise ValueError(
+            "Zone 0 is not a rectangular SLM grid; cannot derive a row-major "
+            "SLM bitstring mapping."
+        )
+
+    x_index = {coordinate: index for index, coordinate in enumerate(x_coordinates)}
+    y_index = {coordinate: index for index, coordinate in enumerate(y_coordinates)}
+    raw_slm_index_by_location = {
+        location: y_index[y] * len(x_coordinates) + x_index[x]
+        for location, (x, y) in positions_by_location.items()
+    }
+
+    mapping = np.asarray(
+        [raw_slm_index_by_location[record.location_address] for record in records],
+        dtype=int,
+    )
+    print(f"row-major SLM mapping: {mapping}")
+    expected_zone0_sites = len(zone0_locations)
+
+    post_processing = interpreter.get_post_processing(physical_move_kernel)
+
+    def postprocess(zone0_shots):
+        zone0_shots = np.asarray(zone0_shots, dtype=bool)
+
+        if zone0_shots.ndim != 2:
+            raise ValueError(f"Expected a 2-D array, got {zone0_shots.shape}.")
+        if zone0_shots.shape[1] != expected_zone0_sites:
+            raise ValueError(
+                f"Expected {expected_zone0_sites} Zone-0 columns, "
+                f"got {zone0_shots.shape[1]}."
+            )
+
+        measurement_shots = zone0_shots[:, mapping]
+
+        # Enable only if the stored QLAM bit convention is opposite to the
+        # simulator/post-processing convention.
+        if invert_bits:
+            measurement_shots = ~measurement_shots
+
+        return measurement_shots.tolist()
+
+    return postprocess, post_processing

--- a/python/tests/gemini/device/test_result.py
+++ b/python/tests/gemini/device/test_result.py
@@ -19,6 +19,9 @@ from qlam_core.plugins.tasks.api.tasks_models import (
 from bloqade import squin
 from bloqade.gemini import GeminiLogicalResult, logical
 from bloqade.gemini.device.logical import result as result_module
+from bloqade.gemini.device.logical.utils import (
+    aligned_detected_and_sorted_shots_for_subtasks,
+)
 
 CREATION_TIME = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
 
@@ -369,6 +372,69 @@ def test_shot_results_default_filter_excludes_non_detected_frames(storage):
     np.testing.assert_array_equal(shots_per_subtask[0], np.array([[True, False]]))
 
 
+def test_aligned_detected_and_sorted_shots_use_full_shot_identity(storage):
+    add_task_definition(
+        storage,
+        "task-1",
+        make_task_definition(subtasks=[Subtask(program_index=0, num_shots=2)]),
+    )
+    storage.add_shots(
+        [
+            make_shot(
+                shot_index=2,
+                subtask_shot_index=1,
+                frame_type="SORTED",
+                bitstring=(False, True),
+            ),
+            make_shot(
+                shot_index=1,
+                subtask_shot_index=0,
+                frame_type="DETECTED",
+                bitstring=(True, False),
+            ),
+            make_shot(
+                shot_index=2,
+                subtask_shot_index=1,
+                frame_type="DETECTED",
+                bitstring=(True, True),
+            ),
+            make_shot(
+                shot_index=1,
+                subtask_shot_index=0,
+                frame_type="SORTED",
+                bitstring=(False, False),
+            ),
+        ]
+    )
+
+    detected, sorted_ = aligned_detected_and_sorted_shots_for_subtasks(
+        storage,
+        ShotFilter(task_ids=("task-1",)),
+        GeminiLogicalResult(storage=storage).subtasks(),
+    )
+
+    np.testing.assert_array_equal(detected[0], np.array([[True, False], [True, True]]))
+    np.testing.assert_array_equal(sorted_[0], np.array([[False, False], [False, True]]))
+
+
+def test_aligned_detected_and_sorted_shots_reject_missing_frame(storage):
+    add_task_definition(
+        storage,
+        "task-1",
+        make_task_definition(subtasks=[Subtask(program_index=0, num_shots=1)]),
+    )
+    storage.add_shots(
+        [make_shot(shot_index=0, frame_type="DETECTED", bitstring=(True, False))]
+    )
+
+    with pytest.raises(ValueError, match="not aligned"):
+        aligned_detected_and_sorted_shots_for_subtasks(
+            storage,
+            ShotFilter(task_ids=("task-1",)),
+            GeminiLogicalResult(storage=storage).subtasks(),
+        )
+
+
 def test_shot_results_empty_when_no_subtasks(storage):
     res = GeminiLogicalResult(storage=storage)
     assert res.shot_results() == []
@@ -467,6 +533,54 @@ def test_logical_results_rebuilds_const_hints_after_serialization(storage):
     result = GeminiLogicalResult(storage=storage).logical_results()
 
     assert list(result[0]) == [True, False]
+
+
+def test_logical_results_supports_legacy_postprocessor_override(storage):
+    add_task_definition(
+        storage,
+        "task-1",
+        make_task_definition(subtasks=[Subtask(program_index=0, num_shots=1)]),
+    )
+    storage.add_shots([make_shot(shot_index=0, bitstring=(True, False))])
+
+    result = GeminiLogicalResult(storage=storage).logical_results(
+        verify=True,
+        postprocessing_functions={
+            0: lambda shots: ("legacy", shots.shape, shots.tolist())
+        },
+    )
+
+    assert result == [("legacy", (1, 2), [[True, False]])]
+
+
+def test_logical_results_legacy_override_can_skip_merge_validation(storage):
+    add_task_definition(
+        storage,
+        "task-1",
+        make_task_definition(
+            subtasks=[Subtask(program_index=0, num_shots=1, arguments={"a": 1})]
+        ),
+    )
+    add_task_definition(
+        storage,
+        "task-2",
+        make_task_definition(
+            subtasks=[Subtask(program_index=0, num_shots=1, arguments={"a": 2})]
+        ),
+    )
+    storage.add_shots(
+        [
+            make_shot(task_id="task-1", shot_index=0, bitstring=(True, False)),
+            make_shot(task_id="task-2", shot_index=0, bitstring=(False, True)),
+        ]
+    )
+
+    result = GeminiLogicalResult(storage=storage).logical_results(
+        verify=False,
+        postprocessing_functions={0: lambda shots: shots.tolist()},
+    )
+
+    assert result == [[[True, False], [False, True]]]
 
 
 def test_logical_results_returns_raw_when_postprocessing_is_none(storage, monkeypatch):


### PR DESCRIPTION
- Added `measurements`, `detectors`, `observables`, `return_values` to `GeminiLogicalResult`
- Added postprocessing from 160 SLM sites to measurements