### PR TITLE
fix(python): honor custom arch specs in the benchmark harness

### DIFF
--- a/python/benchmarks/harness/runner.py
+++ b/python/benchmarks/harness/runner.py
@@ -181,7 +181,9 @@ class BenchmarkRunner:
 
     def _compile(self, job: BenchmarkJob) -> _RunArtifacts:
         placement_strategy = self._build_placement_strategy(job)
-        layout_heuristic = self._build_layout_heuristic(job)
+        layout_heuristic = self._build_layout_heuristic(
+            job, placement_strategy.arch_spec
+        )
 
         move_mt = _squin_to_move(
             job.case.kernel,
@@ -239,10 +241,14 @@ class BenchmarkRunner:
             return fidelity_product
 
         placement_strategy = self._build_placement_strategy(job)
-        layout_heuristic = self._build_layout_heuristic(job)
-        # Construct one ArchSpec and reuse it for both the move compilation and
-        # the noise-insertion step so they cannot disagree on the target arch.
-        arch_spec = get_physical_arch_spec()
+        # Take the arch spec from the strategy and reuse it for the layout
+        # heuristic, the move compilation and the noise-insertion step, so all
+        # four cannot disagree on the target arch. Using a bundled default here
+        # instead makes PhysicalPipeline warn about the placement/pipeline
+        # mismatch and then fail deep in lowering with an unrelated-looking
+        # "SSAValue ... stmt: fill ... not found".
+        arch_spec = placement_strategy.arch_spec
+        layout_heuristic = self._build_layout_heuristic(job, arch_spec)
         move_mt = PhysicalPipeline(
             arch_spec=arch_spec,
             layout_heuristic=layout_heuristic,
@@ -260,10 +266,18 @@ class BenchmarkRunner:
             fidelity_product *= gate_fid.min
         return fidelity_product
 
-    def _build_layout_heuristic(self, job: BenchmarkJob):
+    def _build_layout_heuristic(self, job: BenchmarkJob, arch_spec: ArchSpec):
+        """Build the layout heuristic for ``job`` against ``arch_spec``.
+
+        ``arch_spec`` is the strategy's spec rather than a bundled default so
+        the layout and placement stages cannot disagree on the target
+        architecture. Passing it is a no-op for the shipped suites (each
+        heuristic's default is exactly the spec its suite's strategies carry),
+        but it is what makes ``--arch-spec`` work at all.
+        """
         if job.case.logical_initialize:
-            return logical_layout.LogicalLayoutHeuristic()
-        return PhysicalLayoutHeuristicGraphPartitionCenterOut()
+            return logical_layout.LogicalLayoutHeuristic(arch_spec=arch_spec)
+        return PhysicalLayoutHeuristicGraphPartitionCenterOut(arch_spec=arch_spec)
 
     def _build_placement_strategy(self, job: BenchmarkJob):
         return job.strategy.build_placement_strategy()

--- a/python/tests/benchmarks/test_runner.py
+++ b/python/tests/benchmarks/test_runner.py
@@ -10,6 +10,7 @@ from kirin import ir
 
 from bloqade.lanes.analysis.placement import PlacementStrategyABC
 from bloqade.lanes.arch.gemini import physical
+from bloqade.lanes.arch.spec import ArchSpec
 from bloqade.lanes.bytecode.encoding import SiteLaneAddress
 from bloqade.lanes.dialects import move
 from bloqade.lanes.heuristics.physical.placement import (
@@ -283,3 +284,127 @@ def test_compile_reads_rust_nodes_from_strategy(monkeypatch):
     artifacts = runner._compile(job)
     assert artifacts.nodes_explored == 321
     assert artifacts.notes == ""
+
+
+def _fake_job(*, arch_spec: object, logical_initialize: bool) -> BenchmarkJob:
+    @dataclass
+    class _FakePlacement:
+        arch_spec: object
+
+    return BenchmarkJob(
+        case=BenchmarkCase(
+            case_id="case_x",
+            kernel=cast(ir.Method, object()),
+            logical_initialize=logical_initialize,
+        ),
+        strategy=StrategyConfig(
+            strategy_id="rust_astar",
+            backend="rust",
+            generator_id="rust_solver",
+            build_placement_strategy=lambda: cast(
+                PlacementStrategyABC, _FakePlacement(arch_spec=arch_spec)
+            ),
+        ),
+    )
+
+
+@pytest.mark.parametrize("logical_initialize", [False, True])
+def test_build_layout_heuristic_uses_the_strategy_arch_spec(logical_initialize):
+    """The layout stage must target the strategy's arch, not a bundled default.
+
+    Regression test: both heuristics used to be constructed with no arguments,
+    so they silently fell back to the bundled Gemini specs and ``--arch-spec``
+    only reached the placement stage.
+    """
+    sentinel = object()
+    runner = BenchmarkRunner()
+    job = _fake_job(arch_spec=sentinel, logical_initialize=logical_initialize)
+
+    heuristic = runner._build_layout_heuristic(job, cast(ArchSpec, sentinel))
+
+    assert heuristic.arch_spec is sentinel
+
+
+def test_compile_threads_strategy_arch_spec_into_the_layout_heuristic(monkeypatch):
+    """``_compile`` must hand the layout heuristic the strategy's arch spec."""
+    sentinel = object()
+    seen: dict[str, object] = {}
+
+    def _fake_squin_to_move(mt, *, layout_heuristic, placement_strategy, **kwargs):
+        seen["layout_arch_spec"] = layout_heuristic.arch_spec
+        seen["placement_arch_spec"] = placement_strategy.arch_spec
+        return cast(ir.Method, object())
+
+    monkeypatch.setattr("benchmarks.harness.runner._squin_to_move", _fake_squin_to_move)
+    monkeypatch.setattr(
+        "benchmarks.harness.runner._assert_move_lowering_complete", lambda mt: None
+    )
+
+    artifacts = BenchmarkRunner()._compile(
+        _fake_job(arch_spec=sentinel, logical_initialize=False)
+    )
+
+    assert seen["layout_arch_spec"] is sentinel
+    assert seen["placement_arch_spec"] is sentinel
+    assert artifacts.arch_spec is sentinel
+
+
+def test_estimate_fidelity_physical_mode_uses_the_strategy_arch_spec(monkeypatch):
+    """Fidelity must be measured against the strategy's arch, not bundled Gemini.
+
+    The pipeline and the noise-insertion step both used a hardcoded
+    ``get_physical_arch_spec()``, so a custom-arch run reported a fidelity for
+    the wrong architecture (and failed lowering with a misleading
+    "SSAValue ... stmt: fill ... not found").
+    """
+    sentinel = object()
+    seen: dict[str, object] = {}
+
+    class _FakeGateFidelity:
+        min = 0.5
+
+    class _FakeFidelityAnalysis:
+        def __init__(self, dialects):
+            self.gate_fidelities = [_FakeGateFidelity()]
+
+        def run(self, kernel):
+            return None
+
+    class _FakePhysicalPipeline:
+        def __init__(self, **kwargs):
+            seen["pipeline_arch_spec"] = kwargs["arch_spec"]
+            seen["pipeline_layout_arch_spec"] = kwargs["layout_heuristic"].arch_spec
+
+        def emit(self, kernel, **kwargs):
+            return cast(ir.Method, object())
+
+    class _FakeMoveToSquinPhysical:
+        def __init__(self, **kwargs):
+            seen["noise_arch_spec"] = kwargs["arch_spec"]
+
+        def emit(self, move_mt, **kwargs):
+            class _S:
+                dialects = object()
+
+            return _S()
+
+    monkeypatch.setattr(
+        "benchmarks.harness.runner.PhysicalPipeline", _FakePhysicalPipeline
+    )
+    monkeypatch.setattr(
+        "benchmarks.harness.runner.MoveToSquinPhysical", _FakeMoveToSquinPhysical
+    )
+    monkeypatch.setattr(
+        "benchmarks.harness.runner.FidelityAnalysis", _FakeFidelityAnalysis
+    )
+
+    fidelity = BenchmarkRunner()._estimate_fidelity(
+        _fake_job(arch_spec=sentinel, logical_initialize=False)
+    )
+
+    assert fidelity == 0.5
+    # All three consumers must agree on the arch, or the plan and the noise
+    # model describe different machines.
+    assert seen["pipeline_arch_spec"] is sentinel
+    assert seen["pipeline_layout_arch_spec"] is sentinel
+    assert seen["noise_arch_spec"] is sentinel


### PR DESCRIPTION
Part of #939 (split out, since the bug stands on its own).

`--arch-spec` is effectively broken today for the physical-initialize path: the
custom spec only reaches the *placement* stage. Two spots in
`python/benchmarks/harness/runner.py` hardcode the bundled Gemini physical spec,
so a custom-arch run compiles its moves and measures its fidelity against the
wrong architecture.

## The two spots

- **`_estimate_fidelity`** built `PhysicalPipeline` *and* `MoveToSquinPhysical`
  from `get_physical_arch_spec()` rather than the strategy's spec.
- **`_build_layout_heuristic`** constructed both layout heuristics with no
  arguments, so they fell back to their bundled defaults
  (`PhysicalLayoutHeuristicGraphPartitionCenterOut` also derives home words from
  zone entangling pairs, so it really does need the right spec).

Both now take the spec from the strategy, so the layout, placement, move
compilation and noise-insertion stages cannot disagree on the target.

## Why this was hard to see

The mismatch was only a `UserWarning`, and the failure it eventually produced
named nothing relevant:

```
error=SSAValue <ResultValue[State] stmt: fill, uses: 2> not found
```

That reads like a lowering or dialect bug, not a spec mismatch. Fidelity was
worse than that — silently *wrong* rather than absent: a conveyor-spec run
reported `0.068` where the correct value is `0.788`.

A debugging note for whoever hits this next: a case's `logical_initialize`
defaults to `"physical" not in case_id`, and the CLI's `_apply_architecture_mode`
overrides it per suite. So `ghz_6` driven straight through
`BenchmarkRunner._run_one` silently takes the *logical* layout path and succeeds,
while the same case via the CLI in physical mode fails. Any repro has to
replicate `_apply_architecture_mode` or it chases a phantom.

## No behaviour change for the shipped suites

Threading the spec is a no-op for `physical` and `logical`: each heuristic's
default is exactly the spec its suite's strategies already carry, and
`get_physical_layout_arch_spec()` is literally `return get_arch_spec()`.

Verified against this branch's base — **both `just benchmark-physical` and
`just benchmark-logical` report "no differences found"**, with zero
non-walltime diffs in either baseline. No baseline regeneration needed.

## Tests

Five regression tests in `python/tests/benchmarks/test_runner.py`:

- `_build_layout_heuristic` uses the strategy's spec (parametrized over both
  initialize modes);
- `_compile` threads it into the layout heuristic;
- `_estimate_fidelity` gives the same spec to the pipeline, the pipeline's layout
  heuristic, and the noise-insertion step — all three asserted together, since
  the point is that they agree.

Full suite green: 1908 Python tests, plus clean black/isort/ruff/pyright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)