### PR TITLE
fix(ci): pin working-tree line endings to LF for the primer golden test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Normalize line endings to LF in the working tree on every platform.
+#
+# Without this, Git for Windows checks text files out with CRLF, which breaks
+# golden-file tests that compare a committed fixture against generator output
+# built from `\n` literals (see crates/bloqade-lanes-search/tests/primer_golden.rs).
+# Binary files are still detected and left untouched by `text=auto`.
+* text=auto eol=lf

--- a/crates/bloqade-lanes-search/src/bin/policies-primer.rs
+++ b/crates/bloqade-lanes-search/src/bin/policies-primer.rs
@@ -96,6 +96,10 @@ fn main() {
         print!("{regenerated}");
     } else if check {
         let on_disk = std::fs::read_to_string(PRIMER_PATH).unwrap_or_default();
+        // `regenerated` is LF-only by construction; compare against an
+        // LF-normalized read so a CRLF checkout doesn't report every line
+        // as stale.
+        let on_disk = on_disk.replace("\r\n", "\n");
         if on_disk.trim() != regenerated.trim() {
             let diff = unified_diff(&on_disk, &regenerated);
             eprintln!("{PRIMER_PATH} is stale. Diff:\n{diff}");

--- a/crates/bloqade-lanes-search/tests/primer_golden.rs
+++ b/crates/bloqade-lanes-search/tests/primer_golden.rs
@@ -8,6 +8,14 @@
 use assert_cmd::Command;
 use std::path::PathBuf;
 
+/// The generator emits `\n` unconditionally, so a CRLF checkout of the
+/// fixture would mismatch on every line while printing an identical-looking
+/// diff. `.gitattributes` pins the working tree to LF; this is the backstop
+/// for checkouts that predate it or override it.
+fn lf(s: &str) -> String {
+    s.replace("\r\n", "\n")
+}
+
 #[test]
 fn primer_generator_matches_golden_for_curated_stubs() {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -26,7 +34,7 @@ fn primer_generator_matches_golden_for_curated_stubs() {
         .stdout
         .clone();
     let actual = String::from_utf8(out).unwrap();
-    if actual.trim() != expected.trim() {
+    if lf(&actual).trim() != lf(&expected).trim() {
         panic!("primer-golden mismatch.\n--- expected ---\n{expected}\n--- actual ---\n{actual}");
     }
 }


### PR DESCRIPTION
## Why

The `windows-latest` leg of **Cross-Platform** has failed on every push to `main` since 2026-08-18 — most recently [run 32517286195](https://github.com/QuEraComputing/bloqade-lanes/actions/runs/32517286195). The single failing test is `primer_generator_matches_golden_for_curated_stubs`.

It is a line-ending mismatch, not a content difference — which is why the panic message prints an "expected vs actual" diff that looks byte-for-byte identical:

- `policies-primer` assembles its output from hardcoded `\n` literals, so its stdout is LF-only on every platform.
- The test compares that against `tests/fixtures/primer/expected.md` read from disk. The repo had no `.gitattributes`, so Git for Windows checks that fixture out with CRLF.
- `actual.trim() != expected.trim()` — `trim()` doesn't touch interior `\r`, so every line mismatches.

Confirmed by reproduction: with fixtures untouched the test passes; converting **only** `expected.md` to CRLF reproduces the CI failure exactly, and converting **only** the `input/*.rs` stubs still passes (syn/`quote` normalize those away). So the fixture's checkout encoding is the sole cause.

### Why it started on 2026-08-18

The test has existed since #600 (2026-05-31), but `just test-rust` didn't include `-p bloqade-lanes-search` until #932 — which is exactly where Cross-Platform went red. The test was compiled but never executed on Windows before that, so this is a latent bug newly exposed, not a regression from the PRs it has been failing on top of.

### What it was masking

`cargo test` aborts after the failing target, so `tests/public_bound_api.rs` and `tests/push_rotate.rs` had never run on Windows, and the entire Python leg of the job (setup, extension build, pytest) had been skipped for three days.

## What changed

- **`.gitattributes`** (new) — `* text=auto eol=lf`, so Git stops rewriting text files to CRLF on Windows checkouts.
- **`primer_golden.rs`** — LF-normalize both sides of the comparison, as a backstop for checkouts that predate or override the attribute.
- **`policies-primer.rs`** — the same normalization in the `--check` path behind `just check-primer`, which had the identical latent bug (ubuntu-only today, so it was never firing).

## Verification

Dispatched Cross-Platform on this branch: [run 32520670530](https://github.com/QuEraComputing/bloqade-lanes/actions/runs/32520670530) — **both platforms green**.

- Windows Rust tests pass, including the two integration targets that had never been reached.
- The Windows Python leg ran for the first time since 2026-08-18: `1903 passed, 4 skipped, 1 xfailed`. Nothing was hiding behind the primer failure.
- Locally: `just test-rust`, `cargo fmt --check`, and `cargo clippy -D warnings` all clean; golden test passes with both LF and artificially-CRLF fixtures.

## Reviewer notes

- **No renormalization churn from `.gitattributes`.** `git status` stays clean. The benchmark baseline CSVs (`latest_physical.csv` / `latest_logical.csv`) are committed with CRLF — Python's `csv` module writes `\r\n` — and `text=auto` deliberately leaves blobs that already contain CRLF in the index alone, so they are not rewritten on any platform. PNGs are binary-detected and untouched. There are no `.bat`/`.cmd`/`.ps1` files that would want CRLF.
- **Not addressed here:** Cross-Platform only triggers on push to `main` and `workflow_dispatch`, so it never gates PRs — that is why this sat on `main` for three days. Adding `pull_request` to its triggers would catch the next one pre-merge, at the cost of ~30 min of Windows runner time per PR (dominated by pytest). Happy to add it here or as a follow-up.
- No `backport v0.11` label applied — a repo-wide `.gitattributes` on a release branch felt like a maintainer call rather than a default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)